### PR TITLE
fix(deprecations): TabRow -> PrimaryTabRow, InsertDriveFile -> AutoMirrored

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -131,7 +131,7 @@ fun PackDetailScreen(
             )
         }
 
-        TabRow(
+        PrimaryTabRow(
             selectedTabIndex = tabIndex,
             containerColor   = Color.Transparent,
             contentColor     = CelestiaTheme.colors.textPrimary,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/FileBrowserPane.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/FileBrowserPane.kt
@@ -30,7 +30,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.InsertDriveFile
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -300,7 +300,7 @@ private fun fileIconFor(path: Path): androidx.compose.ui.graphics.vector.ImageVe
     return when {
         ext in TEXT_EXTENSIONS  -> Icons.Default.Description
         ext in IMAGE_EXTENSIONS -> Icons.Default.Image
-        else                    -> Icons.Default.InsertDriveFile
+        else                    -> Icons.AutoMirrored.Filled.InsertDriveFile
     }
 }
 


### PR DESCRIPTION
Two pre-existing Compose deprecation warnings caught by manual smoke on stable.

- \`PackDetailScreen.kt\` -- \`TabRow\` -> \`PrimaryTabRow\`. The detail-screen tab strip is primary navigation inside the surface, so PrimaryTabRow is the right pick. Signature compatible.
- \`FileBrowserPane.kt\` -- \`Icons.Default.InsertDriveFile\` -> \`Icons.AutoMirrored.Filled.InsertDriveFile\`. Launcher ships en/ru/de today (all LTR), so the rendered icon is unchanged; AutoMirrored is the correct token going forward.

## Test plan

- [x] \`:client-ui:compileKotlinDesktop\` -- no deprecation lines in output