### PR TITLE
fix(settings): coerce unknown enum values instead of wiping settings

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -68,6 +68,14 @@ val networkModule = module {
             prettyPrint = true
             isLenient = true
             encodeDefaults = true
+            // Coerce unknown enum values to the field's default instead
+            // of throwing. Without this, downgrading the launcher to a
+            // build that does not yet declare a recently-added enum
+            // variant (e.g. HomeView.New written by a newer build, read
+            // by an older one) blows up SettingsService.reload() and
+            // SilentlyResetsEverything to defaults -- the user loses
+            // every other setting because of one unknown value.
+            coerceInputValues = true
         }
     }
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/SettingsServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/SettingsServiceTest.kt
@@ -25,7 +25,16 @@ import kotlin.test.assertEquals
 class SettingsServiceTest {
 
     private lateinit var workDir: Path
-    private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+    // Mirror the production Json config (see networkModule in
+    // hivens.launcher.di.Modules). coerceInputValues is what protects
+    // against the downgrade-after-new-enum-variant scenario covered
+    // below; the test pins the behavior so a future Json refactor
+    // cannot quietly strip the flag.
+    private val json = Json {
+        encodeDefaults    = true
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
 
     @BeforeTest
     fun setup() {
@@ -54,6 +63,38 @@ class SettingsServiceTest {
         val reloaded = SettingsService(json, file)
         assertEquals(8192, reloaded.getSettings().memoryMB)
         assertEquals("de", reloaded.getSettings().locale)
+    }
+
+    @Test
+    fun `unknown enum value coerces to default and preserves other fields`() {
+        // Scenario: launcher A writes settings with a new enum variant
+        // (HomeView.Future, say); launcher B (older binary, no Future
+        // variant) reads the same file. Without coerceInputValues this
+        // crashes reload(), which then silently resets EVERY OTHER
+        // field to defaults -- the user loses java path, memory, locale,
+        // etc. because of one unknown enum string.
+        val file = workDir / "settings.json"
+        Files.writeString(
+            file,
+            """
+            {
+              "memoryMB": 8192,
+              "locale": "de",
+              "homeView": "Future"
+            }
+            """.trimIndent(),
+        )
+
+        val svc = SettingsService(json, file)
+        val loaded = svc.getSettings()
+
+        assertEquals(8192, loaded.memoryMB, "non-enum fields must survive the coercion")
+        assertEquals("de", loaded.locale, "non-enum fields must survive the coercion")
+        assertEquals(
+            SettingsData().homeView,
+            loaded.homeView,
+            "unknown enum value must coerce to the field default",
+        )
     }
 
     @Test


### PR DESCRIPTION
## The bug

Reported during kernel-3 smoke on a manually-merged build that wrote \`homeView: \"New\"\`. Running an older binary (no \`HomeView.New\` variant yet) hit:

\`\`\`
ERROR hivens.launcher.SettingsService - Failed to load settings, using defaults
kotlinx.serialization.SerializationException: hivens.core.data.HomeView does not contain element with name 'New' at path \$.homeView
\`\`\`

The crash is at the outer catch in \`reload()\`, which logs the error and falls back to a default \`SettingsData\` -- losing **every other field** (java path, memory, locale, JVM args, all toggles) because of one unknown enum string.

## The fix

\`coerceInputValues = true\` on the shared production \`Json\` instance (\`networkModule\` in \`Modules.kt\`). Unknown enum values coerce to the field default; non-enum fields untouched. Mirrored in the test \`Json\` so production behavior is what the test exercises.

New regression test on \`SettingsService\`: loading \`{memoryMB=8192, locale=\"de\", homeView=\"Future\"}\` yields \`memoryMB=8192\`, \`locale=\"de\"\`, \`homeView=Classic\` instead of a full reset.

## Why this matters beyond the kernel-3 trigger

Same scenario fires for **any** future enum extension where a user downgrades, branch-switches during development, or rolls back via the mandatory-update path. Today the launcher silently nukes their settings every time; after this PR it preserves them.

## Test plan

- [x] \`:client-launcher:test\` -- 4 tests, all green (3 existing + new \`unknown enum value coerces to default and preserves other fields\`)