### PR TITLE
feat(widgets): kernel-3 -- widgetize Home + Library + AppShell rails

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -12,7 +12,14 @@ import kotlinx.serialization.Serializable
  * how the user explores the direction before it's finished.
  */
 @Serializable
-enum class HomeView { Classic, LibraryFirst }
+enum class HomeView {
+    Classic,
+    LibraryFirst,
+    // [New] -- widget-composed prototype home (Phase 1 / kernel-3). Carries
+    // the minimal welcome / recent-packs / quick-launch widgets; the
+    // expressive build-out happens as user customization in later phases.
+    New,
+}
 
 /**
  * Which visual style variant is active. Independent from palette

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -45,9 +45,12 @@ import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.ui.theme.CustomTheme
 import hivens.ui.utils.GameConsoleService
+import hivens.ui.widgets.shell.LeftRailContext
+import hivens.ui.widgets.shell.LocalLeftRailContext
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
 import org.koin.compose.koinInject
-import kotlin.math.sin
-import kotlin.random.Random
 
 // ─── Layout ──────────────────────────────────────────────────────────────────
 
@@ -133,6 +136,11 @@ fun AppLayout(
                                 HomeView.LibraryFirst -> LibraryScreen(
                                     appState       = appState,
                                     onScreenChange = onScreenChange,
+                                )
+                                HomeView.New -> NewHomeScreen(
+                                    appState         = appState,
+                                    onScreenChange   = onScreenChange,
+                                    onSessionUpdated = { currentSession = it },
                                 )
                             }
                             // `Loading` is the brief window between startup and resolved
@@ -259,69 +267,10 @@ fun AppSidebar(
     onLogout: () -> Unit
 ) {
     val gameConsole: GameConsoleService = koinInject()
-    val af = LocalAprilFools.current
 
-    val homeActive = currentScreen is Screen.Home
-            || currentScreen is Screen.ServerSettings
-            || currentScreen is Screen.ServerDetails
-    val libraryActive  = currentScreen is Screen.Library
-            || currentScreen is Screen.PackDetail
-    val browseActive   = currentScreen is Screen.Browse
-            || currentScreen is Screen.BrowsePackDetail
-    val profileActive  = currentScreen is Screen.Profile
-    val settingsActive = currentScreen is Screen.Settings
-            || currentScreen is Screen.ThemePicker
-            || currentScreen is Screen.BackgroundSettings
-            || currentScreen is Screen.CustomizationExtension
-    val aboutActive    = currentScreen is Screen.About
-
-    // ── April Fools: nav clicks have a 30% chance of being silently swallowed ──
-    // The button doesn't move or react -- it just feels like the UI froze.
-    // Logout is intentionally excluded so the user can always escape.
-    fun chaosNavClick(originalClick: () -> Unit): () -> Unit {
-        if (!af.isActive()) return originalClick
-        return {
-            if (Random.nextFloat() > 0.30f) {
-                originalClick()
-            }
-            // else: click silently consumed -- simulates UI "lag"
-        }
-    }
-
-    // ── April Fools: bouncing nav buttons ────────────────────────────────────
-    // Each item has a unique sine phase so they bounce out of sync.
-    // Amplitude grows from 0px on day 1 to 18px on day 14.
-    val bounceAmplitude = if (af.isActive()) af.intensity() * 18f else 0f
-
-    val bounceTransition = rememberInfiniteTransition(label = "navBounce")
-    val bounceCycle by bounceTransition.animateFloat(
-        initialValue  = 0f,
-        targetValue   = (2f * Math.PI).toFloat(),
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = if (af.isActive())
-                    (2200 - af.intensity() * 1400).toInt().coerceAtLeast(600)
-                else
-                    2200,
-                easing = LinearEasing
-            ),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "bounceCycle"
-    )
-
-    // Different phase offset per button -- they never all peak at the same time
-    val homeOffset    = sin(bounceCycle + 0.0f) * bounceAmplitude
-    val libraryOffset = sin(bounceCycle + 0.55f) * bounceAmplitude
-    val browseOffset  = sin(bounceCycle + 1.65f) * bounceAmplitude
-    val profileOffset = sin(bounceCycle + 1.1f) * bounceAmplitude
-    val settingsOffset= sin(bounceCycle + 2.2f) * bounceAmplitude
-    val aboutOffset   = sin(bounceCycle + 3.3f) * bounceAmplitude
-
-    // Puppet: sidebar navigation. Puppet driver bypasses the AprilFools
-    // chaos wrapper -- those are user-facing pranks, not behavior we want
-    // to test against. Direct onScreenChange calls keep test runs
-    // deterministic regardless of the calendar.
+    // Puppet: sidebar navigation. Direct onScreenChange calls keep
+    // test runs deterministic regardless of the AprilFools chaos
+    // wrapper inside the nav-buttons widget.
     PuppetClick("nav.home")     { onScreenChange(Screen.Home) }
     PuppetClick("nav.library")  { onScreenChange(Screen.Library) }
     PuppetClick("nav.browse")   { onScreenChange(Screen.Browse) }
@@ -336,133 +285,32 @@ fun AppSidebar(
         PuppetClick("nav.logout") { onLogout() }
     }
 
-    NavigationRail(
-        modifier       = Modifier.width(64.dp).fillMaxHeight(),
-        containerColor = glassSurfaceAlpha(0.35f),
-        contentColor   = CelestiaTheme.colors.textSecondary
-    ) {
-        // ── Nav items ─────────────────────────────────────────────────────
-        Spacer(Modifier.height(8.dp))
-
-        // Each item wrapped in a Box that applies the vertical bounce offset
-        Box(Modifier.graphicsLayer { translationY = homeOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Home,
-                selected = homeActive,
-                onClick  = chaosNavClick { onScreenChange(Screen.Home) }
-            )
-        }
-
-        Box(Modifier.graphicsLayer { translationY = libraryOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Star,
-                selected = libraryActive,
-                onClick  = chaosNavClick { onScreenChange(Screen.Library) }
-            )
-        }
-
-        Box(Modifier.graphicsLayer { translationY = browseOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Search,
-                selected = browseActive,
-                onClick  = chaosNavClick { onScreenChange(Screen.Browse) }
-            )
-        }
-
-        Box(Modifier.graphicsLayer { translationY = profileOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Person,
-                selected = profileActive,
-                enabled  = isAuthenticated,
-                onClick  = chaosNavClick { onScreenChange(Screen.Profile) }
-            )
-        }
-
-        Box(Modifier.graphicsLayer { translationY = settingsOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Settings,
-                selected = settingsActive,
-                onClick  = chaosNavClick { onScreenChange(Screen.Settings) }
-            )
-        }
-
-        Box(Modifier.graphicsLayer { translationY = aboutOffset }) {
-            SidebarNavItem(
-                icon     = Icons.Default.Info,
-                selected = aboutActive,
-                onClick  = chaosNavClick { onScreenChange(Screen.About) }
-            )
-        }
-
-        // ── Bottom actions ────────────────────────────────────────────────
-        Spacer(Modifier.weight(1f))
-
-        // Console toggle -- not bouncing, user needs to be able to open it
-        IconButton(
-            onClick  = {
-                if (gameConsole.shouldShowConsole) gameConsole.hide()
-                else gameConsole.show()
-            },
-            modifier = Modifier.size(48.dp)
+    val ctx = remember(currentScreen, isAuthenticated, onScreenChange, onLogout) {
+        LeftRailContext(
+            currentScreen   = currentScreen,
+            isAuthenticated = isAuthenticated,
+            onScreenChange  = onScreenChange,
+            onLogout        = onLogout,
+        )
+    }
+    CompositionLocalProvider(LocalLeftRailContext provides ctx) {
+        NavigationRail(
+            modifier       = Modifier.width(64.dp).fillMaxHeight(),
+            containerColor = glassSurfaceAlpha(0.35f),
+            contentColor   = CelestiaTheme.colors.textSecondary
         ) {
-            Icon(
-                imageVector        = Icons.Default.Build,
-                contentDescription = null,
-                tint               = if (gameConsole.shouldShowConsole)
-                    CelestiaTheme.colors.primary
-                else
-                    CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
-                modifier           = Modifier.size(22.dp)
-            )
+            SlotRenderer(SurfaceId(SIDEBAR_SURFACE), SlotId("top"))
+            // Spacer is layout, not content -- stays surface-owned so
+            // widgets in the top/bottom slots do not need ColumnScope
+            // for weight.
+            Spacer(Modifier.weight(1f))
+            SlotRenderer(SurfaceId(SIDEBAR_SURFACE), SlotId("bottom"))
+            Spacer(Modifier.height(8.dp))
         }
-
-        // Logout -- NOT chaos-wrapped, NOT bouncing -- user must always be able to log out
-        if (isAuthenticated) {
-            IconButton(onClick = onLogout, modifier = Modifier.size(48.dp)) {
-                Icon(
-                    imageVector        = Icons.AutoMirrored.Filled.ExitToApp,
-                    contentDescription = null,
-                    tint               = CelestiaTheme.colors.error.copy(alpha = 0.75f),
-                    modifier           = Modifier.size(22.dp)
-                )
-            }
-        }
-
-        Spacer(Modifier.height(8.dp))
     }
 }
 
-// ─── NavigationRailItem wrapper (icon-only, no label) ────────────────────────
-
-@Composable
-private fun SidebarNavItem(
-    icon: ImageVector,
-    selected: Boolean,
-    enabled: Boolean = true,
-    onClick: () -> Unit
-) {
-    NavigationRailItem(
-        icon = {
-            Icon(
-                imageVector        = icon,
-                contentDescription = null,
-                modifier           = Modifier.size(24.dp)
-            )
-        },
-        selected        = selected,
-        onClick         = onClick,
-        enabled         = enabled,
-        label           = null,
-        alwaysShowLabel = false,
-        colors          = NavigationRailItemDefaults.colors(
-            selectedIconColor   = CelestiaTheme.colors.primary,
-            unselectedIconColor = CelestiaTheme.colors.textSecondary.copy(
-                alpha = if (enabled) 0.70f else 0.20f
-            ),
-            indicatorColor      = CelestiaTheme.colors.primary.copy(alpha = 0.13f)
-        )
-    )
-}
+private const val SIDEBAR_SURFACE = "appshell.leftrail"
 
 // ─── Loading placeholder ──────────────────────────────────────────────────────
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -1,18 +1,28 @@
 package hivens.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import hivens.core.data.SessionData
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.shell.LocalRightRailContext
+import hivens.ui.widgets.shell.RightRailContext
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
 
 /**
- * Right-side panel. Orchestrator only -- the auth panel (Loading /
- * Unauthenticated / Authenticated) and news feed live in their own files
- * (`LoginPanel.kt`, `AccountPanel.kt`, `CompactNewsFeed.kt`).
+ * Right-side panel. Surface composable: owns the column container and
+ * the divider between auth + news slots; widget content (auth panel,
+ * news feed) resolves through SlotRenderer against the layout graph.
  */
 @Composable
 fun RightPanel(
@@ -22,30 +32,25 @@ fun RightPanel(
     sslBypass: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.background(CelestiaTheme.colors.background)) {
-
-        // ── Auth section (top) ────────────────────────────────────────────────
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(glassSurfaceAlpha(0.22f))
-        ) {
-            when (appState) {
-                AppState.Loading          -> AuthLoadingSlot()
-                AppState.Unauthenticated  -> LoginPanel(onLogin = onLogin)
-                is AppState.Authenticated -> AccountPanel(
-                    session  = appState.session,
-                    onLogout = onLogout,
-                )
-            }
-        }
-
-        HorizontalDivider(color = glassSurfaceAlpha(0.7f))
-
-        // ── News feed (bottom) ────────────────────────────────────────────────
-        CompactNewsFeed(
+    val ctx = remember(appState, onLogin, onLogout, sslBypass) {
+        RightRailContext(
+            appState  = appState,
+            onLogin   = onLogin,
+            onLogout  = onLogout,
             sslBypass = sslBypass,
-            modifier  = Modifier.weight(1f).fillMaxWidth(),
         )
     }
+    CompositionLocalProvider(LocalRightRailContext provides ctx) {
+        Column(modifier = modifier.background(CelestiaTheme.colors.background)) {
+            Box(Modifier.fillMaxWidth()) {
+                SlotRenderer(SurfaceId(SURFACE), SlotId("auth"))
+            }
+            HorizontalDivider(color = glassSurfaceAlpha(0.7f))
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                SlotRenderer(SurfaceId(SURFACE), SlotId("news"))
+            }
+        }
+    }
 }
