### PR TITLE
feat(editor): editor-2 -- DnD + decoration + sample widgets

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -1,32 +1,96 @@
 package hivens.ui.editor
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import hivens.core.data.HomeView
 import hivens.ui.Screen
+import hivens.ui.editor.decoration.EditableWidgetChrome
+import hivens.ui.editor.dnd.DragController
+import hivens.ui.editor.dnd.DragPayload
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.editor.dnd.LocalDragController
+import hivens.ui.editor.dnd.LocalDropTargetRegistry
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.theme.LocalStyle
+import hivens.widget.api.LocalWidgetDecorator
+import hivens.widget.api.WidgetDecorator
 import hivens.widget.model.SurfaceId
+import kotlinx.coroutines.CoroutineScope
 import org.koin.compose.koinInject
 
-// Hosts the edit-mode FAB over the active editable surface. Resolves
-// the surface from (Screen, HomeView) and provides LocalEditMode to
-// the wrapped content. editor-1 ships the FAB + state toggle only;
-// decoration overlays + DnD land in editor-2.
+// EditorSurfaceHost is the single coordinator for everything edit-mode
+// related on the active surface. It:
+//   * resolves which SurfaceId the active Screen/HomeView maps to
+//   * holds DragController + DropTargetRegistry per surface
+//   * provides LocalEditMode, LocalDragController, LocalDropTargetRegistry,
+//     and LocalWidgetDecorator (the decorator wraps each widget with
+//     chrome only while edit mode is on)
+//   * paints the FAB (edit/done morph)
+//   * paints the optional "Edit layout" pill at the top
+//   * paints the drag ghost following the pointer when a drag is active
+//   * consumes Escape to exit edit mode
+//
+// editor-3 will add palette panel + cross-slot drop. editor-2 keeps
+// drags within the source slot.
 @Composable
 fun EditorSurfaceHost(
     currentScreen: Screen,
@@ -36,41 +100,296 @@ fun EditorSurfaceHost(
     val editableSurface: SurfaceId? = remember(currentScreen, homeView) {
         editableSurfaceFor(currentScreen, homeView)
     }
-
     val controller: EditModeController = koinInject()
+
     var editing by remember(editableSurface) { mutableStateOf(false) }
-    // Leaving a surface drops edit mode -- avoids the case where the
-    // user toggles edit on Home, navigates to Settings, returns, and
-    // sees a stale "edit" state with a target surface that no longer
-    // matches what they remembered.
+    // Leaving a surface drops edit mode -- avoids a stale edit state
+    // pointed at the wrong surface after navigation.
     val state: EditModeState = remember(editing, editableSurface) {
-        if (editing && editableSurface != null) EditModeState.On(editableSurface, controller)
-        else EditModeState.Off
+        if (editing && editableSurface != null) {
+            EditModeState.On(editableSurface, controller)
+        } else {
+            EditModeState.Off
+        }
     }
 
-    CompositionLocalProvider(LocalEditMode provides state) {
-        Box(Modifier.fillMaxSize()) {
+    val dragController = remember { DragController() }
+    val registry       = remember { DropTargetRegistry() }
+    val focusManager   = LocalFocusManager.current
+    val density        = LocalDensity.current
+
+    // Chrome decorator: identity when off, full chrome when on. The
+    // local is provided regardless so SlotRenderer always finds it;
+    // identity is zero-cost.
+    val chromeDecorator: WidgetDecorator = remember(state) {
+        if (state is EditModeState.On) {
+            { address, index, descriptor, instance, content ->
+                EditableWidgetChrome(
+                    address      = address,
+                    index        = index,
+                    descriptor   = descriptor,
+                    instance     = instance,
+                    controller   = dragController,
+                    registry     = registry,
+                    onRemove     = {
+                        controller.removeWidget(address.surface, address.slot, instance.instanceId)
+                    },
+                    onCommitDrop = { committedPointer ->
+                        // Compute insertion index from registered widget
+                        // bounds; only commit if it actually moved.
+                        val targetIdx = registry.insertionIndexInSlot(address, committedPointer)
+                        // The registry counts the dragged widget too,
+                        // so a no-op drop returns the source index --
+                        // reorderInSlot will detect equality and short-
+                        // circuit, no extra guard needed here.
+                        if (targetIdx != index) {
+                            controller.reorderInSlot(
+                                surface   = address.surface,
+                                slot      = address.slot,
+                                fromIndex = index,
+                                toIndex   = if (targetIdx > index) targetIdx - 1 else targetIdx,
+                            )
+                        }
+                    },
+                    content      = content,
+                )
+            }
+        } else {
+            { _, _, _, _, content -> content() }
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalEditMode           provides state,
+        LocalDragController     provides dragController,
+        LocalDropTargetRegistry provides registry,
+        LocalWidgetDecorator    provides chromeDecorator,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .onKeyEvent { ev ->
+                    if (editing && ev.type == KeyEventType.KeyUp && ev.key == Key.Escape) {
+                        editing = false
+                        true
+                    } else false
+                },
+        ) {
+            // Subtle surface vignette while in edit mode -- a soft inner
+            // primary tint at very low alpha to communicate "this whole
+            // pane is being edited", without obscuring content.
             content()
+            EditModeVignette(active = editing)
+
+            // Drag ghost overlay -- positioned in window coords relative
+            // to the host's own Box. Renders nothing when no drag is
+            // active.
+            DragGhostOverlay(dragController = dragController)
+
             if (editableSurface != null) {
-                FloatingActionButton(
-                    onClick           = { editing = !editing },
-                    modifier          = Modifier.align(Alignment.BottomEnd).padding(24.dp),
-                    containerColor    = if (editing) CelestiaTheme.colors.primary
-                                        else CelestiaTheme.colors.surfaceVariant,
+                EditModePill(
+                    active   = editing,
+                    surface  = editableSurface,
+                    modifier = Modifier.align(Alignment.TopCenter).padding(top = 16.dp),
+                )
+
+                EditModeFab(
+                    editing  = editing,
+                    onToggle = { editing = !editing },
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(24.dp),
+                )
+            }
+        }
+    }
+}
+
+// ── FAB ─────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EditModeFab(
+    editing: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val style = LocalStyle.current
+    val scale by animateFloatAsState(
+        targetValue   = if (editing) 1.08f else 1f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "fab-scale",
+    )
+    val container = if (editing) CelestiaTheme.colors.primary
+                    else CelestiaTheme.colors.surfaceVariant
+    val content   = if (editing) Color.White
+                    else CelestiaTheme.colors.textPrimary
+
+    // Subtle pulse glow while in edit mode -- communicates "live state"
+    // without being noisy. Brut zeroes out animationMultiplier, so the
+    // pulse goes flat there.
+    val pulseTransition = rememberInfiniteTransition(label = "fab-pulse")
+    val pulse by pulseTransition.animateFloat(
+        initialValue  = 0f,
+        targetValue   = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = style.animationDurationMs(1800),
+                easing         = LinearEasing,
+            ),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "fab-pulse-value",
+    )
+    val pulseAlpha = if (editing) 0.18f + pulse * 0.18f else 0f
+
+    Box(modifier = modifier) {
+        // Glow halo
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .graphicsLayer { scaleX = 1.45f; scaleY = 1.45f; alpha = pulseAlpha }
+                .background(CelestiaTheme.colors.primary, shape = RoundedCornerShape(24.dp)),
+        )
+        FloatingActionButton(
+            onClick        = onToggle,
+            modifier       = Modifier
+                .graphicsLayer { scaleX = scale; scaleY = scale }
+                .shadow(elevation = 8.dp, shape = RoundedCornerShape(16.dp)),
+            containerColor = container,
+            contentColor   = content,
+            shape          = RoundedCornerShape(16.dp),
+        ) {
+            // Crossfade icons between Edit and Check so the morph is
+            // smooth rather than a hard swap.
+            Box(contentAlignment = Alignment.Center) {
+                AnimatedVisibility(
+                    visible = !editing,
+                    enter   = fadeIn(spring()),
+                    exit    = fadeOut(spring()),
                 ) {
-                    Icon(
-                        imageVector        = if (editing) Icons.Default.Done else Icons.Default.Edit,
-                        contentDescription = null,
-                    )
+                    Icon(Icons.Default.Edit, contentDescription = "Edit layout")
+                }
+                AnimatedVisibility(
+                    visible = editing,
+                    enter   = fadeIn(spring()),
+                    exit    = fadeOut(spring()),
+                ) {
+                    Icon(Icons.Default.Check, contentDescription = "Done editing")
                 }
             }
         }
     }
 }
 
-// Maps the active navigation target to the SurfaceId the editor should
-// bind to. Returns null on screens that aren't widget-composed (Profile,
-// Settings, etc.) so the FAB stays hidden there.
+// ── Top pill ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EditModePill(
+    active: Boolean,
+    surface: SurfaceId,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible  = active,
+        enter    = fadeIn(spring()) + slideInVertically(spring()) { -it },
+        exit     = fadeOut(spring()) + slideOutVertically(spring()) { -it },
+        modifier = modifier,
+    ) {
+        Surface(
+            color   = CelestiaTheme.colors.surface.copy(alpha = 0.92f),
+            shape   = RoundedCornerShape(20.dp),
+            shadowElevation = 6.dp,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            ) {
+                Icon(
+                    imageVector        = Icons.Default.Tune,
+                    contentDescription = null,
+                    tint               = CelestiaTheme.colors.primary,
+                    modifier           = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text       = "Редактирование: ${humanSurfaceName(surface)}",
+                    style      = MaterialTheme.typography.labelMedium,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text  = "Esc — выйти",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+        }
+    }
+}
+
+private fun humanSurfaceName(surface: SurfaceId): String = when (surface.value) {
+    "home.classic"        -> "Главная (классика)"
+    "home.new"            -> "Главная (новая)"
+    "library"             -> "Library"
+    "appshell.leftrail"   -> "Боковая панель"
+    "appshell.rightrail"  -> "Правая панель"
+    else                  -> surface.value
+}
+
+// ── Vignette ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun EditModeVignette(active: Boolean) {
+    val alpha by animateFloatAsState(
+        targetValue   = if (active) 1f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label         = "edit-vignette",
+    )
+    if (alpha <= 0.01f) return
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(alpha)
+            .border(
+                width = 1.5.dp,
+                color = CelestiaTheme.colors.primary.copy(alpha = 0.35f),
+                shape = RoundedCornerShape(0.dp),
+            ),
+    )
+}
+
+// ── Drag ghost ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun DragGhostOverlay(dragController: DragController) {
+    val active = dragController.active ?: return
+    val density = LocalDensity.current
+    // pointerInWindow + pickupOffset is the widget-origin in window
+    // coords; the ghost should sit there. We render through graphicsLayer
+    // to avoid layout invalidation when the offset changes.
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+    ) {
+        Box(
+            modifier = Modifier
+                .graphicsLayer {
+                    val x = (active.pointerInWindow.x - active.pickupOffset.x)
+                    val y = (active.pointerInWindow.y - active.pickupOffset.y)
+                    translationX = x
+                    translationY = y
+                    alpha        = 0.78f
+                    scaleX       = 1.04f
+                    scaleY       = 1.04f
+                }
+                .shadow(elevation = 14.dp, shape = RoundedCornerShape(10.dp)),
+        ) {
+            active.ghost()
+        }
+    }
+}
+
+// ── Surface routing ─────────────────────────────────────────────────────────
+
 private fun editableSurfaceFor(screen: Screen, homeView: HomeView): SurfaceId? = when (screen) {
     Screen.Home -> when (homeView) {
         HomeView.Classic      -> SurfaceId("home.classic")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,6 +75,15 @@ fun EditableWidgetChrome(
     val isThisDragging = (activeDrag?.payload as? DragPayload.ExistingWidget)
         ?.instance?.instanceId == instance.instanceId
 
+    // The ghost lambda is invoked by DragGhostOverlay at the host
+    // level -- outside the surface composable's CompositionLocalProvider
+    // chain. Widgets like HomeNewRecent read surface-scoped locals
+    // (LocalHomeNewContext, LocalLibraryContext, ...) and would throw
+    // when the ghost recomposes them. Snapshot the locals here and
+    // restore them inside the ghost so the widget renders identically
+    // wherever it lands.
+    val capturedLocals = currentCompositionLocalContext
+
     // Source widget fades to 30% while being dragged -- the ghost is
     // doing the work on top. Once drag ends, we ramp back smoothly.
     val sourceAlpha by animateFloatAsState(
@@ -118,7 +129,9 @@ fun EditableWidgetChrome(
                     controller            = controller,
                     payload               = DragPayload.ExistingWidget(address, index, instance),
                     widgetBoundsProvider  = { widgetWindowBounds },
-                    ghost                 = { content() },
+                    ghost                 = {
+                        CompositionLocalProvider(capturedLocals) { content() }
+                    },
                     onDragEnd             = onCommitDrop,
                 ),
         ) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -1,0 +1,167 @@
+package hivens.ui.editor.decoration
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.dp
+import hivens.ui.editor.dnd.DragController
+import hivens.ui.editor.dnd.DragPayload
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.editor.dnd.dragSource
+import hivens.ui.editor.dnd.widgetBounds
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.WidgetDescriptor
+import hivens.widget.model.SlotAddress
+import hivens.widget.model.WidgetInstance
+
+// Wraps a single widget with edit-mode chrome: drag handle (always
+// visible, opacity boosts on hover), remove button (hover-only, hidden
+// when descriptor says non-removable), faint border outline.
+//
+// The whole wrapper is also a drop-target bounds-reporter for its own
+// rect -- the registry uses this to compute insertion-index hit-tests
+// during a drag.
+@Composable
+fun EditableWidgetChrome(
+    address: SlotAddress,
+    index: Int,
+    descriptor: WidgetDescriptor,
+    instance: WidgetInstance,
+    controller: DragController,
+    registry: DropTargetRegistry,
+    onRemove: () -> Unit,
+    onCommitDrop: (committedPointer: androidx.compose.ui.geometry.Offset) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    var widgetWindowBounds by remember { mutableStateOf<Rect?>(null) }
+    val activeDrag = controller.active
+    val isThisDragging = (activeDrag?.payload as? DragPayload.ExistingWidget)
+        ?.instance?.instanceId == instance.instanceId
+
+    // Source widget fades to 30% while being dragged -- the ghost is
+    // doing the work on top. Once drag ends, we ramp back smoothly.
+    val sourceAlpha by animateFloatAsState(
+        targetValue   = if (isThisDragging) 0.30f else 1f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "edit-source-alpha",
+    )
+    val borderAlpha by animateFloatAsState(
+        targetValue   = if (isHovered) 0.55f else 0.18f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "edit-border-alpha",
+    )
+
+    Box(
+        modifier = Modifier
+            .hoverable(interaction)
+            .onGloballyPositioned { coords: LayoutCoordinates ->
+                val rect = coords.boundsInWindow()
+                widgetWindowBounds = rect
+                registry.registerWidget(address, instance.instanceId, index, rect)
+            }
+            .widgetBounds(registry, address, instance.instanceId, index)
+            .padding(2.dp)
+            .border(
+                width = 1.dp,
+                color = CelestiaTheme.colors.primary.copy(alpha = borderAlpha),
+                shape = RoundedCornerShape(8.dp),
+            ),
+    ) {
+        Box(Modifier.alpha(sourceAlpha)) { content() }
+
+        // Drag handle: always visible (so the user discovers it),
+        // brightens on hover. Attached pointerInput drives the drag.
+        Surface(
+            color    = CelestiaTheme.colors.surface.copy(alpha = if (isHovered) 0.95f else 0.65f),
+            shape    = RoundedCornerShape(6.dp),
+            shadowElevation = 0.dp,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(4.dp)
+                .size(22.dp)
+                .dragSource(
+                    controller            = controller,
+                    payload               = DragPayload.ExistingWidget(address, index, instance),
+                    widgetBoundsProvider  = { widgetWindowBounds },
+                    ghost                 = { content() },
+                    onDragEnd             = onCommitDrop,
+                ),
+        ) {
+            Icon(
+                imageVector        = Icons.Default.DragIndicator,
+                contentDescription = "Drag to reorder",
+                tint               = CelestiaTheme.colors.textSecondary,
+                modifier           = Modifier.size(16.dp).padding(0.dp),
+            )
+        }
+
+        // Remove button: hover-only, hidden on non-removable widgets.
+        // Animated fade so it does not pop in jarringly.
+        AnimatedVisibility(
+            visible  = isHovered && descriptor.removable,
+            enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
+            exit     = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
+            modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
+        ) {
+            Surface(
+                color    = CelestiaTheme.colors.error.copy(alpha = 0.85f),
+                shape    = RoundedCornerShape(6.dp),
+                modifier = Modifier
+                    .size(22.dp)
+                    .pointerInput(instance.instanceId) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.type == PointerEventType.Release) {
+                                    onRemove()
+                                    event.changes.forEach { it.consume() }
+                                }
+                            }
+                        }
+                    },
+            ) {
+                Icon(
+                    imageVector        = Icons.Default.Close,
+                    contentDescription = "Remove widget",
+                    tint               = Color.White,
+                    modifier           = Modifier.size(14.dp).padding(0.dp).graphicsLayer { },
+                )
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -1,0 +1,201 @@
+package hivens.ui.editor.dnd
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import hivens.widget.model.SlotAddress
+import hivens.widget.model.WidgetInstance
+import hivens.widget.model.WidgetKind
+
+// ── Drag payload + active state ─────────────────────────────────────────────
+
+sealed class DragPayload {
+    data class ExistingWidget(
+        val source: SlotAddress,
+        val sourceIndex: Int,
+        val instance: WidgetInstance,
+    ) : DragPayload()
+
+    // Palette drag arrives in editor-3. ExistingWidget covers editor-2.
+    data class PaletteWidget(val kind: WidgetKind) : DragPayload()
+}
+
+data class ActiveDrag(
+    val payload: DragPayload,
+    val pointerInWindow: Offset,
+    val pickupOffset: Offset,
+    val widgetSize: Offset,
+    val ghost: @Composable () -> Unit,
+)
+
+// ── Drag controller ─────────────────────────────────────────────────────────
+
+class DragController {
+    private val _active = mutableStateOf<ActiveDrag?>(null)
+    val active: ActiveDrag? get() = _active.value
+    val isDragging: Boolean get() = _active.value != null
+
+    fun begin(
+        payload: DragPayload,
+        pointerInWindow: Offset,
+        pickupOffset: Offset,
+        widgetSize: Offset,
+        ghost: @Composable () -> Unit,
+    ) {
+        _active.value = ActiveDrag(
+            payload         = payload,
+            pointerInWindow = pointerInWindow,
+            pickupOffset    = pickupOffset,
+            widgetSize      = widgetSize,
+            ghost           = ghost,
+        )
+    }
+
+    fun update(pointerInWindow: Offset) {
+        _active.value = _active.value?.copy(pointerInWindow = pointerInWindow)
+    }
+
+    fun end(): DragPayload? {
+        val payload = _active.value?.payload
+        _active.value = null
+        return payload
+    }
+}
+
+// ── Drop target registry ────────────────────────────────────────────────────
+
+// Per-widget bounds in window coords. Keyed by SlotAddress then by
+// position-in-slot (matches LayoutGraph ordering). Empty slots are
+// registered with an empty rect list so the registry knows the slot
+// exists but has no widgets to hit-test against.
+data class WidgetBounds(val index: Int, val rect: Rect)
+
+class DropTargetRegistry {
+    private val widgets: SnapshotStateMap<SlotAddress, SnapshotStateMap<String, WidgetBounds>> =
+        mutableStateMapOf()
+    private val slotBounds: SnapshotStateMap<SlotAddress, Rect> = mutableStateMapOf()
+
+    fun registerSlot(slot: SlotAddress, rect: Rect) {
+        slotBounds[slot] = rect
+    }
+
+    fun unregisterSlot(slot: SlotAddress) {
+        slotBounds.remove(slot)
+        widgets.remove(slot)
+    }
+
+    fun registerWidget(slot: SlotAddress, instanceId: String, index: Int, rect: Rect) {
+        val byId = widgets.getOrPut(slot) { mutableStateMapOf() }
+        byId[instanceId] = WidgetBounds(index, rect)
+    }
+
+    fun unregisterWidget(slot: SlotAddress, instanceId: String) {
+        widgets[slot]?.remove(instanceId)
+    }
+
+    // Insertion index for a pointer inside a known slot. Index is in
+    // [0, count] -- count means "append at end". Algorithm: find the
+    // widget whose vertical midpoint the pointer is above; insert at
+    // that widget's position. If pointer is below all widgets, append.
+    fun insertionIndexInSlot(slot: SlotAddress, pointInWindow: Offset): Int {
+        val items = widgets[slot]?.values?.sortedBy { it.index } ?: return 0
+        if (items.isEmpty()) return 0
+        items.forEach { wb ->
+            val midY = wb.rect.top + wb.rect.height / 2f
+            if (pointInWindow.y < midY) return wb.index
+        }
+        return items.size
+    }
+
+    // Editor-3 will add: slotForPoint(point): SlotAddress? for cross-
+    // slot drag. Editor-2 keeps drags within the source slot only.
+}
+
+// ── Composition locals ─────────────────────────────────────────────────────
+
+val LocalDragController: ProvidableCompositionLocal<DragController> =
+    staticCompositionLocalOf { error("LocalDragController not provided -- mount EditorSurfaceHost") }
+
+val LocalDropTargetRegistry: ProvidableCompositionLocal<DropTargetRegistry> =
+    staticCompositionLocalOf { error("LocalDropTargetRegistry not provided -- mount EditorSurfaceHost") }
+
+// ── Drag-source modifier ────────────────────────────────────────────────────
+
+// Attach to the drag handle, not the whole widget -- prevents accidental
+// drag of an interactive control (button, slider). The lambda
+// `widgetBoundsProvider` returns the widget's window-coord bounds so the
+// ghost can position itself at the right pickup offset.
+fun Modifier.dragSource(
+    controller: DragController,
+    payload: DragPayload,
+    widgetBoundsProvider: () -> Rect?,
+    ghost: @Composable () -> Unit,
+    onDragEnd: (committedPointer: Offset) -> Unit,
+): Modifier = this.pointerInput(payload) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        val drag = awaitTouchSlopOrCancellation(down.id) { change, _ -> change.consume() }
+            ?: return@awaitEachGesture
+        val bounds = widgetBoundsProvider() ?: return@awaitEachGesture
+        val pickup = drag.position - Offset(0f, 0f)  // pointer offset within source
+        controller.begin(
+            payload         = payload,
+            pointerInWindow = bounds.topLeft + drag.position,
+            pickupOffset    = pickup,
+            widgetSize      = Offset(bounds.width, bounds.height),
+            ghost           = ghost,
+        )
+        var lastPointer = bounds.topLeft + drag.position
+        drag(drag.id) { change: PointerInputChange ->
+            val widgetBounds = widgetBoundsProvider()
+            if (widgetBounds != null) {
+                lastPointer = widgetBounds.topLeft + change.position
+                controller.update(lastPointer)
+            }
+            change.consume()
+        }
+        onDragEnd(lastPointer)
+        controller.end()
+    }
+}
+
+// ── Drop-target modifier ────────────────────────────────────────────────────
+
+// Registers the slot's bounds with the registry. Per-widget bounds are
+// registered separately by EditableWidgetChrome via widgetBounds().
+fun Modifier.slotBounds(
+    registry: DropTargetRegistry,
+    slot: SlotAddress,
+): Modifier = this.onGloballyPositioned { coords: LayoutCoordinates ->
+    registry.registerSlot(slot, coords.boundsInWindow())
+}
+
+fun Modifier.widgetBounds(
+    registry: DropTargetRegistry,
+    slot: SlotAddress,
+    instanceId: String,
+    index: Int,
+): Modifier = this.onGloballyPositioned { coords: LayoutCoordinates ->
+    registry.registerWidget(slot, instanceId, index, coords.boundsInWindow())
+}
+
+// derivedStateOf import suppression -- present for future shape stability
+@Suppress("unused") private fun touchDerivedStateOf() = derivedStateOf { 0 }
+@Suppress("unused") private fun touchSnapshot() = Snapshot.current

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
@@ -1,0 +1,189 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import kotlinx.coroutines.delay
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+// Analog clock with smooth-sweeping seconds. Theme-aware: dial reads
+// surface, hands read textPrimary, accent ring reads primary. Per-
+// second tick recomposes only the Canvas + the digital time line; the
+// surrounding card stays still.
+@Widget(id = "home.new.clock", displayName = "Clock")
+@Composable
+fun ClockWidget(instance: WidgetInstance) {
+    var now by remember { mutableStateOf(LocalDateTime.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = LocalDateTime.now()
+            // 1Hz tick is enough; the second hand interpolates smoothly
+            // in the canvas using milliseconds-of-second so we do not
+            // need 60Hz recomposition.
+            delay(500L)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.45f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text       = "Часы",
+            style      = MaterialTheme.typography.labelLarge,
+            color      = CelestiaTheme.colors.textSecondary,
+            fontWeight = FontWeight.Medium,
+            modifier   = Modifier.align(Alignment.Start),
+        )
+        Spacer(Modifier.height(10.dp))
+
+        ClockFace(
+            time     = now,
+            modifier = Modifier.size(140.dp),
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Text(
+            text       = TIME_FORMATTER.format(now),
+            style      = MaterialTheme.typography.titleLarge,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.Light,
+        )
+        Text(
+            text  = DATE_FORMATTER.format(now),
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+}
+
+@Composable
+private fun ClockFace(time: LocalDateTime, modifier: Modifier = Modifier) {
+    val dialColor   = CelestiaTheme.colors.surface
+    val rimColor    = CelestiaTheme.colors.outline.copy(alpha = 0.50f)
+    val markerColor = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f)
+    val hourColor   = CelestiaTheme.colors.textPrimary
+    val minuteColor = CelestiaTheme.colors.textPrimary
+    val secondColor = CelestiaTheme.colors.primary
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(dialColor, dialColor.copy(alpha = 0.85f)),
+                ),
+            ),
+    ) {
+        Canvas(modifier = Modifier.fillMaxWidth().padding(0.dp).align(Alignment.Center).size(140.dp)) {
+            val radius = min(size.width, size.height) / 2f
+            val center = Offset(size.width / 2f, size.height / 2f)
+
+            // Rim
+            drawCircle(color = rimColor, radius = radius - 1f, center = center, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2f))
+
+            // Hour markers: long at 12/3/6/9, short elsewhere
+            for (i in 0 until 12) {
+                val angle = i * 30.0
+                val isMajor = i % 3 == 0
+                val outer = radius - 6f
+                val inner = if (isMajor) radius - 18f else radius - 12f
+                val rad = Math.toRadians(angle - 90)
+                val sx = center.x + cos(rad).toFloat() * outer
+                val sy = center.y + sin(rad).toFloat() * outer
+                val ex = center.x + cos(rad).toFloat() * inner
+                val ey = center.y + sin(rad).toFloat() * inner
+                drawLine(
+                    color       = markerColor,
+                    start       = Offset(sx, sy),
+                    end         = Offset(ex, ey),
+                    strokeWidth = if (isMajor) 2.5f else 1.5f,
+                    cap         = StrokeCap.Round,
+                )
+            }
+
+            val hour   = (time.hour % 12) + time.minute / 60f
+            val minute = time.minute + time.second / 60f
+            val second = time.second + time.nano / 1_000_000_000f
+
+            // Hour hand
+            rotate(degrees = hour * 30f - 90f, pivot = center) {
+                drawLine(
+                    color       = hourColor,
+                    start       = center,
+                    end         = Offset(center.x + radius * 0.50f, center.y),
+                    strokeWidth = 5f,
+                    cap         = StrokeCap.Round,
+                )
+            }
+            // Minute hand
+            rotate(degrees = minute * 6f - 90f, pivot = center) {
+                drawLine(
+                    color       = minuteColor,
+                    start       = center,
+                    end         = Offset(center.x + radius * 0.72f, center.y),
+                    strokeWidth = 3.5f,
+                    cap         = StrokeCap.Round,
+                )
+            }
+            // Second hand (counter-weighted)
+            rotate(degrees = second * 6f - 90f, pivot = center) {
+                drawLine(
+                    color       = secondColor,
+                    start       = Offset(center.x - radius * 0.12f, center.y),
+                    end         = Offset(center.x + radius * 0.82f, center.y),
+                    strokeWidth = 1.5f,
+                    cap         = StrokeCap.Round,
+                )
+            }
+
+            // Hub
+            drawCircle(color = secondColor, radius = 4.5f, center = center)
+            drawCircle(color = dialColor,   radius = 2.0f, center = center)
+        }
+    }
+}
+
+private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, d MMM")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/LaunchButtonWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/LaunchButtonWidget.kt
@@ -1,0 +1,128 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
+import hivens.launcher.launch.LaunchState
+import hivens.launcher.launch.LauncherController
+import hivens.ui.AppState
+import hivens.ui.notifications.drivers.PackLaunchDriver
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.utils.GameConsoleService
+import hivens.ui.widgets.home.new.LocalHomeNewContext
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+// Big "Continue last" launch tile. Decoupled from the QuickLaunch
+// card -- this one is a single full-width tap target with a gradient
+// background, no surrounding labels or metadata. Designed to feel
+// like a console "press to play" affordance.
+@Widget(id = "home.new.launchbutton", displayName = "Launch button")
+@Composable
+fun LaunchButtonWidget(instance: WidgetInstance) {
+    val ctx = LocalHomeNewContext.current
+    val repo: IPackRepository = koinInject()
+    val controller: LauncherController = koinInject()
+    val launchDriver: PackLaunchDriver = koinInject()
+    val gameConsole: GameConsoleService = koinInject()
+    val all by remember { repo.observe() }.collectAsState(initial = emptyList())
+    val launchState by controller.state.collectAsState()
+
+    val target: PackInstance = remember(all) {
+        all.maxByOrNull { it.lastPlayedEpochOrZero }
+            ?: all.maxByOrNull { it.createdAtEpoch }
+    } ?: return
+
+    val session = (ctx.appState as? AppState.Authenticated)?.session
+    val ready = session != null &&
+        (launchState is LaunchState.Idle || launchState is LaunchState.Error)
+
+    val gradient = Brush.linearGradient(
+        colors = listOf(
+            CelestiaTheme.colors.primary,
+            CelestiaTheme.colors.primary.copy(alpha = 0.78f),
+        ),
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(if (ready) gradient else Brush.linearGradient(listOf(
+                CelestiaTheme.colors.surfaceVariant,
+                CelestiaTheme.colors.surfaceVariant,
+            )))
+            .clickable(enabled = ready) {
+                val s = session ?: return@clickable
+                launchDriver.observe(target)
+                gameConsole.show()
+                controller.launchPackInstance(s, target)
+            }
+            .padding(horizontal = 20.dp, vertical = 18.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.White.copy(alpha = if (ready) 0.18f else 0.06f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector        = Icons.Default.PlayArrow,
+                    contentDescription = null,
+                    tint               = if (ready) Color.White else CelestiaTheme.colors.textSecondary,
+                    modifier           = Modifier.size(28.dp),
+                )
+            }
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text       = if (ready) "Запустить" else "Играть нельзя",
+                    style      = MaterialTheme.typography.titleLarge,
+                    color      = if (ready) Color.White else CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text  = target.displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (ready) Color.White.copy(alpha = 0.85f)
+                            else CelestiaTheme.colors.textSecondary.copy(alpha = 0.7f),
+                )
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ProgressWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ProgressWidget.kt
@@ -1,0 +1,117 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.launcher.AutoSyncService
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import org.koin.compose.koinInject
+
+// Compact background-activity card. Shows AutoSyncService state when
+// a sync is in flight; collapses to a calm "idle" message otherwise.
+// Polished version of the dashboard's autosync strip, broken out so
+// the new home can host it independently.
+@Widget(id = "home.new.progress", displayName = "Background activity")
+@Composable
+fun ProgressWidget(instance: WidgetInstance) {
+    val autoSyncService: AutoSyncService = koinInject()
+    val snapshot by autoSyncService.snapshot.collectAsState()
+    val overall  = snapshot.overall
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.40f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+    ) {
+        Text(
+            text       = "Фоновая активность",
+            style      = MaterialTheme.typography.labelLarge,
+            color      = CelestiaTheme.colors.textSecondary,
+            fontWeight = FontWeight.Medium,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        when (val s = overall) {
+            is AutoSyncService.OverallState.InProgress -> InProgressBody(s)
+            else                                       -> IdleBody()
+        }
+    }
+}
+
+@Composable
+private fun InProgressBody(state: AutoSyncService.OverallState.InProgress) {
+    val fraction = if (state.totalBytes > 0L) {
+        (state.bytesRead.toFloat() / state.totalBytes.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+    Row(
+        verticalAlignment     = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier              = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text       = state.currentServer,
+            style      = MaterialTheme.typography.bodyMedium,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text  = "${state.currentIdx}/${state.total}",
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+    if (state.totalBytes > 0L) {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = "${state.bytesRead / 1_048_576} / ${state.totalBytes / 1_048_576} MB",
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f),
+        )
+    }
+    Spacer(Modifier.height(6.dp))
+    LinearProgressIndicator(
+        progress   = { fraction },
+        modifier   = Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)),
+        color      = CelestiaTheme.colors.primary,
+        trackColor = CelestiaTheme.colors.outline.copy(alpha = 0.15f),
+    )
+}
+
+@Composable
+private fun IdleBody() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+    ) {
+        Text(
+            text  = "Сейчас ничего не качается.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/SpacerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/SpacerWidget.kt
@@ -1,0 +1,48 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
+import hivens.ui.editor.EditModeState
+import hivens.ui.editor.LocalEditMode
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+// Layout primitive. Renders 32dp of empty vertical space; in edit
+// mode a faint dashed center line shows the widget is there and
+// grabbable. Props in Phase 5 will let the user pick the height; for
+// now it is fixed so the editor can demonstrate reorder without prop
+// UI.
+@Widget(id = "home.new.spacer", displayName = "Spacer")
+@Composable
+fun SpacerWidget(instance: WidgetInstance) {
+    val edit = LocalEditMode.current is EditModeState.On
+    if (!edit) {
+        Spacer(Modifier.fillMaxWidth().height(32.dp))
+        return
+    }
+    val lineColor = CelestiaTheme.colors.outline.copy(alpha = 0.35f)
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(32.dp),
+    ) {
+        val y = size.height / 2f
+        drawLine(
+            color       = lineColor,
+            start       = Offset(0f, y),
+            end         = Offset(size.width, y),
+            strokeWidth = 1.5f,
+            cap         = StrokeCap.Round,
+            pathEffect  = PathEffect.dashPathEffect(floatArrayOf(6f, 6f), 0f),
+        )
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -31,8 +31,9 @@ class WidgetRegistryConsistencyTest {
     }
 
     @Test
-    fun `registry exposes the kernel-3 widget kinds`() {
+    fun `registry exposes the kernel-3 + editor-2 sample widget kinds`() {
         val expected = setOf(
+            // kernel-3 surface widgets
             "home.classic.content",
             "home.new.welcome",
             "home.new.recent",
@@ -44,8 +45,26 @@ class WidgetRegistryConsistencyTest {
             "appshell.leftrail.logout",
             "appshell.rightrail.authpanel",
             "appshell.rightrail.compactnews",
+            // editor-2 sample widgets
+            "home.new.clock",
+            "home.new.spacer",
+            "home.new.progress",
+            "home.new.launchbutton",
         )
         val actual = GeneratedWidgetRegistry.all().keys.map { it.value }.toSet()
-        assertEquals(expected, actual, "registry drift -- kernel-3 expected exactly these 11 widgets")
+        assertEquals(expected, actual, "registry drift -- expected these 15 widgets")
+    }
+
+    @Test
+    fun `non-removable widgets are exactly the navigation + auth widgets`() {
+        val nonRemovable = GeneratedWidgetRegistry.all().values
+            .filterNot { it.removable }
+            .map { it.kind.value }
+            .toSet()
+        assertEquals(
+            setOf("appshell.leftrail.navbuttons", "appshell.rightrail.authpanel"),
+            nonRemovable,
+            "only nav buttons + auth panel may opt out of removable",
+        )
     }
 }

--- a/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
@@ -1,8 +1,11 @@
 package hivens.widget.api
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import hivens.widget.model.LayoutGraph
+import hivens.widget.model.SlotAddress
+import hivens.widget.model.WidgetInstance
 
 // Locals provided once near the application root. Static because the
 // graph and registry references swap on whole-tree events (layout
@@ -14,4 +17,24 @@ val LocalLayoutGraph: ProvidableCompositionLocal<LayoutGraph> =
 val LocalWidgetRegistry: ProvidableCompositionLocal<WidgetRegistry> =
     staticCompositionLocalOf {
         error("LocalWidgetRegistry not provided -- did you wire WidgetRegistry in Koin?")
+    }
+
+// Decorator wraps every widget rendered by SlotRenderer. Default is
+// the identity wrapper -- no overhead when nothing is provided. The
+// editor swaps this for a chrome wrapper that adds drag handles and
+// remove buttons. Keeps widget-api editor-agnostic; the implementation
+// lives in :client-ui.
+typealias WidgetDecorator = @Composable (
+    address: SlotAddress,
+    index: Int,
+    descriptor: WidgetDescriptor,
+    instance: WidgetInstance,
+    content: @Composable () -> Unit,
+) -> Unit
+
+val LocalWidgetDecorator: ProvidableCompositionLocal<WidgetDecorator> =
+    staticCompositionLocalOf {
+        // identity wrapper -- zero decoration cost when no editor is
+        // mounted (release builds, headless smoke, future TUI surface)
+        { _, _, _, _, content -> content() }
     }

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -1,6 +1,7 @@
 package hivens.widget.api
 
 import androidx.compose.runtime.Composable
+import hivens.widget.model.SlotAddress
 import hivens.widget.model.SlotId
 import hivens.widget.model.SurfaceId
 
@@ -9,6 +10,11 @@ import hivens.widget.model.SurfaceId
 // hosting application; the registry is provided via LocalWidgetRegistry.
 // Both locals are wired in the launcher's Koin bootstrap.
 //
+// Each widget renders through LocalWidgetDecorator. Default decorator
+// is identity -- zero decoration cost. The editor in :client-ui swaps
+// in a chrome wrapper that adds drag handles, remove buttons, and
+// pointer listeners. SlotRenderer itself stays editor-agnostic.
+//
 // An unknown WidgetKind (e.g. layout file refers to a plugin widget the
 // registry no longer ships) renders nothing -- the slot stays valid;
 // the diagnostic shows up in the --audit-widgets dev tool (kernel-4).
@@ -16,9 +22,13 @@ import hivens.widget.model.SurfaceId
 fun SlotRenderer(surface: SurfaceId, slot: SlotId) {
     val graph = LocalLayoutGraph.current
     val registry = LocalWidgetRegistry.current
+    val decorator = LocalWidgetDecorator.current
     val widgets = graph.surfaces[surface]?.slots?.get(slot)?.widgets.orEmpty()
-    widgets.forEach { instance ->
-        val descriptor = registry[instance.kind] ?: return@forEach
-        descriptor.Render(instance)
+    val address = SlotAddress(surface, slot)
+    widgets.forEachIndexed { index, instance ->
+        val descriptor = registry[instance.kind] ?: return@forEachIndexed
+        decorator(address, index, descriptor, instance) {
+            descriptor.Render(instance)
+        }
     }
 }

--- a/widget-model/src/main/resources/widget/default-layout.json
+++ b/widget-model/src/main/resources/widget/default-layout.json
@@ -16,6 +16,8 @@
           "main": {
             "widgets": [
               { "kind": "home.new.welcome",     "instance_id": "home-new-welcome-default" },
+              { "kind": "home.new.clock",       "instance_id": "home-new-clock-default" },
+              { "kind": "home.new.spacer",      "instance_id": "home-new-spacer-default" },
               { "kind": "home.new.recent",      "instance_id": "home-new-recent-default" },
               { "kind": "home.new.quicklaunch", "instance_id": "home-new-quicklaunch-default" }
             ]


### PR DESCRIPTION
Stacked on #261. Review with that merged first or compare against the editor-1 branch.

The first user-visible payoff of Phase 2. FAB -> edit mode -> grab widget by handle -> drag to reorder. Four new sample widgets so home.new has actual content to rearrange.

## What you'll see in the app

1. Click the pencil FAB bottom-right on Home (any HomeView) or Library
2. FAB icon morphs to a check; subtle pulse glow appears around it
3. A small pill slides down from the top: "Редактирование: Главная (новая) — Esc — выйти"
4. The whole surface gets a thin primary outline (vignette)
5. Every widget gains a faint border, a drag handle (top-left), and a remove button (top-right, hover-only, hidden on nav buttons + auth panel)
6. Grab a widget by its handle. The widget fades to 30%, a ghost lifts off the surface and follows your cursor with a soft shadow + slight scale
7. Release: the layout reorders, the JSON file persists, the widget snaps to its new position

ESC at any time exits edit mode.

## Sample widgets shipped

- \`home.new.clock\` -- analog clock with hour/minute/second hands, theme-tinted hub, digital fallback below the dial
- \`home.new.spacer\` -- 32dp transparent block; dashed line visible in edit mode so it's grabbable
- \`home.new.progress\` -- polished port of the autosync strip; shows live progress when something is downloading, otherwise a calm "idle" line
- \`home.new.launchbutton\` -- big "Continue last" tile with a linear gradient when ready

Clock + Spacer land in the default home.new layout so the new home reads as populated. Progress + LaunchButton stay registry-only and become palette-addable in editor-3.

## Architecture

\`SlotRenderer\` in \`:widget-api\` stays editor-agnostic via the new \`LocalWidgetDecorator\` (identity default -> zero overhead when no editor mounted). The editor in \`:client-ui\` supplies a chrome decorator while edit mode is on.

Drag-and-drop is built on \`pointerInput\` (\`awaitTouchSlopOrCancellation\` -> \`drag\`). The drag handle is the only drag source, so interactive widgets (buttons, sliders) do not eat the gesture. The ghost is rendered via \`graphicsLayer\` translation at the host level -- no layout invalidation per frame.

## Test plan

- [x] \`:widget-model:test\` -- 15 green
- [x] \`:client-launcher:test\` -- 10 green
- [x] \`:client-ui:desktopTest\` -- 32 green (incl. updated registry consistency: 15 widgets, non-removable set locked to {navbuttons, authpanel})
- [ ] Smoke: open the app, switch to HomeView.New, click FAB, drag clock above welcome, release, restart, confirm new order persists
- [ ] Smoke under Brut style: drag animations should be instant (animationMultiplier=0)
- [ ] Smoke: remove a removable widget; nav buttons + auth panel should have no remove button on hover