### PR TITLE
feat(editor): kernel-1 -- removable flag + EditMode + FAB stub

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -44,6 +44,7 @@ import hivens.ui.screens.settings.SettingsScreen
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.ui.theme.CustomTheme
+import hivens.ui.editor.EditorSurfaceHost
 import hivens.ui.utils.GameConsoleService
 import hivens.ui.widgets.shell.LeftRailContext
 import hivens.ui.widgets.shell.LocalLeftRailContext
@@ -111,6 +112,7 @@ fun AppLayout(
 
         // ── Main content ──────────────────────────────────────────────────
         Box(Modifier.weight(1f).fillMaxHeight()) {
+          EditorSurfaceHost(currentScreen = currentScreen, homeView = homeView) {
             // Screen-to-screen Crossfade duration follows the active
             // style. Under Brut (animationMultiplier = 0) the swap is
             // effectively instant; under Celestia keeps the 180ms fade.
@@ -239,6 +241,7 @@ fun AppLayout(
                         )
                 }
             }
+          } // end EditorSurfaceHost
         }
 
         VerticalDivider(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -11,6 +11,7 @@ import hivens.ui.notifications.NotificationCenter
 import hivens.ui.notifications.SessionRegistry
 import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetServerLoader
+import hivens.ui.editor.EditModeController
 import hivens.ui.utils.GameConsoleService
 import hivens.widget.api.WidgetRegistry
 import hivens.widget.generated.GeneratedWidgetRegistry
@@ -33,6 +34,11 @@ val uiModule = module {
     // composables are added across the codebase. Kernel-1 starts the
     // registry empty -- surface refactors arrive in kernel-3.
     single<WidgetRegistry> { GeneratedWidgetRegistry }
+
+    // Editor mutation facade. Holds no state itself; fires LayoutGraph
+    // updates into the shared CoroutineScope so callers stay
+    // fire-and-forget.
+    single { EditModeController(repo = get(), scope = get()) }
 
     // Notification subsystem: data-only state holders (Center +
     // Registry) are pure singletons; PackLaunchDriver bridges them

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditMode.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditMode.kt
@@ -1,0 +1,23 @@
+package hivens.ui.editor
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import hivens.widget.model.SurfaceId
+
+// Edit mode is bound to one surface at a time -- the surface the
+// EditorSurfaceHost FAB was on when the user toggled. Off when the
+// host isn't on an editable surface or the user hasn't toggled.
+//
+// Static composition local: flips on whole-screen events (user
+// toggles, navigates away from surface), not per-frame. Matches
+// the choice for LocalLayoutGraph and LocalWidgetRegistry.
+sealed class EditModeState {
+    object Off : EditModeState()
+    data class On(
+        val surface: SurfaceId,
+        val controller: EditModeController,
+    ) : EditModeState()
+}
+
+val LocalEditMode: ProvidableCompositionLocal<EditModeState> =
+    staticCompositionLocalOf { EditModeState.Off }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -1,0 +1,56 @@
+package hivens.ui.editor
+
+import hivens.launcher.LayoutGraphRepository
+import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
+import hivens.widget.model.WidgetInstance
+import hivens.widget.model.WidgetKind
+import hivens.widget.model.insertWidget
+import hivens.widget.model.moveWidget
+import hivens.widget.model.removeWidget
+import hivens.widget.model.reorderInSlot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+// Single mutation entry point for the editor. Every operation resolves
+// to one LayoutGraphRepository.update { transform } call -- the repo
+// already handles atomic write + StateFlow re-emission, so the
+// controller is just an ergonomic facade.
+//
+// Methods fire-and-forget on the supplied scope. The repo's StateFlow
+// drives recomposition; the caller never awaits the write.
+class EditModeController(
+    private val repo: LayoutGraphRepository,
+    private val scope: CoroutineScope,
+) {
+    fun addWidget(surface: SurfaceId, slot: SlotId, kind: WidgetKind, index: Int) {
+        scope.launch {
+            val widget = WidgetInstance(kind = kind, instanceId = newInstanceId())
+            repo.update { it.insertWidget(surface, slot, widget, index) }
+        }
+    }
+
+    fun removeWidget(surface: SurfaceId, slot: SlotId, instanceId: String) {
+        scope.launch {
+            repo.update { it.removeWidget(surface, slot, instanceId) }
+        }
+    }
+
+    fun reorderInSlot(surface: SurfaceId, slot: SlotId, fromIndex: Int, toIndex: Int) {
+        scope.launch {
+            repo.update { it.reorderInSlot(surface, slot, fromIndex, toIndex) }
+        }
+    }
+
+    fun moveWidget(from: SlotAddress, to: SlotAddress, instanceId: String, toIndex: Int) {
+        scope.launch {
+            repo.update { it.moveWidget(from, to, instanceId, toIndex) }
+        }
+    }
+
+    // UUID minting on palette drop. Matches NotificationCenter.kt's
+    // UUID.randomUUID() pattern -- no kotlinx.uuid dep for one call.
+    private fun newInstanceId(): String = UUID.randomUUID().toString()
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -1,0 +1,82 @@
+package hivens.ui.editor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.core.data.HomeView
+import hivens.ui.Screen
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.SurfaceId
+import org.koin.compose.koinInject
+
+// Hosts the edit-mode FAB over the active editable surface. Resolves
+// the surface from (Screen, HomeView) and provides LocalEditMode to
+// the wrapped content. editor-1 ships the FAB + state toggle only;
+// decoration overlays + DnD land in editor-2.
+@Composable
+fun EditorSurfaceHost(
+    currentScreen: Screen,
+    homeView: HomeView,
+    content: @Composable () -> Unit,
+) {
+    val editableSurface: SurfaceId? = remember(currentScreen, homeView) {
+        editableSurfaceFor(currentScreen, homeView)
+    }
+
+    val controller: EditModeController = koinInject()
+    var editing by remember(editableSurface) { mutableStateOf(false) }
+    // Leaving a surface drops edit mode -- avoids the case where the
+    // user toggles edit on Home, navigates to Settings, returns, and
+    // sees a stale "edit" state with a target surface that no longer
+    // matches what they remembered.
+    val state: EditModeState = remember(editing, editableSurface) {
+        if (editing && editableSurface != null) EditModeState.On(editableSurface, controller)
+        else EditModeState.Off
+    }
+
+    CompositionLocalProvider(LocalEditMode provides state) {
+        Box(Modifier.fillMaxSize()) {
+            content()
+            if (editableSurface != null) {
+                FloatingActionButton(
+                    onClick           = { editing = !editing },
+                    modifier          = Modifier.align(Alignment.BottomEnd).padding(24.dp),
+                    containerColor    = if (editing) CelestiaTheme.colors.primary
+                                        else CelestiaTheme.colors.surfaceVariant,
+                ) {
+                    Icon(
+                        imageVector        = if (editing) Icons.Default.Done else Icons.Default.Edit,
+                        contentDescription = null,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Maps the active navigation target to the SurfaceId the editor should
+// bind to. Returns null on screens that aren't widget-composed (Profile,
+// Settings, etc.) so the FAB stays hidden there.
+private fun editableSurfaceFor(screen: Screen, homeView: HomeView): SurfaceId? = when (screen) {
+    Screen.Home -> when (homeView) {
+        HomeView.Classic      -> SurfaceId("home.classic")
+        HomeView.LibraryFirst -> SurfaceId("library")
+        HomeView.New          -> SurfaceId("home.new")
+    }
+    Screen.Library -> SurfaceId("library")
+    else           -> null
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailNavButtons.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailNavButtons.kt
@@ -34,7 +34,11 @@ import hivens.widget.model.WidgetInstance
 import kotlin.math.sin
 import kotlin.random.Random
 
-@Widget(id = "appshell.leftrail.navbuttons", displayName = "Sidebar nav buttons")
+@Widget(
+    id          = "appshell.leftrail.navbuttons",
+    displayName = "Sidebar nav buttons",
+    removable   = false,
+)
 @Composable
 fun LeftRailNavButtons(instance: WidgetInstance) {
     val ctx = LocalLeftRailContext.current

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailAuthPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/RightRailAuthPanel.kt
@@ -13,7 +13,11 @@ import hivens.ui.customization.glassSurfaceAlpha
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
 
-@Widget(id = "appshell.rightrail.authpanel", displayName = "Auth panel")
+@Widget(
+    id          = "appshell.rightrail.authpanel",
+    displayName = "Auth panel",
+    removable   = false,
+)
 @Composable
 fun RightRailAuthPanel(instance: WidgetInstance) {
     val ctx = LocalRightRailContext.current

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
@@ -8,6 +8,10 @@ interface WidgetDescriptor {
     val kind: WidgetKind
     val displayName: String
 
+    // false hides the remove affordance in the editor. Drives the
+    // safety check on nav rail / auth panel widgets.
+    val removable: Boolean
+
     @Composable
     fun Render(instance: WidgetInstance)
 }

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -23,3 +23,88 @@ data class LayoutGraph(val surfaces: Map<SurfaceId, SurfaceLayout> = emptyMap())
         val EMPTY: LayoutGraph = LayoutGraph()
     }
 }
+
+// (SurfaceId, SlotId) pair. Editor mutations reference slots by this
+// address; passing two value classes around at every call site is
+// noisy and prone to argument-swap mistakes.
+data class SlotAddress(val surface: SurfaceId, val slot: SlotId)
+
+// Immutable transforms on the graph. Each returns a new LayoutGraph;
+// the caller hands the result to LayoutGraphRepository.update. Unknown
+// surfaces, slots, or widgets are no-ops -- editor mutations race with
+// disk reloads, and a transform on a vanished slot must not crash.
+fun LayoutGraph.insertWidget(
+    surface: SurfaceId,
+    slot: SlotId,
+    widget: WidgetInstance,
+    index: Int,
+): LayoutGraph {
+    val layout = surfaces[surface] ?: return this
+    val content = layout.slots[slot] ?: return this
+    val coerced = index.coerceIn(0, content.widgets.size)
+    val updated = content.copy(
+        widgets = content.widgets.toMutableList().apply { add(coerced, widget) },
+    )
+    return withSlot(surface, slot, updated)
+}
+
+fun LayoutGraph.removeWidget(
+    surface: SurfaceId,
+    slot: SlotId,
+    instanceId: String,
+): LayoutGraph {
+    val layout = surfaces[surface] ?: return this
+    val content = layout.slots[slot] ?: return this
+    if (content.widgets.none { it.instanceId == instanceId }) return this
+    return withSlot(
+        surface,
+        slot,
+        content.copy(widgets = content.widgets.filterNot { it.instanceId == instanceId }),
+    )
+}
+
+fun LayoutGraph.reorderInSlot(
+    surface: SurfaceId,
+    slot: SlotId,
+    fromIndex: Int,
+    toIndex: Int,
+): LayoutGraph {
+    val layout = surfaces[surface] ?: return this
+    val content = layout.slots[slot] ?: return this
+    if (fromIndex !in content.widgets.indices) return this
+    val target = toIndex.coerceIn(0, content.widgets.size - 1)
+    if (fromIndex == target) return this
+    val reordered = content.widgets.toMutableList().apply {
+        add(target, removeAt(fromIndex))
+    }
+    return withSlot(surface, slot, content.copy(widgets = reordered))
+}
+
+fun LayoutGraph.moveWidget(
+    from: SlotAddress,
+    to: SlotAddress,
+    instanceId: String,
+    toIndex: Int,
+): LayoutGraph {
+    val fromContent = surfaces[from.surface]?.slots?.get(from.slot) ?: return this
+    val widget = fromContent.widgets.firstOrNull { it.instanceId == instanceId } ?: return this
+    if (from == to) {
+        val sourceIdx = fromContent.widgets.indexOfFirst { it.instanceId == instanceId }
+        return reorderInSlot(from.surface, from.slot, sourceIdx, toIndex)
+    }
+    if (surfaces[to.surface]?.slots?.get(to.slot) == null) return this
+    return this
+        .removeWidget(from.surface, from.slot, instanceId)
+        .insertWidget(to.surface, to.slot, widget, toIndex)
+}
+
+private fun LayoutGraph.withSlot(
+    surface: SurfaceId,
+    slot: SlotId,
+    content: SlotContent,
+): LayoutGraph {
+    val layout = surfaces[surface] ?: return this
+    val newSlots = layout.slots.toMutableMap().apply { put(slot, content) }
+    val newSurfaces = surfaces.toMutableMap().apply { put(surface, layout.copy(slots = newSlots)) }
+    return copy(surfaces = newSurfaces)
+}

--- a/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
@@ -17,4 +17,9 @@ package hivens.widget.model
 annotation class Widget(
     val id: String,
     val displayName: String = "",
+    // false hides the remove affordance on this widget in the editor.
+    // Use for widgets whose removal would brick a surface (nav rail
+    // buttons, the auth panel) -- the user can still rearrange but
+    // cannot delete. Defaults true; opt-out is explicit.
+    val removable: Boolean = true,
 )

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -1,0 +1,118 @@
+package hivens.widget.model
+
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class LayoutGraphMutationsTest {
+
+    private val home = SurfaceId("home.new")
+    private val main = SlotId("main")
+    private val w1 = WidgetInstance(WidgetKind("a"), "i1", JsonObject(emptyMap()))
+    private val w2 = WidgetInstance(WidgetKind("b"), "i2", JsonObject(emptyMap()))
+    private val w3 = WidgetInstance(WidgetKind("c"), "i3", JsonObject(emptyMap()))
+
+    private fun seed(vararg widgets: WidgetInstance): LayoutGraph = LayoutGraph(
+        surfaces = mapOf(
+            home to SurfaceLayout(slots = mapOf(main to SlotContent(widgets.toList()))),
+        ),
+    )
+
+    private fun LayoutGraph.mainWidgets(): List<WidgetInstance> =
+        surfaces[home]?.slots?.get(main)?.widgets ?: emptyList()
+
+    @Test
+    fun `insertWidget at zero pushes existing widgets back`() {
+        val out = seed(w1, w2).insertWidget(home, main, w3, 0)
+        assertEquals(listOf(w3, w1, w2), out.mainWidgets())
+    }
+
+    @Test
+    fun `insertWidget past end coerces to append`() {
+        val out = seed(w1).insertWidget(home, main, w2, 999)
+        assertEquals(listOf(w1, w2), out.mainWidgets())
+    }
+
+    @Test
+    fun `insertWidget into unknown slot is a no-op identity return`() {
+        val graph = seed(w1)
+        val out = graph.insertWidget(home, SlotId("nope"), w2, 0)
+        assertSame(graph, out, "no-op must return the same instance (no allocation)")
+    }
+
+    @Test
+    fun `removeWidget filters by instanceId`() {
+        val out = seed(w1, w2, w3).removeWidget(home, main, "i2")
+        assertEquals(listOf(w1, w3), out.mainWidgets())
+    }
+
+    @Test
+    fun `removeWidget of unknown id is identity`() {
+        val graph = seed(w1)
+        assertSame(graph, graph.removeWidget(home, main, "ghost"))
+    }
+
+    @Test
+    fun `reorderInSlot swaps positions`() {
+        val out = seed(w1, w2, w3).reorderInSlot(home, main, fromIndex = 0, toIndex = 2)
+        assertEquals(listOf(w2, w3, w1), out.mainWidgets())
+    }
+
+    @Test
+    fun `reorderInSlot with same index is identity`() {
+        val graph = seed(w1, w2)
+        assertSame(graph, graph.reorderInSlot(home, main, fromIndex = 0, toIndex = 0))
+    }
+
+    @Test
+    fun `reorderInSlot out-of-range fromIndex is identity`() {
+        val graph = seed(w1, w2)
+        assertSame(graph, graph.reorderInSlot(home, main, fromIndex = 5, toIndex = 0))
+    }
+
+    @Test
+    fun `moveWidget across slots removes from source and inserts at target`() {
+        val twoSlots = LayoutGraph(
+            surfaces = mapOf(
+                home to SurfaceLayout(slots = mapOf(
+                    SlotId("top")    to SlotContent(listOf(w1, w2)),
+                    SlotId("bottom") to SlotContent(listOf(w3)),
+                )),
+            ),
+        )
+        val out = twoSlots.moveWidget(
+            from       = SlotAddress(home, SlotId("top")),
+            to         = SlotAddress(home, SlotId("bottom")),
+            instanceId = "i1",
+            toIndex    = 0,
+        )
+        val top    = out.surfaces[home]!!.slots[SlotId("top")]!!.widgets
+        val bottom = out.surfaces[home]!!.slots[SlotId("bottom")]!!.widgets
+        assertEquals(listOf(w2),     top)
+        assertEquals(listOf(w1, w3), bottom)
+    }
+
+    @Test
+    fun `moveWidget within same slot delegates to reorderInSlot`() {
+        val out = seed(w1, w2, w3).moveWidget(
+            from       = SlotAddress(home, main),
+            to         = SlotAddress(home, main),
+            instanceId = "i3",
+            toIndex    = 0,
+        )
+        assertEquals(listOf(w3, w1, w2), out.mainWidgets())
+    }
+
+    @Test
+    fun `moveWidget of unknown instanceId is identity`() {
+        val graph = seed(w1)
+        val out = graph.moveWidget(
+            from       = SlotAddress(home, main),
+            to         = SlotAddress(home, main),
+            instanceId = "ghost",
+            toIndex    = 0,
+        )
+        assertSame(graph, out)
+    }
+}

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
@@ -103,6 +103,7 @@ class WidgetRegistryProcessor(
         val args = widgetAnnotation.arguments.associate { it.name?.asString() to it.value }
         val id = (args["id"] as? String).orEmpty()
         val displayName = (args["displayName"] as? String).orEmpty()
+        val removable = (args["removable"] as? Boolean) ?: true
         if (id.isBlank()) {
             env.logger.error("@Widget id must be non-blank", symbol)
             return null
@@ -113,6 +114,7 @@ class WidgetRegistryProcessor(
         return WidgetEntry(
             id = id,
             displayName = displayName.ifBlank { funcName },
+            removable = removable,
             functionFqn = if (packageName.isEmpty()) funcName else "$packageName.$funcName",
             containingFile = symbol.containingFile,
         )
@@ -154,6 +156,7 @@ class WidgetRegistryProcessor(
             appendLine("        put($kindLiteral, object : WidgetDescriptor {")
             appendLine("            override val kind: WidgetKind = $kindLiteral")
             appendLine("            override val displayName: String = \"${entry.displayName.kotlinEscape()}\"")
+            appendLine("            override val removable: Boolean = ${entry.removable}")
             appendLine("            @Composable override fun Render(instance: WidgetInstance) {")
             appendLine("                ${entry.functionFqn}(instance)")
             appendLine("            }")
@@ -173,6 +176,7 @@ class WidgetRegistryProcessor(
 private data class WidgetEntry(
     val id: String,
     val displayName: String,
+    val removable: Boolean,
     val functionFqn: String,
     val containingFile: com.google.devtools.ksp.symbol.KSFile?,
 )


### PR DESCRIPTION
First sub-PR of Phase 2 (project_ui_editor_arch). The cross-module annotation extension + mutation facade + floating toggle. No DnD, no decoration, no palette -- those arrive in editor-2/3.

## Surfaces of change

- **\`@Widget\`** gains \`removable: Boolean = true\`. Opt out explicit. \`LeftRailNavButtons\` + \`RightRailAuthPanel\` mark \`removable = false\` so the editor cannot delete them and brick the launcher. KSP processor parses + emits on \`WidgetDescriptor\`.
- **\`:widget-model\`** gains \`SlotAddress\` + four immutable transforms (\`insertWidget\`, \`removeWidget\`, \`reorderInSlot\`, \`moveWidget\`). 11 unit tests pin: insert at zero pushes back; insert past end appends; insert into unknown slot is identity; remove of unknown id is identity; reorder same-index is identity; out-of-range reorder is identity; move across slots; move within same slot delegates to reorder; move of unknown id is identity.
- **\`client-ui/.../editor/\`** new package: \`EditMode\` (CompositionLocal + sealed state), \`EditModeController\` (mutation facade, fires through shared scope, mints UUIDs on add), \`EditorSurfaceHost\` (FAB + Screen->SurfaceId resolver).
- **\`AppLayout\`** wraps the main-content Crossfade in \`EditorSurfaceHost\`. FAB appears on Home (Classic/LibraryFirst/New) and Library; hidden on Settings/Profile/etc.
- **\`Main.kt\`** Koin registers \`EditModeController\` in \`uiModule\`.

## Test plan

- [x] \`:widget-model:test\` -- 15 tests (4 DefaultLayout + 11 LayoutGraphMutations) all green
- [x] \`:client-launcher:test\` -- 10 green
- [x] \`:client-ui:desktopTest\` -- existing WidgetRegistryConsistencyTest green; KSP-generated registry shows \`override val removable: Boolean = false\` exactly on \`appshell.leftrail.navbuttons\` and \`appshell.rightrail.authpanel\`
- [ ] Smoke: \`./gradlew :client-ui:run\` -- FAB appears bottom-right on Home (any HomeView) and Library; absent on Settings/Profile; clicking flips the icon (edit/done). No decoration yet (editor-2).