+
+private const val SURFACE = "appshell.rightrail"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -519,6 +519,7 @@ interface AppStrings {
     val settingsHomeViewSub: String
     val settingsHomeViewClassic: String
     val settingsHomeViewLibrary: String
+    val settingsHomeViewNew: String
 
     // --- UI style variant picker (in Settings -> Interface) ---
     val settingsUiStyleTitle: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -489,6 +489,7 @@ object EnglishStrings : AppStrings {
     override val settingsHomeViewSub     = "Try the new Library-first surface alongside the classic Dashboard. Switch any time."
     override val settingsHomeViewClassic = "Classic"
     override val settingsHomeViewLibrary = "Library (alpha)"
+    override val settingsHomeViewNew     = "New (prototype)"
 
     override val settingsUiStyleTitle    = "UI style"
     override val settingsUiStyleSub      = "Switch the form / surface / motion approach independently from the color palette. Celestia is the current rounded-glass look; Brut is hard-edged and flat."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -489,6 +489,7 @@ object GermanStrings : AppStrings {
     override val settingsHomeViewSub     = "Probiere die neue Library-first-Ansicht neben dem klassischen Dashboard. Jederzeit umschaltbar."
     override val settingsHomeViewClassic = "Klassisch"
     override val settingsHomeViewLibrary = "Library (Alpha)"
+    override val settingsHomeViewNew     = "Neu (Prototyp)"
 
     override val settingsUiStyleTitle    = "UI-Stil"
     override val settingsUiStyleSub      = "Wechsle Form / Oberfläche / Bewegung unabhängig von der Farbpalette. Celestia ist die aktuelle abgerundete Glasoptik; Brut ist hart und flach."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -490,6 +490,7 @@ object RussianStrings : AppStrings {
     override val settingsHomeViewSub     = "Попробуй новый Library-first интерфейс параллельно с классическим Dashboard. Можно переключаться когда захочешь."
     override val settingsHomeViewClassic = "Классический"
     override val settingsHomeViewLibrary = "Library (alpha)"
+    override val settingsHomeViewNew     = "Новый (прототип)"
 
     override val settingsUiStyleTitle    = "Стиль интерфейса"
     override val settingsUiStyleSub      = "Переключай форму / поверхности / анимации независимо от цветовой палитры. Celestia — текущий вид с мягкими скруглениями и стеклом; Brut — жёсткий, без скруглений, без анимаций."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
@@ -1,39 +1,26 @@
 package hivens.ui.screens
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.WifiOff
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import hivens.core.api.interfaces.IServerListService
-import hivens.core.api.interfaces.ISettingsService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.SessionData
-import hivens.launcher.AutoSyncService
-import hivens.launcher.launch.LaunchState
-import hivens.launcher.launch.LauncherController
-import hivens.launcher.network.NetworkState
-import hivens.launcher.ProfileManager
-import hivens.ui.components.LaunchControlPanel
-import hivens.ui.components.ServerGrid
-import hivens.ui.customization.glassSurfaceAlpha
-import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetScreen
-import hivens.ui.theme.CelestiaTheme
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.koin.compose.koinInject
+import hivens.ui.widgets.home.classic.HomeClassicContext
+import hivens.ui.widgets.home.classic.LocalHomeClassicContext
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
 
+/**
+ * Classic dashboard surface. Provides navigation context for the
+ * monolithic home.classic.content widget; the widget owns layout and
+ * state for the entire legacy dashboard.
+ *
+ * Surface signature stays compatible with AppLayout so the existing
+ * callback wiring keeps working.
+ */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun DashboardScreen(
@@ -43,277 +30,27 @@ fun DashboardScreen(
     onSessionUpdated: (SessionData) -> Unit,
     onCloseApp: () -> Unit,
     onOpenServerSettings: (ServerProfile) -> Unit,
-    onOpenDetails: (ServerProfile) -> Unit
+    onOpenDetails: (ServerProfile) -> Unit,
 ) {
     PuppetScreen("Dashboard")
 
-    val serverListService: IServerListService = koinInject()
-    val settingsService: ISettingsService     = koinInject()
-    val profileManager: ProfileManager        = koinInject()
-    val controller: LauncherController        = koinInject()
-    val autoSyncService: AutoSyncService      = koinInject()
-    val protocolConfig: hivens.launcher.network.ServerProtocolConfig = koinInject()
-    val s = LocalStrings.current
-    val scope = rememberCoroutineScope()
-
-    val launchState by controller.state.collectAsState()
-    val syncSnapshot by autoSyncService.snapshot.collectAsState()
-    val syncStates  = syncSnapshot.perServer
-    val syncOverall = syncSnapshot.overall
-    var hiddenForCurrentSession by remember { mutableStateOf(false) }
-
-    var servers             by remember { mutableStateOf<List<ServerProfile>>(emptyList()) }
-    var selectedServerState by remember { mutableStateOf(initialSelectedServer) }
-    var favoriteTrigger     by remember { mutableStateOf(0) }
-    val favorites = remember(favoriteTrigger) { profileManager.favoriteServers }
-    var isLoadingServers    by remember { mutableStateOf(true) }
-    val bypassHost = protocolConfig.sslBypassHost
-    val bypassesList by NetworkState.bypassesState.collectAsState()
-    val sslBypass = remember(bypassesList, bypassHost) { NetworkState.bypassFor(bypassHost) }
-
-
-    fun fetchServers(forceRefresh: Boolean = false) {
-        isLoadingServers = true
-        scope.launch(Dispatchers.IO) {
-            try {
-                val data = if (forceRefresh) serverListService.refresh().get()
-                           else              serverListService.fetchDashboardData().get()
-                withContext(Dispatchers.Main) {
-                    servers = data.servers
-                    if (selectedServerState == null && servers.isNotEmpty()) {
-                        val lastId  = profileManager.lastServerId
-                        val default = servers.find { it.assetDir == lastId } ?: servers.firstOrNull()
-                        if (default != null) {
-                            selectedServerState = default
-                            onServerSelected(default)
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                org.slf4j.LoggerFactory.getLogger("DashboardScreen")
-                    .error("Failed to load server list", e)
-            } finally {
-                withContext(Dispatchers.Main) {
-                    isLoadingServers = false
-                }
-            }
-        }
-    }
-
-    LaunchedEffect(launchState) {
-        when (launchState) {
-            is LaunchState.GameRunning -> {
-                if (settingsService.getSettings().closeAfterStart && !hiddenForCurrentSession) {
-                    hiddenForCurrentSession = true
-                    onCloseApp()
-                }
-            }
-            is LaunchState.Idle, is LaunchState.Error -> {
-                hiddenForCurrentSession = false
-            }
-            else -> {}
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        if (servers.isEmpty()) fetchServers()
-        else isLoadingServers = false
-    }
-
-    LaunchedEffect(sslBypass) {
-        if (sslBypass && servers.isEmpty()) {
-            fetchServers()
-        }
-    }
-
-    LaunchedEffect(initialSelectedServer) {
-        if (initialSelectedServer != null) selectedServerState = initialSelectedServer
-    }
-
-    Column(Modifier.fillMaxSize().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 16.dp)) {
-
-        // ── Header ────────────────────────────────────────────────────────────
-        Text(
-            text       = s.dashboardWelcome(session.playerName),
-            style      = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Medium,
-            color      = CelestiaTheme.colors.textSecondary
-        )
-
-        Spacer(Modifier.height(4.dp))
-
-        Text(
-            text       = s.dashboardServers,
-            style      = MaterialTheme.typography.bodySmall,
-            color      = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
-            fontWeight = FontWeight.Bold
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        // ── Server grid ────────────────────────────────────────────────────
-        Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
-            when {
-                isLoadingServers -> {
-                    CircularProgressIndicator(color = CelestiaTheme.colors.primary)
-                }
-                servers.isEmpty() -> {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Icon(
-                            imageVector        = Icons.Default.WifiOff,
-                            contentDescription = null,
-                            tint               = CelestiaTheme.colors.textSecondary.copy(alpha = 0.5f),
-                            modifier           = Modifier.size(48.dp)
-                        )
-                        Spacer(Modifier.height(16.dp))
-                        Text(
-                            s.dashboardServersEmpty,
-                            color = CelestiaTheme.colors.textSecondary
-                        )
-                        Spacer(Modifier.height(16.dp))
-                        OutlinedButton(
-                            onClick = { fetchServers(forceRefresh = true) },
-                            colors  = ButtonDefaults.outlinedButtonColors(
-                                contentColor = CelestiaTheme.colors.primary
-                            )
-                        ) {
-                            Icon(Icons.Default.Refresh, contentDescription = null)
-                            Spacer(Modifier.width(8.dp))
-                            Text(s.updateRetry)
-                        }
-                    }
-                }
-                else -> {
-                    ServerGrid(
-                        servers        = servers,
-                        favorites      = favorites,
-                        selectedServer = selectedServerState,
-                        isLaunchable   = launchState is LaunchState.Idle || launchState is LaunchState.Error,
-                        onSelect       = { srv ->
-                            selectedServerState = srv
-                            onServerSelected(srv)
-                            profileManager.lastServerId = srv.assetDir
-                            profileManager.save()
-                        },
-                        onLaunch = { srv ->
-                            selectedServerState = srv
-                            onServerSelected(srv)
-                            controller.launch(session, srv, onSessionUpdated)
-                        },
-                        onSettings  = { onOpenServerSettings(it) },
-                        onDetails   = { onOpenDetails(it) },
-                        onToggleFav = {
-                            profileManager.toggleFavorite(it.assetDir)
-                            favoriteTrigger++
-                        },
-                        syncStates = syncStates
-                    )
-                }
-            }
-        }
-
-        // ── Auto-sync overall progress strip ──────────────────────────────────
-        // Sticky just above the launch control panel. Visible only while
-        // AutoSyncService is actively walking the queue. Stays out of the way
-        // when auto-sync is disabled or has finished.
-        if (syncOverall is AutoSyncService.OverallState.InProgress) {
-            Spacer(Modifier.height(8.dp))
-            AutoSyncProgressStrip(
-                serverName = syncOverall.currentServer,
-                currentIdx = syncOverall.currentIdx,
-                total      = syncOverall.total,
-                bytesRead  = syncOverall.bytesRead,
-                totalBytes = syncOverall.totalBytes,
-            )
-        }
-
-        Spacer(Modifier.height(12.dp))
-
-        // ── Launch control ────────────────────────────────────────────────────
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .border(
-                    width = 1.dp,
-                    color = CelestiaTheme.colors.outline.copy(alpha = 0.25f),
-                    shape = RoundedCornerShape(14.dp)
-                )
-                .background(
-                    color = glassSurfaceAlpha(0.45f),
-                    shape = RoundedCornerShape(14.dp)
-                )
-                .padding(horizontal = 16.dp, vertical = 14.dp)
-        ) {
-            LaunchControlPanel(
-                state        = launchState,
-                onLaunch     = { selectedServerState?.let { controller.launch(session, it, onSessionUpdated) } },
-                onAbort      = { controller.abort() },
-                onClearError = { controller.clearError() }
-            )
-        }
-    }
-}
-
-/**
- * Compact strip above the launch panel showing AutoSyncService progress.
- * Renders only while a sync is in-flight; auto-hides when state transitions
- * to Idle / Done. Kept self-contained (no Koin deps) so it can be tested
- * with a fake `InProgress` state.
- */
-@Composable
-private fun AutoSyncProgressStrip(
-    serverName: String,
-    currentIdx: Int,
-    total: Int,
-    bytesRead: Long,
-    totalBytes: Long,
-) {
-    val s = LocalStrings.current
-    val progressFraction = if (totalBytes > 0) {
-        (bytesRead.toFloat() / totalBytes.toFloat()).coerceIn(0f, 1f)
-    } else 0f
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .border(
-                width = 1.dp,
-                color = CelestiaTheme.colors.outline.copy(alpha = 0.20f),
-                shape = RoundedCornerShape(10.dp)
-            )
-            .background(
-                color = glassSurfaceAlpha(0.35f),
-                shape = RoundedCornerShape(10.dp)
-            )
-            .padding(horizontal = 14.dp, vertical = 8.dp)
+    val ctx = remember(
+        session, initialSelectedServer, onServerSelected, onSessionUpdated,
+        onCloseApp, onOpenServerSettings, onOpenDetails,
     ) {
-        Column(Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = s.dashboardAutoSyncProgress(serverName, currentIdx, total),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = CelestiaTheme.colors.textSecondary,
-                    fontWeight = FontWeight.Medium
-                )
-                if (totalBytes > 0) {
-                    Text(
-                        text = s.dashboardAutoSyncBytes(bytesRead / 1_048_576, totalBytes / 1_048_576),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.7f)
-                    )
-                }
-            }
-            Spacer(Modifier.height(4.dp))
-            LinearProgressIndicator(
-                progress = { progressFraction },
-                modifier = Modifier.fillMaxWidth(),
-                color = CelestiaTheme.colors.primary,
-                trackColor = CelestiaTheme.colors.outline.copy(alpha = 0.15f),
-            )
-        }
+        HomeClassicContext(
+            session               = session,
+            initialSelectedServer = initialSelectedServer,
+            onServerSelected      = onServerSelected,
+            onSessionUpdated      = onSessionUpdated,
+            onCloseApp            = onCloseApp,
+            onOpenServerSettings  = onOpenServerSettings,
+            onOpenDetails         = onOpenDetails,
+        )
+    }
+    CompositionLocalProvider(LocalHomeClassicContext provides ctx) {
+        SlotRenderer(SurfaceId(SURFACE), SlotId("main"))
     }
 }
+
+private const val SURFACE = "home.classic"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
@@ -1,0 +1,49 @@
+package hivens.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.core.data.SessionData
+import hivens.ui.AppState
+import hivens.ui.Screen
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.widgets.home.new.HomeNewContext
+import hivens.ui.widgets.home.new.LocalHomeNewContext
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
+
+/**
+ * Widget-composed home surface. Kernel-3 ships a minimal prototype --
+ * welcome banner + recent-packs row + quick-launch -- proving the
+ * slot machinery for a brand-new (rather than legacy-wrapped) surface.
+ * Content grows in later phases as user-customization arrives.
+ */
+@Composable
+fun NewHomeScreen(
+    appState: AppState,
+    onScreenChange: (Screen) -> Unit,
+    onSessionUpdated: (SessionData) -> Unit,
+) {
+    PuppetScreen("NewHome")
+
+    val ctx = remember(appState, onScreenChange, onSessionUpdated) {
+        HomeNewContext(
+            appState         = appState,
+            onScreenChange   = onScreenChange,
+            onSessionUpdated = onSessionUpdated,
+        )
+    }
+    CompositionLocalProvider(LocalHomeNewContext provides ctx) {
+        Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
+            SlotRenderer(SurfaceId(SURFACE), SlotId("main"))
+        }
+    }
+}
+
+private const val SURFACE = "home.new"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -1,55 +1,29 @@
 package hivens.ui.screens.library
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import hivens.core.api.interfaces.IPackRepository
-import hivens.core.data.PackInstance
-import hivens.launcher.launch.LauncherController
 import hivens.ui.AppState
 import hivens.ui.Screen
-import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetScreen
-import hivens.ui.theme.CelestiaTheme
-import hivens.ui.utils.GameConsoleService
-import org.koin.compose.koinInject
+import hivens.ui.widgets.library.LibraryContext
+import hivens.ui.widgets.library.LocalLibraryContext
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
 
 /**
- * Library = user's collection of installed [PackInstance]s.
- * Renders [PackCard] rows for each instance the [IPackRepository]
- * is aware of. Card click navigates to [hivens.ui.Screen.PackDetail];
- * per-card Play launches via [LauncherController.launchPackInstance]
- * without the detail-screen hop; Settings / More still route to the
- * detail surface (the per-pack settings window lands in a follow-up
- * PR, [[project_pack_centric_direction]]).
- *
- * Empty state when the repository has nothing to show -- by design
- * this is the cold-start view for a fresh install (no packs yet);
- * the Browse screen is the entry point for installing.
+ * Library = user's collection of installed packs. Surface composable:
+ * owns the screen padding + header/body column; widget content
+ * (header text, list-or-empty) resolves through SlotRenderer against
+ * the layout graph.
  */
 @Composable
 fun LibraryScreen(
@@ -58,108 +32,19 @@ fun LibraryScreen(
 ) {
     PuppetScreen("Library")
 
-    val repo: IPackRepository = koinInject()
-    val controller: LauncherController = koinInject()
-    val launchDriver: PackLaunchDriver = koinInject()
-    val gameConsole: GameConsoleService = koinInject()
-    val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
-    val authedSession = (appState as? AppState.Authenticated)?.session
-
-    Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
-        Text(
-            text       = "БИБЛИОТЕКА",
-            style      = MaterialTheme.typography.headlineSmall,
-            color      = CelestiaTheme.colors.textPrimary,
-            fontWeight = FontWeight.Bold,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text  = "Установленные сборки",
-            style = MaterialTheme.typography.bodyMedium,
-            color = CelestiaTheme.colors.textSecondary,
-        )
-        Spacer(Modifier.height(16.dp))
-
-        if (instances.isEmpty()) {
-            LibraryEmpty(onBrowse = { onScreenChange(Screen.Browse) })
-        } else {
-            LibraryList(
-                instances = instances,
-                onOpenDetail = { onScreenChange(Screen.PackDetail(it.id)) },
-                onPlay = { instance ->
-                    // Unauthenticated state: defer to the detail screen
-                    // which renders an explicit "Sign in to play" prompt
-                    // instead of swallowing the click silently.
-                    val session = authedSession
-                    if (session == null) {
-                        onScreenChange(Screen.PackDetail(instance.id))
-                    } else {
-                        launchDriver.observe(instance)
-                        gameConsole.show()
-                        controller.launchPackInstance(session, instance)
-                    }
-                },
-                onSettings = { onScreenChange(Screen.PackDetail(it.id)) },
-                onMore = { onScreenChange(Screen.PackDetail(it.id)) },
-            )
+    val ctx = remember(appState, onScreenChange) {
+        LibraryContext(appState = appState, onScreenChange = onScreenChange)
+    }
+    CompositionLocalProvider(LocalLibraryContext provides ctx) {
+        Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
+            Box(Modifier.fillMaxWidth()) {
+                SlotRenderer(SurfaceId(SURFACE), SlotId("header"))
+            }
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                SlotRenderer(SurfaceId(SURFACE), SlotId("body"))
+            }
         }
     }
 }
 
-@Composable
-private fun LibraryList(
-    instances: List<PackInstance>,
-    onOpenDetail: (PackInstance) -> Unit,
-    onPlay: (PackInstance) -> Unit,
-    onSettings: (PackInstance) -> Unit,
-    onMore: (PackInstance) -> Unit,
-) {
-    LazyColumn(
-        modifier              = Modifier.fillMaxSize(),
-        contentPadding        = PaddingValues(bottom = 16.dp),
-        verticalArrangement   = Arrangement.spacedBy(10.dp),
-    ) {
-        items(items = instances, key = { it.id }) { instance ->
-            PackCard(
-                instance      = instance,
-                onOpenDetail  = { onOpenDetail(instance) },
-                onPlay        = { onPlay(instance) },
-                onSettings    = { onSettings(instance) },
-                onMore        = { onMore(instance) },
-            )
-        }
-    }
-}
-
-@Composable
-private fun LibraryEmpty(onBrowse: () -> Unit) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(14.dp),
-        ) {
-            Text(
-                text       = "Пока пусто",
-                style      = MaterialTheme.typography.titleLarge,
-                color      = CelestiaTheme.colors.textPrimary,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text      = "Установите сборку через Browse — она появится здесь.",
-                style     = MaterialTheme.typography.bodyMedium,
-                color     = CelestiaTheme.colors.textSecondary,
-                textAlign = TextAlign.Center,
-                modifier  = Modifier.widthIn(max = 360.dp),
-            )
-            Button(
-                onClick = onBrowse,
-                shape   = RoundedCornerShape(10.dp),
-                colors  = ButtonDefaults.buttonColors(
-                    containerColor = CelestiaTheme.colors.primary,
-                    contentColor   = Color.White,
-                ),
-            ) { Text("Открыть Browse", fontWeight = FontWeight.SemiBold) }
-        }
-    }
-}
-
+private const val SURFACE = "library"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
@@ -219,9 +219,11 @@ internal fun AppearanceSection(
         labelSub     = s.settingsHomeViewSub,
         classicLabel = s.settingsHomeViewClassic,
         libraryLabel = s.settingsHomeViewLibrary,
+        newLabel     = s.settingsHomeViewNew,
     )
     PuppetClick("settings.homeView.classic")      { onHomeViewChanged(HomeView.Classic) }
     PuppetClick("settings.homeView.libraryFirst") { onHomeViewChanged(HomeView.LibraryFirst) }
+    PuppetClick("settings.homeView.new")          { onHomeViewChanged(HomeView.New) }
 
     Spacer(Modifier.height(4.dp))
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
@@ -150,6 +150,7 @@ internal fun HomeViewPicker(
     labelSub: String,
     classicLabel: String,
     libraryLabel: String,
+    newLabel: String,
 ) {
     val style = LocalStyle.current
     Column(
@@ -176,6 +177,11 @@ internal fun HomeViewPicker(
                 label    = libraryLabel,
                 selected = current == HomeView.LibraryFirst,
                 onClick  = { onChange(HomeView.LibraryFirst) },
+            )
+            VariantPill(
+                label    = newLabel,
+                selected = current == HomeView.New,
+                onClick  = { onChange(HomeView.New) },
             )
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContent.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContent.kt
@@ -1,0 +1,312 @@
+package hivens.ui.widgets.home.classic
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IServerListService
+import hivens.core.api.interfaces.ISettingsService
+import hivens.core.api.model.ServerProfile
+import hivens.launcher.AutoSyncService
+import hivens.launcher.ProfileManager
+import hivens.launcher.launch.LaunchState
+import hivens.launcher.launch.LauncherController
+import hivens.launcher.network.NetworkState
+import hivens.ui.components.LaunchControlPanel
+import hivens.ui.components.ServerGrid
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.i18n.LocalStrings
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.compose.koinInject
+
+// Monolithic dashboard widget. Wraps the entire legacy DashboardScreen
+// body verbatim -- the regions (header / server grid / sync strip /
+// launch panel) share too much local state for clean extraction. The
+// classic dashboard is transitional and slated for removal once the
+// new widget-composed home matures; we widgetize it as one block so
+// the slot machinery is exercised without paying the refactor cost on
+// code that's going away.
+@Widget(id = "home.classic.content", displayName = "Classic dashboard")
+@Composable
+fun HomeClassicContent(instance: WidgetInstance) {
+    val ctx = LocalHomeClassicContext.current
+    val serverListService: IServerListService = koinInject()
+    val settingsService: ISettingsService = koinInject()
+    val profileManager: ProfileManager = koinInject()
+    val controller: LauncherController = koinInject()
+    val autoSyncService: AutoSyncService = koinInject()
+    val protocolConfig: hivens.launcher.network.ServerProtocolConfig = koinInject()
+    val s = LocalStrings.current
+    val scope = rememberCoroutineScope()
+
+    val launchState by controller.state.collectAsState()
+    val syncSnapshot by autoSyncService.snapshot.collectAsState()
+    val syncStates = syncSnapshot.perServer
+    val syncOverall = syncSnapshot.overall
+    var hiddenForCurrentSession by remember { mutableStateOf(false) }
+
+    var servers by remember { mutableStateOf<List<ServerProfile>>(emptyList()) }
+    var selectedServerState by remember { mutableStateOf(ctx.initialSelectedServer) }
+    var favoriteTrigger by remember { mutableStateOf(0) }
+    val favorites = remember(favoriteTrigger) { profileManager.favoriteServers }
+    var isLoadingServers by remember { mutableStateOf(true) }
+    val bypassHost = protocolConfig.sslBypassHost
+    val bypassesList by NetworkState.bypassesState.collectAsState()
+    val sslBypass = remember(bypassesList, bypassHost) { NetworkState.bypassFor(bypassHost) }
+
+    fun fetchServers(forceRefresh: Boolean = false) {
+        isLoadingServers = true
+        scope.launch(Dispatchers.IO) {
+            try {
+                val data = if (forceRefresh) serverListService.refresh().get()
+                           else              serverListService.fetchDashboardData().get()
+                withContext(Dispatchers.Main) {
+                    servers = data.servers
+                    if (selectedServerState == null && servers.isNotEmpty()) {
+                        val lastId = profileManager.lastServerId
+                        val default = servers.find { it.assetDir == lastId } ?: servers.firstOrNull()
+                        if (default != null) {
+                            selectedServerState = default
+                            ctx.onServerSelected(default)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                org.slf4j.LoggerFactory.getLogger("HomeClassicContent")
+                    .error("Failed to load server list", e)
+            } finally {
+                withContext(Dispatchers.Main) { isLoadingServers = false }
+            }
+        }
+    }
+
+    LaunchedEffect(launchState) {
+        when (launchState) {
+            is LaunchState.GameRunning -> {
+                if (settingsService.getSettings().closeAfterStart && !hiddenForCurrentSession) {
+                    hiddenForCurrentSession = true
+                    ctx.onCloseApp()
+                }
+            }
+            is LaunchState.Idle, is LaunchState.Error -> hiddenForCurrentSession = false
+            else -> {}
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (servers.isEmpty()) fetchServers() else isLoadingServers = false
+    }
+
+    LaunchedEffect(sslBypass) {
+        if (sslBypass && servers.isEmpty()) fetchServers()
+    }
+
+    LaunchedEffect(ctx.initialSelectedServer) {
+        if (ctx.initialSelectedServer != null) selectedServerState = ctx.initialSelectedServer
+    }
+
+    Column(Modifier.fillMaxSize().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 16.dp)) {
+        Text(
+            text       = s.dashboardWelcome(ctx.session.playerName),
+            style      = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+            color      = CelestiaTheme.colors.textSecondary,
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text       = s.dashboardServers,
+            style      = MaterialTheme.typography.bodySmall,
+            color      = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+            when {
+                isLoadingServers -> CircularProgressIndicator(color = CelestiaTheme.colors.primary)
+                servers.isEmpty() -> {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            imageVector        = Icons.Default.WifiOff,
+                            contentDescription = null,
+                            tint               = CelestiaTheme.colors.textSecondary.copy(alpha = 0.5f),
+                            modifier           = Modifier.size(48.dp),
+                        )
+                        Spacer(Modifier.height(16.dp))
+                        Text(s.dashboardServersEmpty, color = CelestiaTheme.colors.textSecondary)
+                        Spacer(Modifier.height(16.dp))
+                        OutlinedButton(
+                            onClick = { fetchServers(forceRefresh = true) },
+                            colors  = ButtonDefaults.outlinedButtonColors(
+                                contentColor = CelestiaTheme.colors.primary,
+                            ),
+                        ) {
+                            Icon(Icons.Default.Refresh, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text(s.updateRetry)
+                        }
+                    }
+                }
+                else -> {
+                    ServerGrid(
+                        servers        = servers,
+                        favorites      = favorites,
+                        selectedServer = selectedServerState,
+                        isLaunchable   = launchState is LaunchState.Idle || launchState is LaunchState.Error,
+                        onSelect       = { srv ->
+                            selectedServerState = srv
+                            ctx.onServerSelected(srv)
+                            profileManager.lastServerId = srv.assetDir
+                            profileManager.save()
+                        },
+                        onLaunch = { srv ->
+                            selectedServerState = srv
+                            ctx.onServerSelected(srv)
+                            controller.launch(ctx.session, srv, ctx.onSessionUpdated)
+                        },
+                        onSettings  = { ctx.onOpenServerSettings(it) },
+                        onDetails   = { ctx.onOpenDetails(it) },
+                        onToggleFav = {
+                            profileManager.toggleFavorite(it.assetDir)
+                            favoriteTrigger++
+                        },
+                        syncStates = syncStates,
+                    )
+                }
+            }
+        }
+
+        if (syncOverall is AutoSyncService.OverallState.InProgress) {
+            Spacer(Modifier.height(8.dp))
+            AutoSyncProgressStrip(
+                serverName = syncOverall.currentServer,
+                currentIdx = syncOverall.currentIdx,
+                total      = syncOverall.total,
+                bytesRead  = syncOverall.bytesRead,
+                totalBytes = syncOverall.totalBytes,
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    color = CelestiaTheme.colors.outline.copy(alpha = 0.25f),
+                    shape = RoundedCornerShape(14.dp),
+                )
+                .background(
+                    color = glassSurfaceAlpha(0.45f),
+                    shape = RoundedCornerShape(14.dp),
+                )
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            LaunchControlPanel(
+                state        = launchState,
+                onLaunch     = { selectedServerState?.let { controller.launch(ctx.session, it, ctx.onSessionUpdated) } },
+                onAbort      = { controller.abort() },
+                onClearError = { controller.clearError() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AutoSyncProgressStrip(
+    serverName: String,
+    currentIdx: Int,
+    total: Int,
+    bytesRead: Long,
+    totalBytes: Long,
+) {
+    val s = LocalStrings.current
+    val progressFraction = if (totalBytes > 0) {
+        (bytesRead.toFloat() / totalBytes.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = CelestiaTheme.colors.outline.copy(alpha = 0.20f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .background(
+                color = glassSurfaceAlpha(0.35f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        Column(Modifier.fillMaxWidth()) {
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text       = s.dashboardAutoSyncProgress(serverName, currentIdx, total),
+                    style      = MaterialTheme.typography.bodySmall,
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                )
+                if (totalBytes > 0) {
+                    Text(
+                        text  = s.dashboardAutoSyncBytes(bytesRead / 1_048_576, totalBytes / 1_048_576),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.7f),
+                    )
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+            LinearProgressIndicator(
+                progress   = { progressFraction },
+                modifier   = Modifier.fillMaxWidth(),
+                color      = CelestiaTheme.colors.primary,
+                trackColor = CelestiaTheme.colors.outline.copy(alpha = 0.15f),
+            )
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContext.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContext.kt
@@ -1,0 +1,25 @@
+package hivens.ui.widgets.home.classic
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import hivens.core.api.model.ServerProfile
+import hivens.core.data.SessionData
+
+// Navigation context for the monolithic classic-home widget. Provided
+// by DashboardScreen, consumed by HomeClassicContent. Carries the
+// per-render values that cannot live in Koin (live session, navigation
+// callbacks routing back into AppShell).
+data class HomeClassicContext(
+    val session: SessionData,
+    val initialSelectedServer: ServerProfile?,
+    val onServerSelected: (ServerProfile) -> Unit,
+    val onSessionUpdated: (SessionData) -> Unit,
+    val onCloseApp: () -> Unit,
+    val onOpenServerSettings: (ServerProfile) -> Unit,
+    val onOpenDetails: (ServerProfile) -> Unit,
+)
+
+val LocalHomeClassicContext: ProvidableCompositionLocal<HomeClassicContext> =
+    staticCompositionLocalOf {
+        error("LocalHomeClassicContext not provided -- mount inside DashboardScreen")
+    }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewContext.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewContext.kt
@@ -1,0 +1,22 @@
+package hivens.ui.widgets.home.new
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import hivens.core.data.SessionData
+import hivens.ui.AppState
+import hivens.ui.Screen
+
+// Navigation context for the new prototype home surface. Widgets in
+// home.new.main read live appState + nav dispatcher. session lifts
+// from AppState.Authenticated where applicable; widgets that need it
+// guard on the cast themselves.
+data class HomeNewContext(
+    val appState: AppState,
+    val onScreenChange: (Screen) -> Unit,
+    val onSessionUpdated: (SessionData) -> Unit,
+)
+
+val LocalHomeNewContext: ProvidableCompositionLocal<HomeNewContext> =
+    staticCompositionLocalOf {
+        error("LocalHomeNewContext not provided -- mount inside NewHomeScreen")
+    }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
@@ -1,0 +1,120 @@
+package hivens.ui.widgets.home.new
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.launcher.launch.LaunchState
+import hivens.launcher.launch.LauncherController
+import hivens.ui.AppState
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.notifications.drivers.PackLaunchDriver
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.utils.GameConsoleService
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+// One-click launch of the most-recently-played pack. Disabled when no
+// session is available or the repo has no played packs. While a launch
+// is in flight, the button reflects the current state rather than
+// firing duplicate launches.
+@Widget(id = "home.new.quicklaunch", displayName = "Quick launch")
+@Composable
+fun HomeNewQuickLaunch(instance: WidgetInstance) {
+    val ctx = LocalHomeNewContext.current
+    val repo: IPackRepository = koinInject()
+    val controller: LauncherController = koinInject()
+    val launchDriver: PackLaunchDriver = koinInject()
+    val gameConsole: GameConsoleService = koinInject()
+    val all by remember { repo.observe() }.collectAsState(initial = emptyList())
+    val launchState by controller.state.collectAsState()
+
+    val mostRecent = remember(all) {
+        all.filter { it.lastPlayedEpochOrZero > 0L }
+            .maxByOrNull { it.lastPlayedEpochOrZero }
+    } ?: return
+    val session = (ctx.appState as? AppState.Authenticated)?.session
+
+    val canLaunch = session != null &&
+        (launchState is LaunchState.Idle || launchState is LaunchState.Error)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.45f))
+            .padding(horizontal = 18.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text       = "Быстрый запуск",
+            style      = MaterialTheme.typography.labelLarge,
+            color      = CelestiaTheme.colors.textSecondary,
+            fontWeight = FontWeight.Medium,
+        )
+        Row(
+            modifier              = Modifier.fillMaxWidth(),
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text       = mostRecent.displayName,
+                    style      = MaterialTheme.typography.titleMedium,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text  = mostRecent.packRef.id,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Button(
+                onClick = {
+                    val s = session ?: return@Button
+                    launchDriver.observe(mostRecent)
+                    gameConsole.show()
+                    controller.launchPackInstance(s, mostRecent)
+                },
+                enabled = canLaunch,
+                shape   = RoundedCornerShape(10.dp),
+                colors  = ButtonDefaults.buttonColors(
+                    containerColor = CelestiaTheme.colors.primary,
+                    contentColor   = Color.White,
+                ),
+            ) {
+                Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("Играть", fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
 import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.LauncherController
 import hivens.ui.AppState
@@ -39,10 +40,10 @@ import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
 import org.koin.compose.koinInject
 
-// One-click launch of the most-recently-played pack. Disabled when no
-// session is available or the repo has no played packs. While a launch
-// is in flight, the button reflects the current state rather than
-// firing duplicate launches.
+// Quick-launch target = most recently played, falling back to most
+// recently installed when nothing has been played. Empty repo elides
+// the widget entirely -- HomeNewRecent already shows the install CTA
+// in that state and two empty cards would be noisy.
 @Widget(id = "home.new.quicklaunch", displayName = "Quick launch")
 @Composable
 fun HomeNewQuickLaunch(instance: WidgetInstance) {
@@ -54,14 +55,16 @@ fun HomeNewQuickLaunch(instance: WidgetInstance) {
     val all by remember { repo.observe() }.collectAsState(initial = emptyList())
     val launchState by controller.state.collectAsState()
 
-    val mostRecent = remember(all) {
-        all.filter { it.lastPlayedEpochOrZero > 0L }
-            .maxByOrNull { it.lastPlayedEpochOrZero }
+    val target: PackInstance = remember(all) {
+        all.maxByOrNull { it.lastPlayedEpochOrZero }
+            ?: all.maxByOrNull { it.createdAtEpoch }
     } ?: return
     val session = (ctx.appState as? AppState.Authenticated)?.session
 
     val canLaunch = session != null &&
         (launchState is LaunchState.Idle || launchState is LaunchState.Error)
+
+    val label = if (target.lastPlayedEpochOrZero > 0L) "Продолжить" else "Запустить"
 
     Column(
         modifier = Modifier
@@ -73,7 +76,7 @@ fun HomeNewQuickLaunch(instance: WidgetInstance) {
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            text       = "Быстрый запуск",
+            text       = label,
             style      = MaterialTheme.typography.labelLarge,
             color      = CelestiaTheme.colors.textSecondary,
             fontWeight = FontWeight.Medium,
@@ -85,13 +88,13 @@ fun HomeNewQuickLaunch(instance: WidgetInstance) {
         ) {
             Column(Modifier.weight(1f)) {
                 Text(
-                    text       = mostRecent.displayName,
+                    text       = target.displayName,
                     style      = MaterialTheme.typography.titleMedium,
                     color      = CelestiaTheme.colors.textPrimary,
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    text  = mostRecent.packRef.id,
+                    text  = target.packRef.id,
                     style = MaterialTheme.typography.bodySmall,
                     color = CelestiaTheme.colors.textSecondary,
                 )
@@ -100,9 +103,9 @@ fun HomeNewQuickLaunch(instance: WidgetInstance) {
             Button(
                 onClick = {
                     val s = session ?: return@Button
-                    launchDriver.observe(mostRecent)
+                    launchDriver.observe(target)
                     gameConsole.show()
-                    controller.launchPackInstance(s, mostRecent)
+                    controller.launchPackInstance(s, target)
                 },
                 enabled = canLaunch,
                 shape   = RoundedCornerShape(10.dp),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
@@ -1,0 +1,126 @@
+package hivens.ui.widgets.home.new
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
+import hivens.ui.Screen
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+private const val MAX_RECENT = 5
+
+// Recent packs LRU row. Sorted by lastPlayedEpochOrZero descending;
+// packs that have never been played fall to the end. Empty repo
+// elides the whole widget so the slot does not show a stranded
+// section header.
+@Widget(id = "home.new.recent", displayName = "Recent packs")
+@Composable
+fun HomeNewRecent(instance: WidgetInstance) {
+    val ctx = LocalHomeNewContext.current
+    val repo: IPackRepository = koinInject()
+    val all by remember { repo.observe() }.collectAsState(initial = emptyList())
+
+    val recent = remember(all) {
+        all.filter { it.lastPlayedEpochOrZero > 0L }
+            .sortedByDescending { it.lastPlayedEpochOrZero }
+            .take(MAX_RECENT)
+    }
+    if (recent.isEmpty()) return
+
+    Column(Modifier.fillMaxWidth().padding(top = 12.dp)) {
+        Text(
+            text       = "Недавние сборки",
+            style      = MaterialTheme.typography.titleSmall,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.SemiBold,
+            modifier   = Modifier.padding(bottom = 8.dp),
+        )
+        LazyRow(
+            modifier            = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            contentPadding      = PaddingValues(vertical = 2.dp),
+        ) {
+            items(items = recent, key = { it.id }) { pack ->
+                RecentPackTile(
+                    pack    = pack,
+                    onClick = { ctx.onScreenChange(Screen.PackDetail(pack.id)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentPackTile(pack: PackInstance, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .width(180.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(glassSurfaceAlpha(0.40f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(CelestiaTheme.colors.textSecondary.copy(alpha = 0.15f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector        = Icons.Default.History,
+                contentDescription = null,
+                tint               = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f),
+                modifier           = Modifier.size(18.dp),
+            )
+        }
+        Text(
+            text       = pack.displayName,
+            style      = MaterialTheme.typography.bodyMedium,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.SemiBold,
+            maxLines   = 1,
+            overflow   = TextOverflow.Ellipsis,
+        )
+        Text(
+            text     = pack.packRef.id,
+            style    = MaterialTheme.typography.bodySmall,
+            color    = CelestiaTheme.colors.textSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
@@ -17,8 +17,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -41,39 +45,45 @@ import org.koin.compose.koinInject
 
 private const val MAX_RECENT = 5
 
-// Recent packs LRU row. Sorted by lastPlayedEpochOrZero descending;
-// packs that have never been played fall to the end. Empty repo
-// elides the whole widget so the slot does not show a stranded
-// section header.
-@Widget(id = "home.new.recent", displayName = "Recent packs")
+// Pack tiles row. Sort priority: played packs first by recency, then
+// unplayed packs by install order. A fresh install with packs but no
+// launches still shows the tiles (sorted by createdAt), so the new
+// home reads as populated rather than blank. Empty repo shows a CTA
+// pointing at Browse.
+@Widget(id = "home.new.recent", displayName = "Pack tiles")
 @Composable
 fun HomeNewRecent(instance: WidgetInstance) {
     val ctx = LocalHomeNewContext.current
     val repo: IPackRepository = koinInject()
     val all by remember { repo.observe() }.collectAsState(initial = emptyList())
 
-    val recent = remember(all) {
-        all.filter { it.lastPlayedEpochOrZero > 0L }
-            .sortedByDescending { it.lastPlayedEpochOrZero }
-            .take(MAX_RECENT)
+    if (all.isEmpty()) {
+        EmptyPacksCta(onBrowse = { ctx.onScreenChange(Screen.Browse) })
+        return
     }
-    if (recent.isEmpty()) return
+
+    val recent = remember(all) {
+        all.sortedWith(
+            compareByDescending<PackInstance> { it.lastPlayedEpochOrZero }
+                .thenByDescending { it.createdAtEpoch },
+        ).take(MAX_RECENT)
+    }
 
     Column(Modifier.fillMaxWidth().padding(top = 12.dp)) {
         Text(
-            text       = "Недавние сборки",
+            text       = "Твои сборки",
             style      = MaterialTheme.typography.titleSmall,
             color      = CelestiaTheme.colors.textPrimary,
             fontWeight = FontWeight.SemiBold,
             modifier   = Modifier.padding(bottom = 8.dp),
         )
         LazyRow(
-            modifier            = Modifier.fillMaxWidth(),
+            modifier              = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
-            contentPadding      = PaddingValues(vertical = 2.dp),
+            contentPadding        = PaddingValues(vertical = 2.dp),
         ) {
             items(items = recent, key = { it.id }) { pack ->
-                RecentPackTile(
+                PackTile(
                     pack    = pack,
                     onClick = { ctx.onScreenChange(Screen.PackDetail(pack.id)) },
                 )
@@ -83,7 +93,8 @@ fun HomeNewRecent(instance: WidgetInstance) {
 }
 
 @Composable
-private fun RecentPackTile(pack: PackInstance, onClick: () -> Unit) {
+private fun PackTile(pack: PackInstance, onClick: () -> Unit) {
+    val played = pack.lastPlayedEpochOrZero > 0L
     Column(
         modifier = Modifier
             .width(180.dp)
@@ -101,7 +112,7 @@ private fun RecentPackTile(pack: PackInstance, onClick: () -> Unit) {
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector        = Icons.Default.History,
+                imageVector        = if (played) Icons.Default.History else Icons.Default.Inventory2,
                 contentDescription = null,
                 tint               = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f),
                 modifier           = Modifier.size(18.dp),
@@ -122,5 +133,42 @@ private fun RecentPackTile(pack: PackInstance, onClick: () -> Unit) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+}
+
+@Composable
+private fun EmptyPacksCta(onBrowse: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.40f))
+            .padding(horizontal = 18.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text       = "Сборок пока нет",
+            style      = MaterialTheme.typography.titleSmall,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text  = "Установи что-нибудь через Browse — твои сборки появятся здесь.",
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+        Spacer(Modifier.height(2.dp))
+        OutlinedButton(
+            onClick = onBrowse,
+            shape   = RoundedCornerShape(10.dp),
+            colors  = ButtonDefaults.outlinedButtonColors(
+                contentColor = CelestiaTheme.colors.primary,
+            ),
+        ) {
+            Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text("Открыть Browse", fontWeight = FontWeight.Medium)
+        }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewWelcome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewWelcome.kt
@@ -1,0 +1,54 @@
+package hivens.ui.widgets.home.new
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.AppState
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.i18n.LocalStrings
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+// Greeting banner. Personalizes with the authenticated player name;
+// in unauthenticated / loading states the welcome stays generic so the
+// banner does not flicker between greetings during login.
+@Widget(id = "home.new.welcome", displayName = "Welcome banner")
+@Composable
+fun HomeNewWelcome(instance: WidgetInstance) {
+    val ctx = LocalHomeNewContext.current
+    val s = LocalStrings.current
+    val playerName = (ctx.appState as? AppState.Authenticated)?.session?.playerName
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.45f))
+            .padding(horizontal = 20.dp, vertical = 18.dp),
+    ) {
+        Text(
+            text       = if (playerName != null) s.dashboardWelcome(playerName) else s.appName,
+            style      = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color      = CelestiaTheme.colors.textPrimary,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = s.settingsHomeViewSub,
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryBody.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryBody.kt
@@ -1,0 +1,135 @@
+package hivens.ui.widgets.library
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
+import hivens.launcher.launch.LauncherController
+import hivens.ui.AppState
+import hivens.ui.Screen
+import hivens.ui.notifications.drivers.PackLaunchDriver
+import hivens.ui.screens.library.PackCard
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.utils.GameConsoleService
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+// Single widget covers both populated list and empty state. Slot-level
+// branching would force the layout graph to know about appState, which
+// belongs to navigation, not layout. Self-gating keeps the slot stable
+// across the empty -> populated transition.
+@Widget(id = "library.body", displayName = "Library Body")
+@Composable
+fun LibraryBody(instance: WidgetInstance) {
+    val ctx = LocalLibraryContext.current
+    val repo: IPackRepository = koinInject()
+    val controller: LauncherController = koinInject()
+    val launchDriver: PackLaunchDriver = koinInject()
+    val gameConsole: GameConsoleService = koinInject()
+    val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
+    val authedSession = (ctx.appState as? AppState.Authenticated)?.session
+
+    if (instances.isEmpty()) {
+        LibraryEmpty(onBrowse = { ctx.onScreenChange(Screen.Browse) })
+    } else {
+        LibraryList(
+            instances    = instances,
+            onOpenDetail = { ctx.onScreenChange(Screen.PackDetail(it.id)) },
+            onPlay       = { pack ->
+                // Unauthenticated state: defer to the detail screen
+                // which renders an explicit "Sign in to play" prompt
+                // instead of swallowing the click silently.
+                val session = authedSession
+                if (session == null) {
+                    ctx.onScreenChange(Screen.PackDetail(pack.id))
+                } else {
+                    launchDriver.observe(pack)
+                    gameConsole.show()
+                    controller.launchPackInstance(session, pack)
+                }
+            },
+            onSettings = { ctx.onScreenChange(Screen.PackDetail(it.id)) },
+            onMore     = { ctx.onScreenChange(Screen.PackDetail(it.id)) },
+        )
+    }
+}
+
+@Composable
+private fun LibraryList(
+    instances: List<PackInstance>,
+    onOpenDetail: (PackInstance) -> Unit,
+    onPlay: (PackInstance) -> Unit,
+    onSettings: (PackInstance) -> Unit,
+    onMore: (PackInstance) -> Unit,
+) {
+    LazyColumn(
+        modifier            = Modifier.fillMaxSize(),
+        contentPadding      = PaddingValues(bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        items(items = instances, key = { it.id }) { instance ->
+            PackCard(
+                instance     = instance,
+                onOpenDetail = { onOpenDetail(instance) },
+                onPlay       = { onPlay(instance) },
+                onSettings   = { onSettings(instance) },
+                onMore       = { onMore(instance) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryEmpty(onBrowse: () -> Unit) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                text       = "Пока пусто",
+                style      = MaterialTheme.typography.titleLarge,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text      = "Установите сборку через Browse — она появится здесь.",
+                style     = MaterialTheme.typography.bodyMedium,
+                color     = CelestiaTheme.colors.textSecondary,
+                textAlign = TextAlign.Center,
+                modifier  = Modifier.widthIn(max = 360.dp),
+            )
+            Button(
+                onClick = onBrowse,
+                shape   = RoundedCornerShape(10.dp),
+                colors  = ButtonDefaults.buttonColors(
+                    containerColor = CelestiaTheme.colors.primary,
+                    contentColor   = Color.White,
+                ),
+            ) { Text("Открыть Browse", fontWeight = FontWeight.SemiBold) }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryContext.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryContext.kt
@@ -1,0 +1,18 @@
+package hivens.ui.widgets.library
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import hivens.ui.AppState
+import hivens.ui.Screen
+
+// Navigation context for the library surface. Provided by
+// LibraryScreen, consumed by library.header / library.body widgets.
+data class LibraryContext(
+    val appState: AppState,
+    val onScreenChange: (Screen) -> Unit,
+)
+
+val LocalLibraryContext: ProvidableCompositionLocal<LibraryContext> =
+    staticCompositionLocalOf {
+        error("LocalLibraryContext not provided -- mount inside LibraryScreen")
+    }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
@@ -1,0 +1,35 @@
+package hivens.ui.widgets.library
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+@Widget(id = "library.header", displayName = "Library Header")
+@Composable
+fun LibraryHeader(instance: WidgetInstance) {
+    Column(Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+        Text(
+            text       = "БИБЛИОТЕКА",
+            style      = MaterialTheme.typography.headlineSmall,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = "Установленные сборки",
+            style = MaterialTheme.typography.bodyMedium,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailConsoleToggle.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailConsoleToggle.kt
@@ -1,0 +1,38 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.utils.GameConsoleService
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+@Widget(id = "appshell.leftrail.consoletoggle", displayName = "Console toggle")
+@Composable
+fun LeftRailConsoleToggle(instance: WidgetInstance) {
+    val gameConsole: GameConsoleService = koinInject()
+    IconButton(
+        onClick  = {
+            if (gameConsole.shouldShowConsole) gameConsole.hide()
+            else gameConsole.show()
+        },
+        modifier = Modifier.size(48.dp),
+    ) {
+        Icon(
+            imageVector        = Icons.Default.Build,
+            contentDescription = null,
+            tint               = if (gameConsole.shouldShowConsole)
+                CelestiaTheme.colors.primary
+            else
+                CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+            modifier           = Modifier.size(22.dp),
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailLogout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailLogout.kt
@@ -1,0 +1,32 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+// Self-gates on isAuthenticated -- renders nothing when the session
+// is absent so the slot can list the widget unconditionally and the
+// layout graph stays free of auth-state vocabulary.
+@Widget(id = "appshell.leftrail.logout", displayName = "Logout")
+@Composable
+fun LeftRailLogout(instance: WidgetInstance) {
+    val ctx = LocalLeftRailContext.current
+    if (!ctx.isAuthenticated) return
+
+    IconButton(onClick = ctx.onLogout, modifier = Modifier.size(48.dp)) {
+        Icon(
+            imageVector        = Icons.AutoMirrored.Filled.ExitToApp,
+            contentDescription = null,
+            tint               = CelestiaTheme.colors.error.copy(alpha = 0.75f),
+            modifier           = Modifier.size(22.dp),
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailNavButtons.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailNavButtons.kt
@@ -1,0 +1,170 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import hivens.ui.Screen
+import hivens.ui.easter.LocalAprilFools
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import kotlin.math.sin
+import kotlin.random.Random
+
+@Widget(id = "appshell.leftrail.navbuttons", displayName = "Sidebar nav buttons")
+@Composable
+fun LeftRailNavButtons(instance: WidgetInstance) {
+    val ctx = LocalLeftRailContext.current
+    val af = LocalAprilFools.current
+
+    val homeActive = ctx.currentScreen is Screen.Home ||
+        ctx.currentScreen is Screen.ServerSettings ||
+        ctx.currentScreen is Screen.ServerDetails
+    val libraryActive = ctx.currentScreen is Screen.Library ||
+        ctx.currentScreen is Screen.PackDetail
+    val browseActive = ctx.currentScreen is Screen.Browse ||
+        ctx.currentScreen is Screen.BrowsePackDetail
+    val profileActive = ctx.currentScreen is Screen.Profile
+    val settingsActive = ctx.currentScreen is Screen.Settings ||
+        ctx.currentScreen is Screen.ThemePicker ||
+        ctx.currentScreen is Screen.BackgroundSettings ||
+        ctx.currentScreen is Screen.CustomizationExtension
+    val aboutActive = ctx.currentScreen is Screen.About
+
+    // April Fools: nav clicks have a 30% chance of being silently
+    // swallowed. The button doesn't move or react -- it just feels
+    // like the UI froze. Logout is intentionally excluded so the
+    // user can always escape.
+    fun chaosNavClick(originalClick: () -> Unit): () -> Unit {
+        if (!af.isActive()) return originalClick
+        return {
+            if (Random.nextFloat() > 0.30f) originalClick()
+        }
+    }
+
+    // April Fools: bouncing nav buttons. Each item has a unique sine
+    // phase so they bounce out of sync. Amplitude grows from 0px on
+    // day 1 to 18px on day 14.
+    val bounceAmplitude = if (af.isActive()) af.intensity() * 18f else 0f
+    val bounceTransition = rememberInfiniteTransition(label = "navBounce")
+    val bounceCycle by bounceTransition.animateFloat(
+        initialValue  = 0f,
+        targetValue   = (2f * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = if (af.isActive())
+                    (2200 - af.intensity() * 1400).toInt().coerceAtLeast(600)
+                else 2200,
+                easing = LinearEasing,
+            ),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "bounceCycle",
+    )
+
+    val homeOffset     = sin(bounceCycle + 0.0f)  * bounceAmplitude
+    val libraryOffset  = sin(bounceCycle + 0.55f) * bounceAmplitude
+    val browseOffset   = sin(bounceCycle + 1.65f) * bounceAmplitude
+    val profileOffset  = sin(bounceCycle + 1.1f)  * bounceAmplitude
+    val settingsOffset = sin(bounceCycle + 2.2f)  * bounceAmplitude
+    val aboutOffset    = sin(bounceCycle + 3.3f)  * bounceAmplitude
+
+    Spacer(Modifier.height(8.dp))
+
+    Box(Modifier.graphicsLayer { translationY = homeOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Home,
+            selected = homeActive,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.Home) },
+        )
+    }
+    Box(Modifier.graphicsLayer { translationY = libraryOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Star,
+            selected = libraryActive,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.Library) },
+        )
+    }
+    Box(Modifier.graphicsLayer { translationY = browseOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Search,
+            selected = browseActive,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.Browse) },
+        )
+    }
+    Box(Modifier.graphicsLayer { translationY = profileOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Person,
+            selected = profileActive,
+            enabled  = ctx.isAuthenticated,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.Profile) },
+        )
+    }
+    Box(Modifier.graphicsLayer { translationY = settingsOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Settings,
+            selected = settingsActive,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.Settings) },
+        )
+    }
+    Box(Modifier.graphicsLayer { translationY = aboutOffset }) {
+        SidebarNavItem(
+            icon     = Icons.Default.Info,
+            selected = aboutActive,
+            onClick  = chaosNavClick { ctx.onScreenChange(Screen.About) },
+        )
+    }
+}
+
+@Composable
+private fun SidebarNavItem(
+    icon: ImageVector,
+    selected: Boolean,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    NavigationRailItem(
+        icon = {
+            Icon(
+                imageVector        = icon,
+                contentDescription = null,
+                modifier           = Modifier.size(24.dp),
+            )
+        },
+        selected        = selected,
+        onClick         = onClick,
+        enabled         = enabled,
+        label           = null,
+        alwaysShowLabel = false,
+        colors          = NavigationRailItemDefaults.colors(
+            selectedIconColor   = CelestiaTheme.colors.primary,
+            unselectedIconColor = CelestiaTheme.colors.textSecondary.copy(
+                alpha = if (enabled) 0.70f else 0.20f,
+            ),
+            indicatorColor      = CelestiaTheme.colors.primary.copy(alpha = 0.13f),
+        ),
+    )
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailAuthPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailAuthPanel.kt
@@ -1,0 +1,34 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import hivens.ui.AccountPanel
+import hivens.ui.AppState
+import hivens.ui.AuthLoadingSlot
+import hivens.ui.LoginPanel
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+@Widget(id = "appshell.rightrail.authpanel", displayName = "Auth panel")
+@Composable
+fun RightRailAuthPanel(instance: WidgetInstance) {
+    val ctx = LocalRightRailContext.current
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(glassSurfaceAlpha(0.22f)),
+    ) {
+        when (val state = ctx.appState) {
+            AppState.Loading          -> AuthLoadingSlot()
+            AppState.Unauthenticated  -> LoginPanel(onLogin = ctx.onLogin)
+            is AppState.Authenticated -> AccountPanel(
+                session  = state.session,
+                onLogout = ctx.onLogout,
+            )
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailCompactNews.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailCompactNews.kt
@@ -1,0 +1,18 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import hivens.ui.CompactNewsFeed
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+@Widget(id = "appshell.rightrail.compactnews", displayName = "News feed")
+@Composable
+fun RightRailCompactNews(instance: WidgetInstance) {
+    val ctx = LocalRightRailContext.current
+    CompactNewsFeed(
+        sslBypass = ctx.sslBypass,
+        modifier  = Modifier.fillMaxSize(),
+    )
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/ShellContexts.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/ShellContexts.kt
@@ -1,0 +1,34 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import hivens.core.data.SessionData
+import hivens.ui.AppState
+import hivens.ui.Screen
+
+// AppShell rails carry navigation state per render. The shell composable
+// computes them once and provides via these locals; rail widgets read
+// without re-resolving.
+data class LeftRailContext(
+    val currentScreen: Screen,
+    val isAuthenticated: Boolean,
+    val onScreenChange: (Screen) -> Unit,
+    val onLogout: () -> Unit,
+)
+
+val LocalLeftRailContext: ProvidableCompositionLocal<LeftRailContext> =
+    staticCompositionLocalOf {
+        error("LocalLeftRailContext not provided -- mount inside AppSidebar")
+    }
+
+data class RightRailContext(
+    val appState: AppState,
+    val onLogin: (SessionData) -> Unit,
+    val onLogout: () -> Unit,
+    val sslBypass: Boolean,
+)
+
+val LocalRightRailContext: ProvidableCompositionLocal<RightRailContext> =
+    staticCompositionLocalOf {
+        error("LocalRightRailContext not provided -- mount inside RightPanel")
+    }

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -1,0 +1,51 @@
+package hivens.widget
+
+import hivens.widget.generated.GeneratedWidgetRegistry
+import hivens.widget.model.DefaultLayout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Pins the kernel-3 contract: every widget kind referenced from the
+// bundled default layout must exist in the KSP-generated registry.
+// If a refactor renames a widget but forgets the layout JSON (or
+// vice versa), SlotRenderer would silently skip the missing kind in
+// production -- this catches it at compile time of the test.
+class WidgetRegistryConsistencyTest {
+
+    @Test
+    fun `every default-layout widget kind exists in the generated registry`() {
+        val graph = DefaultLayout.load()
+        val referenced = graph.surfaces.values
+            .flatMap { it.slots.values }
+            .flatMap { it.widgets }
+            .map { it.kind }
+            .toSet()
+        val available = GeneratedWidgetRegistry.all().keys
+
+        val missing = referenced - available
+        assertEquals(
+            emptySet(),
+            missing,
+            "default-layout.json references widget kinds that the registry does not know about: $missing",
+        )
+    }
+
+    @Test
+    fun `registry exposes the kernel-3 widget kinds`() {
+        val expected = setOf(
+            "home.classic.content",
+            "home.new.welcome",
+            "home.new.recent",
+            "home.new.quicklaunch",
+            "library.header",
+            "library.body",
+            "appshell.leftrail.navbuttons",
+            "appshell.leftrail.consoletoggle",
+            "appshell.leftrail.logout",
+            "appshell.rightrail.authpanel",
+            "appshell.rightrail.compactnews",
+        )
+        val actual = GeneratedWidgetRegistry.all().keys.map { it.value }.toSet()
+        assertEquals(expected, actual, "registry drift -- kernel-3 expected exactly these 11 widgets")
+    }
+}

--- a/widget-model/src/main/resources/widget/default-layout.json
+++ b/widget-model/src/main/resources/widget/default-layout.json
@@ -4,22 +4,65 @@
     "surfaces": {
       "home.classic": {
         "slots": {
-          "main": { "widgets": [] }
+          "main": {
+            "widgets": [
+              { "kind": "home.classic.content", "instance_id": "home-classic-content-default" }
+            ]
+          }
         }
       },
-      "home.libraryfirst": {
+      "home.new": {
         "slots": {
-          "main": { "widgets": [] }
+          "main": {
+            "widgets": [
+              { "kind": "home.new.welcome",     "instance_id": "home-new-welcome-default" },
+              { "kind": "home.new.recent",      "instance_id": "home-new-recent-default" },
+              { "kind": "home.new.quicklaunch", "instance_id": "home-new-quicklaunch-default" }
+            ]
+          }
+        }
+      },
+      "library": {
+        "slots": {
+          "header": {
+            "widgets": [
+              { "kind": "library.header", "instance_id": "library-header-default" }
+            ]
+          },
+          "body": {
+            "widgets": [
+              { "kind": "library.body", "instance_id": "library-body-default" }
+            ]
+          }
         }
       },
       "appshell.leftrail": {
         "slots": {
-          "main": { "widgets": [] }
+          "top": {
+            "widgets": [
+              { "kind": "appshell.leftrail.navbuttons", "instance_id": "appshell-leftrail-navbuttons-default" }
+            ]
+          },
+          "bottom": {
+            "widgets": [
+              { "kind": "appshell.leftrail.consoletoggle", "instance_id": "appshell-leftrail-consoletoggle-default" },
+              { "kind": "appshell.leftrail.logout",        "instance_id": "appshell-leftrail-logout-default" }
+            ]
+          }
         }
       },
       "appshell.rightrail": {
         "slots": {
-          "main": { "widgets": [] }
+          "auth": {
+            "widgets": [
+              { "kind": "appshell.rightrail.authpanel", "instance_id": "appshell-rightrail-authpanel-default" }
+            ]
+          },
+          "news": {
+            "widgets": [
+              { "kind": "appshell.rightrail.compactnews", "instance_id": "appshell-rightrail-compactnews-default" }
+            ]
+          }
         }
       }
     }

--- a/widget-model/src/test/kotlin/hivens/widget/model/DefaultLayoutTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/DefaultLayoutTest.kt
@@ -8,26 +8,60 @@ import kotlin.test.assertTrue
 class DefaultLayoutTest {
 
     @Test
-    fun `bundled default decodes to the four kernel surfaces`() {
+    fun `bundled default decodes to the kernel-3 surface set`() {
         val graph = DefaultLayout.load()
         val surfaceIds = graph.surfaces.keys.map { it.value }.toSet()
         assertEquals(
-            setOf("home.classic", "home.libraryfirst", "appshell.leftrail", "appshell.rightrail"),
+            setOf("home.classic", "home.new", "library", "appshell.leftrail", "appshell.rightrail"),
             surfaceIds,
-            "kernel-2 default ships four named surfaces; any drift means kernel-3 forgot to keep them",
+            "kernel-3 ships five named surfaces; any drift means a refactor lost one",
         )
     }
 
     @Test
-    fun `each kernel surface has a main slot with no widgets`() {
+    fun `every surface declares at least one slot with at least one widget`() {
         val graph = DefaultLayout.load()
         graph.surfaces.forEach { (surfaceId, layout) ->
-            val main = layout.slots[SlotId("main")]
-            assertNotNull(main, "surface ${surfaceId.value} must declare a `main` slot")
             assertTrue(
-                main.widgets.isEmpty(),
-                "kernel-2 ships empty slots; widget kinds come in kernel-3",
+                layout.slots.isNotEmpty(),
+                "surface ${surfaceId.value} declares no slots; SlotRenderer would render nothing",
             )
+            layout.slots.forEach { (slotId, content) ->
+                assertTrue(
+                    content.widgets.isNotEmpty(),
+                    "slot ${surfaceId.value}.${slotId.value} is empty; kernel-3 populates every slot",
+                )
+            }
         }
+    }
+
+    @Test
+    fun `every widget instance has a non-blank kind and unique instance_id`() {
+        val graph = DefaultLayout.load()
+        val instanceIds = mutableListOf<String>()
+        graph.surfaces.values.forEach { layout ->
+            layout.slots.values.forEach { content ->
+                content.widgets.forEach { widget ->
+                    assertTrue(widget.kind.value.isNotBlank(), "blank widget kind")
+                    assertTrue(widget.instanceId.isNotBlank(), "blank instance_id on ${widget.kind.value}")
+                    instanceIds += widget.instanceId
+                }
+            }
+        }
+        val dupes = instanceIds.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        assertEquals(emptySet(), dupes, "instance_id values must be unique across the graph")
+    }
+
+    @Test
+    fun `kernel surface and slot identifiers match the documented map`() {
+        val graph = DefaultLayout.load()
+        fun slots(surface: String) = graph.surfaces[SurfaceId(surface)]?.slots?.keys?.map { it.value }?.toSet()
+            ?: emptySet()
+
+        assertEquals(setOf("main"),           slots("home.classic"))
+        assertEquals(setOf("main"),           slots("home.new"))
+        assertEquals(setOf("header", "body"), slots("library"))
+        assertEquals(setOf("top", "bottom"),  slots("appshell.leftrail"))
+        assertEquals(setOf("auth", "news"),   slots("appshell.rightrail"))
     }
 }


### PR DESCRIPTION
Third of four sub-PRs landing Phase 1 of the widget kernel. First user-visible step -- the four surface composables now render via SlotRenderer against a populated default layout graph.

## Scope

**11 widgets across 5 surfaces** (registry verified by WidgetRegistryConsistencyTest):

| Surface | Slot | Widgets |
|---|---|---|
| home.classic | main | content (monolithic) |
| home.new | main | welcome, recent, quicklaunch |
| library | header, body | header / body (with self-gating empty state) |
| appshell.leftrail | top, bottom | navbuttons / consoletoggle, logout |
| appshell.rightrail | auth, news | authpanel / compactnews |

- **home.classic.content** is intentionally monolithic. The legacy dashboard has too much shared local state for clean per-region extraction and is slated for removal once the new home matures. Widgetizing as one block exercises the slot machinery without paying refactor cost on disappearing code.
- **home.new** is the brand-new widget-composed prototype. `HomeView` gains a `New` variant; settings picker exposes it. Content stays minimal in kernel-3 -- expressive build-out arrives with user customization in later phases.
- **library.body** self-gates on `IPackRepository` population, rendering the empty-state CTA itself. Keeps the layout graph free of `appState` vocabulary.
- **Two-slot rails** (leftrail top/bottom, rightrail auth/news) avoid forcing widgets to receive `ColumnScope` for `weight(1f)`. The surface owns layout primitives (spacer, divider) between slots.

Per-surface `CompositionLocal`s carry the navigation context that cannot live in Koin -- live session and AppShell-owned navigation callbacks.

## Tests

- [x] `:widget-model:test` -- 4 DefaultLayoutTest assertions (surface set / slot population / instance_id uniqueness / documented slot map)
- [x] `:client-ui:desktopTest` -- new WidgetRegistryConsistencyTest pins kind-set equality between bundled layout and KSP-generated registry
- [x] `:client-ui:compileKotlinDesktop` green; registry contains the expected 11 widgets
- [ ] Visual smoke: `./gradlew :client-ui:run` -- verify Home (Classic / New / Library views), Library nav, sidebar (auth + unauth), right rail (login / authenticated). No pixel regression expected vs pre-PR for Classic / Library / rails. New home shows the welcome + recent (populates after first play) + quick-launch.