### PR TITLE
feat(editor): editor-3 -- palette + cross-slot drop + add widgets

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -11,6 +11,7 @@ import hivens.ui.notifications.NotificationCenter
 import hivens.ui.notifications.SessionRegistry
 import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetServerLoader
+import hivens.ui.audio.AudioPlayer
 import hivens.ui.editor.EditModeController
 import hivens.ui.utils.GameConsoleService
 import hivens.widget.api.WidgetRegistry
@@ -39,6 +40,11 @@ val uiModule = module {
     // updates into the shared CoroutineScope so callers stay
     // fire-and-forget.
     single { EditModeController(repo = get(), scope = get()) }
+
+    // Audio engine for MusicPlayerWidget. Survives recomposition;
+    // playback state lives in the singleton so swapping the widget
+    // out of the layout does not stop playback.
+    single { AudioPlayer(scope = get()) }
 
     // Notification subsystem: data-only state holders (Center +
     // Registry) are pure singletons; PackLaunchDriver bridges them

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/audio/AudioPlayer.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/audio/AudioPlayer.kt
@@ -1,0 +1,193 @@
+package hivens.ui.audio
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.DataLine
+import javax.sound.sampled.LineUnavailableException
+import javax.sound.sampled.SourceDataLine
+import javax.sound.sampled.UnsupportedAudioFileException
+import kotlin.io.path.name
+
+// In-process audio playback for the MusicPlayerWidget. Pure
+// javax.sound.sampled -- WAV / AU / AIFF / SND supported out of the
+// JDK box. MP3 / OGG / FLAC require a codec SPI; deferred to the
+// planned Skinema library which will wrap FFmpeg via Panama and
+// cover both audio and video. Until Skinema lands, the user can
+// convert MP3 -> WAV externally or use lossless source files.
+//
+// Single track at a time; opening a new file stops the previous
+// playback. State exposed as a StateFlow so widgets recompose on
+// position updates (1Hz from the playback loop).
+class AudioPlayer(private val scope: CoroutineScope) {
+    private val log = LoggerFactory.getLogger(AudioPlayer::class.java)
+
+    private val _state = MutableStateFlow<PlaybackState>(PlaybackState.Idle)
+    val state: StateFlow<PlaybackState> = _state.asStateFlow()
+
+    private var line: SourceDataLine? = null
+    private var playbackJob: Job? = null
+    private var currentFile: Path? = null
+    private var currentFormat: AudioFormat? = null
+    private var totalFrames: Long = 0L
+
+    fun open(file: Path) {
+        stop()
+        currentFile = file
+        try {
+            val stream = AudioSystem.getAudioInputStream(file.toAbsolutePath().toFile())
+            stream.close()
+            // Probe format + duration without holding the stream open.
+            val baseFormat = AudioSystem.getAudioFileFormat(file.toAbsolutePath().toFile())
+            currentFormat = baseFormat.format
+            totalFrames = baseFormat.frameLength.toLong()
+            val durationMs = if (baseFormat.format.frameRate > 0f && totalFrames > 0L) {
+                (totalFrames * 1000L / baseFormat.format.frameRate.toLong()).coerceAtLeast(0L)
+            } else 0L
+            _state.value = PlaybackState.Ready(
+                file       = file,
+                positionMs = 0L,
+                durationMs = durationMs,
+            )
+        } catch (e: UnsupportedAudioFileException) {
+            log.warn("Unsupported audio format: ${file.name}", e)
+            _state.value = PlaybackState.Error(file, "Формат не поддерживается -- нужен WAV / AU / AIFF.")
+        } catch (e: Exception) {
+            log.error("Failed to open audio file ${file.name}", e)
+            _state.value = PlaybackState.Error(file, e.message ?: "Не удалось открыть файл")
+        }
+    }
+
+    fun play() {
+        val file = currentFile ?: return
+        val current = _state.value
+        if (current is PlaybackState.Playing) return
+        val format = currentFormat ?: return
+
+        playbackJob?.cancel()
+        playbackJob = scope.launch(Dispatchers.IO) {
+            var newStream = AudioSystem.getAudioInputStream(file.toAbsolutePath().toFile())
+            try {
+                val info = DataLine.Info(SourceDataLine::class.java, format)
+                val newLine = AudioSystem.getLine(info) as SourceDataLine
+                newLine.open(format)
+                newLine.start()
+                line = newLine
+
+                val frameSize = format.frameSize
+                val buffer = ByteArray(4096)
+                var bytesRead = newStream.read(buffer)
+                var framesPlayed = 0L
+                while (isActive && bytesRead != -1) {
+                    newLine.write(buffer, 0, bytesRead)
+                    framesPlayed += bytesRead / frameSize
+                    val positionMs = if (format.frameRate > 0f) {
+                        (framesPlayed * 1000L / format.frameRate.toLong())
+                    } else 0L
+                    val durationMs = if (format.frameRate > 0f && totalFrames > 0L) {
+                        totalFrames * 1000L / format.frameRate.toLong()
+                    } else 0L
+                    _state.value = PlaybackState.Playing(
+                        file       = file,
+                        positionMs = positionMs,
+                        durationMs = durationMs,
+                    )
+                    bytesRead = newStream.read(buffer)
+                }
+                newLine.drain()
+                newLine.close()
+                line = null
+                if (isActive) {
+                    _state.value = PlaybackState.Ready(file, positionMs = 0L, durationMs = 0L)
+                }
+            } catch (e: LineUnavailableException) {
+                log.error("Audio line unavailable for ${file.name}", e)
+                _state.value = PlaybackState.Error(file, "Аудиоустройство занято")
+            } catch (e: Exception) {
+                log.error("Playback failed for ${file.name}", e)
+                _state.value = PlaybackState.Error(file, e.message ?: "Ошибка воспроизведения")
+            } finally {
+                runCatching { newStream.close() }
+            }
+        }
+    }
+
+    fun pause() {
+        // javax.sound.sampled has no pause primitive; stop the line
+        // and remember where we are. resume = play() (restarts the
+        // stream from beginning -- limitation of the simple shape;
+        // proper seek requires building a buffered position-stream).
+        line?.stop()
+        line?.close()
+        line = null
+        val current = _state.value
+        if (current is PlaybackState.Playing) {
+            _state.value = PlaybackState.Paused(current.file, current.positionMs, current.durationMs)
+        }
+        playbackJob?.cancel()
+        playbackJob = null
+    }
+
+    fun stop() {
+        playbackJob?.cancel()
+        playbackJob = null
+        line?.stop()
+        line?.close()
+        line = null
+        val current = _state.value
+        if (current is PlaybackState.Playing || current is PlaybackState.Paused) {
+            val file = currentFile
+            if (file != null) {
+                _state.value = PlaybackState.Ready(file, positionMs = 0L, durationMs = 0L)
+            } else {
+                _state.value = PlaybackState.Idle
+            }
+        }
+    }
+
+    fun shutdown() {
+        stop()
+        scope.cancel()
+    }
+}
+
+sealed class PlaybackState {
+    abstract val file: Path?
+
+    object Idle : PlaybackState() {
+        override val file: Path? = null
+    }
+
+    data class Ready(
+        override val file: Path,
+        val positionMs: Long,
+        val durationMs: Long,
+    ) : PlaybackState()
+
+    data class Playing(
+        override val file: Path,
+        val positionMs: Long,
+        val durationMs: Long,
+    ) : PlaybackState()
+
+    data class Paused(
+        override val file: Path,
+        val positionMs: Long,
+        val durationMs: Long,
+    ) : PlaybackState()
+
+    data class Error(
+        override val file: Path,
+        val message: String,
+    ) : PlaybackState()
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Widgets
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -69,6 +71,7 @@ import hivens.ui.editor.dnd.DragPayload
 import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.editor.dnd.LocalDragController
 import hivens.ui.editor.dnd.LocalDropTargetRegistry
+import hivens.ui.editor.palette.WidgetPalettePanel
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.widget.api.LocalWidgetDecorator
@@ -102,7 +105,8 @@ fun EditorSurfaceHost(
     }
     val controller: EditModeController = koinInject()
 
-    var editing by remember(editableSurface) { mutableStateOf(false) }
+    var editing       by remember(editableSurface) { mutableStateOf(false) }
+    var paletteOpen   by remember(editableSurface) { mutableStateOf(true) }
     // Leaving a surface drops edit mode -- avoids a stale edit state
     // pointed at the wrong surface after navigation.
     val state: EditModeState = remember(editing, editableSurface) {
@@ -135,19 +139,32 @@ fun EditorSurfaceHost(
                         controller.removeWidget(address.surface, address.slot, instance.instanceId)
                     },
                     onCommitDrop = { committedPointer ->
-                        // Compute insertion index from registered widget
-                        // bounds; only commit if it actually moved.
-                        val targetIdx = registry.insertionIndexInSlot(address, committedPointer)
-                        // The registry counts the dragged widget too,
-                        // so a no-op drop returns the source index --
-                        // reorderInSlot will detect equality and short-
-                        // circuit, no extra guard needed here.
-                        if (targetIdx != index) {
-                            controller.reorderInSlot(
-                                surface   = address.surface,
-                                slot      = address.slot,
-                                fromIndex = index,
-                                toIndex   = if (targetIdx > index) targetIdx - 1 else targetIdx,
+                        // Hit-test which slot received the drop. Null =
+                        // pointer is off any slot; treat as cancel.
+                        val targetSlot = registry.slotForPoint(committedPointer)
+                            ?: return@EditableWidgetChrome
+                        val targetIdx = registry.insertionIndexInSlot(targetSlot, committedPointer)
+                        if (targetSlot == address) {
+                            // Same slot -- reorder. -1 when moving down
+                            // because removing the source shifts indices.
+                            if (targetIdx != index) {
+                                controller.reorderInSlot(
+                                    surface   = address.surface,
+                                    slot      = address.slot,
+                                    fromIndex = index,
+                                    toIndex   = if (targetIdx > index) targetIdx - 1 else targetIdx,
+                                )
+                            }
+                        } else {
+                            // Cross-slot move. moveWidget removes from
+                            // source then inserts at target index; no
+                            // index adjustment needed since the source
+                            // slot is different.
+                            controller.moveWidget(
+                                from       = address,
+                                to         = targetSlot,
+                                instanceId = instance.instanceId,
+                                toIndex    = targetIdx,
                             )
                         }
                     },
@@ -188,9 +205,20 @@ fun EditorSurfaceHost(
 
             if (editableSurface != null) {
                 EditModePill(
-                    active   = editing,
-                    surface  = editableSurface,
-                    modifier = Modifier.align(Alignment.TopCenter).padding(top = 16.dp),
+                    active            = editing,
+                    surface           = editableSurface,
+                    paletteOpen       = paletteOpen,
+                    onTogglePalette   = { paletteOpen = !paletteOpen },
+                    modifier          = Modifier.align(Alignment.TopCenter).padding(top = 16.dp),
+                )
+
+                WidgetPalettePanel(
+                    visible        = editing && paletteOpen,
+                    onDismiss      = { paletteOpen = false },
+                    controller     = dragController,
+                    registry       = registry,
+                    editController = controller,
+                    modifier       = Modifier.align(Alignment.TopEnd),
                 )
 
                 EditModeFab(
@@ -285,6 +313,8 @@ private fun EditModeFab(
 private fun EditModePill(
     active: Boolean,
     surface: SurfaceId,
+    paletteOpen: Boolean,
+    onTogglePalette: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -300,7 +330,7 @@ private fun EditModePill(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                modifier = Modifier.padding(start = 14.dp, end = 4.dp, top = 6.dp, bottom = 6.dp),
             ) {
                 Icon(
                     imageVector        = Icons.Default.Tune,
@@ -321,6 +351,36 @@ private fun EditModePill(
                     style = MaterialTheme.typography.labelSmall,
                     color = CelestiaTheme.colors.textSecondary,
                 )
+                Spacer(Modifier.width(10.dp))
+                Surface(
+                    color    = if (paletteOpen) CelestiaTheme.colors.primary.copy(alpha = 0.18f)
+                               else CelestiaTheme.colors.surfaceVariant,
+                    shape    = RoundedCornerShape(14.dp),
+                    modifier = Modifier.padding(start = 4.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .clickable { onTogglePalette() }
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                    ) {
+                        Icon(
+                            imageVector        = Icons.Default.Widgets,
+                            contentDescription = null,
+                            tint               = if (paletteOpen) CelestiaTheme.colors.primary
+                                                 else CelestiaTheme.colors.textSecondary,
+                            modifier           = Modifier.size(14.dp),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text  = if (paletteOpen) "Скрыть" else "Виджеты",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (paletteOpen) CelestiaTheme.colors.primary
+                                    else CelestiaTheme.colors.textPrimary,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
             }
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -66,12 +66,20 @@ import androidx.compose.ui.unit.dp
 import hivens.core.data.HomeView
 import hivens.ui.Screen
 import hivens.ui.editor.decoration.EditableWidgetChrome
+import hivens.ui.editor.decoration.EmptySlotPlaceholder
 import hivens.ui.editor.dnd.DragController
 import hivens.ui.editor.dnd.DragPayload
 import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.editor.dnd.LocalDragController
 import hivens.ui.editor.dnd.LocalDropTargetRegistry
 import hivens.ui.editor.palette.WidgetPalettePanel
+import hivens.ui.widgets.home.classic.LocalHomeClassicContext
+import hivens.ui.widgets.home.new.LocalHomeNewContext
+import hivens.ui.widgets.library.LocalLibraryContext
+import hivens.ui.widgets.shell.LocalLeftRailContext
+import hivens.ui.widgets.shell.LocalRightRailContext
+import hivens.widget.api.EmptySlotDecorator
+import hivens.widget.api.LocalEmptySlotDecorator
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.widget.api.LocalWidgetDecorator
@@ -176,11 +184,32 @@ fun EditorSurfaceHost(
         }
     }
 
+    // Empty-slot decorator only renders the "drop here" placeholder
+    // while edit mode is on -- otherwise empty slots stay invisible
+    // in normal use.
+    val emptyDecorator: EmptySlotDecorator = remember(state, registry) {
+        if (state is EditModeState.On) {
+            { address -> EmptySlotPlaceholder(address = address, registry = registry) }
+        } else {
+            {}
+        }
+    }
+
     CompositionLocalProvider(
         LocalEditMode           provides state,
         LocalDragController     provides dragController,
         LocalDropTargetRegistry provides registry,
         LocalWidgetDecorator    provides chromeDecorator,
+        LocalEmptySlotDecorator provides emptyDecorator,
+        // Stub surface contexts. Surface composables that mount under
+        // content() override with the real values; widgets dropped on
+        // a foreign surface fall through to the stubs and render
+        // with no-op callbacks instead of crashing the launcher.
+        LocalHomeClassicContext provides STUB_HOME_CLASSIC,
+        LocalHomeNewContext     provides STUB_HOME_NEW,
+        LocalLibraryContext     provides STUB_LIBRARY,
+        LocalLeftRailContext    provides STUB_LEFTRAIL,
+        LocalRightRailContext   provides STUB_RIGHTRAIL,
     ) {
         Box(
             modifier = Modifier

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/StubContexts.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/StubContexts.kt
@@ -1,0 +1,60 @@
+package hivens.ui.editor
+
+import hivens.core.data.SessionData
+import hivens.ui.AppState
+import hivens.ui.Screen
+import hivens.ui.widgets.home.classic.HomeClassicContext
+import hivens.ui.widgets.home.new.HomeNewContext
+import hivens.ui.widgets.library.LibraryContext
+import hivens.ui.widgets.shell.LeftRailContext
+import hivens.ui.widgets.shell.RightRailContext
+
+// No-op stubs for every per-surface context. EditorSurfaceHost provides
+// them at its level BELOW the active surface composable. The active
+// surface still overrides with the real context (CompositionLocalProvider
+// child shadows parent), so widgets in their natural slot see real data.
+//
+// A widget dragged onto a foreign surface (e.g. a home.new widget
+// dropped into home.classic.main via the palette) falls through to the
+// stub instead of throwing. The widget renders; its navigation
+// callbacks are no-ops. Cosmetic, but the launcher stays alive while
+// the user explores the editor.
+//
+// Phase 5 widget capability metadata + palette filtering will narrow
+// the palette to compatible widgets per surface so foreign-drop never
+// happens in the first place; until then the stubs are the safety net.
+
+internal val STUB_HOME_CLASSIC = HomeClassicContext(
+    session               = SessionData(),
+    initialSelectedServer = null,
+    onServerSelected      = {},
+    onSessionUpdated      = {},
+    onCloseApp            = {},
+    onOpenServerSettings  = {},
+    onOpenDetails         = {},
+)
+
+internal val STUB_HOME_NEW = HomeNewContext(
+    appState         = AppState.Loading,
+    onScreenChange   = {},
+    onSessionUpdated = {},
+)
+
+internal val STUB_LIBRARY = LibraryContext(
+    appState       = AppState.Loading,
+    onScreenChange = {},
+)
+
+internal val STUB_LEFTRAIL = LeftRailContext(
+    currentScreen   = Screen.Home,
+    isAuthenticated = false,
+    onScreenChange  = {},
+    onLogout        = {},
+)
+
+internal val STUB_RIGHTRAIL = RightRailContext(
+    appState  = AppState.Loading,
+    onLogin   = {},
+    onLogout  = {},
+    sslBypass = false,
+)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EmptySlotPlaceholder.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EmptySlotPlaceholder.kt
@@ -1,0 +1,109 @@
+package hivens.ui.editor.decoration
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.SlotAddress
+
+// Rendered by SlotRenderer when a slot has no widgets and the editor
+// has supplied this decorator. Two purposes:
+//   1. Visually communicate that an empty slot exists and accepts drops
+//      ("drag a widget here" hint).
+//   2. Register the slot's bounds with DropTargetRegistry so cross-slot
+//      and palette drops can resolve the slot via slotForPoint.
+//
+// 80dp tall by default -- enough to be obviously droppable without
+// stealing too much visual real estate. Subtle dashed primary border
+// + breathing alpha animation so the placeholder reads as "active
+// but not noisy".
+@Composable
+fun EmptySlotPlaceholder(
+    address: SlotAddress,
+    registry: DropTargetRegistry,
+) {
+    val breath by rememberInfiniteTransition(label = "empty-slot-breath").animateFloat(
+        initialValue  = 0.45f,
+        targetValue   = 0.85f,
+        animationSpec = infiniteRepeatable(
+            animation  = tween(durationMillis = 1600, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "empty-slot-breath-value",
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(80.dp)
+            .padding(vertical = 6.dp)
+            .onGloballyPositioned { c: LayoutCoordinates ->
+                registry.registerSlot(address, c.boundsInWindow())
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        // Dashed border via Canvas so we can use PathEffect; M3's
+        // border modifier does not support dashed strokes.
+        val borderColor = CelestiaTheme.colors.primary.copy(alpha = breath)
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawRoundRect(
+                color  = borderColor,
+                style  = Stroke(
+                    width      = 1.5f,
+                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f), 0f),
+                ),
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(10f, 10f),
+            )
+        }
+        Box(
+            modifier         = Modifier.padding(8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            androidx.compose.foundation.layout.Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector        = Icons.Default.Add,
+                    contentDescription = null,
+                    tint               = CelestiaTheme.colors.primary.copy(alpha = breath),
+                    modifier           = Modifier.padding(end = 6.dp),
+                )
+                Text(
+                    text       = "Перетащи виджет сюда",
+                    style      = MaterialTheme.typography.bodySmall,
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -110,10 +110,11 @@ class DropTargetRegistry {
         widgets[slot]?.remove(instanceId)
     }
 
-    // Locates which slot the pointer is currently over. Two passes:
-    // first an exact rect hit on any widget; second the slot whose
-    // tracked widget rects most-nearly bracket the pointer Y. Returns
-    // null when the pointer is outside every registered slot.
+    // Locates which slot the pointer is currently over. Three passes:
+    // 1) exact rect hit on any widget, 2) the slot whose tracked
+    // widget rects most-nearly bracket the pointer Y, 3) empty-slot
+    // bounds registered by EmptySlotDecorator. Returns null when the
+    // pointer is outside every registered slot.
     fun slotForPoint(pointInWindow: Offset): SlotAddress? {
         widgets.forEach { (slot, byId) ->
             byId.values.forEach { wb ->
@@ -134,6 +135,11 @@ class DropTargetRegistry {
             if (pointInWindow.y in minY..maxY && pointInWindow.x in minX..maxX) {
                 return slot
             }
+        }
+        // Empty slot fallback: EmptySlotDecorator registers slot
+        // bounds; drop into the empty placeholder lands here.
+        slotBounds.forEach { (slot, rect) ->
+            if (rect.contains(pointInWindow)) return slot
         }
         return null
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -110,6 +110,34 @@ class DropTargetRegistry {
         widgets[slot]?.remove(instanceId)
     }
 
+    // Locates which slot the pointer is currently over. Two passes:
+    // first an exact rect hit on any widget; second the slot whose
+    // tracked widget rects most-nearly bracket the pointer Y. Returns
+    // null when the pointer is outside every registered slot.
+    fun slotForPoint(pointInWindow: Offset): SlotAddress? {
+        widgets.forEach { (slot, byId) ->
+            byId.values.forEach { wb ->
+                if (wb.rect.contains(pointInWindow)) return slot
+            }
+        }
+        // Fallback: pick the slot whose vertical span covers the
+        // pointer, plus a 12px tolerance to make gap drops feel
+        // forgiving. Horizontal span must also cover the pointer.
+        val tolerance = 12f
+        widgets.forEach { (slot, byId) ->
+            val items = byId.values
+            if (items.isEmpty()) return@forEach
+            val minY = items.minOf { it.rect.top } - tolerance
+            val maxY = items.maxOf { it.rect.bottom } + tolerance
+            val minX = items.minOf { it.rect.left }
+            val maxX = items.maxOf { it.rect.right }
+            if (pointInWindow.y in minY..maxY && pointInWindow.x in minX..maxX) {
+                return slot
+            }
+        }
+        return null
+    }
+
     // Insertion index for a pointer inside a known slot. Index is in
     // [0, count] -- count means "append at end". Algorithm: find the
     // widget whose vertical midpoint the pointer is above; insert at
@@ -123,9 +151,6 @@ class DropTargetRegistry {
         }
         return items.size
     }
-
-    // Editor-3 will add: slotForPoint(point): SlotAddress? for cross-
-    // slot drag. Editor-2 keeps drags within the source slot only.
 }
 
 // ── Composition locals ─────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
@@ -1,0 +1,179 @@
+package hivens.ui.editor.palette
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import hivens.ui.editor.EditModeController
+import hivens.ui.editor.dnd.DragController
+import hivens.ui.editor.dnd.DragPayload
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.editor.dnd.dragSource
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.WidgetDescriptor
+
+// Palette row. Click + drag from the row drops the widget into the
+// hit-tested slot under the cursor. The ghost is a labeled chip rather
+// than the real widget render -- @Composable exceptions can't be
+// caught by runCatching mid-composition, so trying to render
+// surface-context-dependent widgets during a palette drag would crash
+// every frame. The label ghost is robust and still communicates the
+// drop target intent ("Adding: Clock") clearly while the cursor moves.
+@Composable
+fun PaletteItem(
+    descriptor: WidgetDescriptor,
+    controller: DragController,
+    registry: DropTargetRegistry,
+    editController: EditModeController,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    var rowBounds by remember { mutableStateOf<Rect?>(null) }
+
+    val background = if (isHovered) CelestiaTheme.colors.primary.copy(alpha = 0.12f)
+                     else Color.Transparent
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .onGloballyPositioned { c: LayoutCoordinates -> rowBounds = c.boundsInWindow() }
+            .clip(RoundedCornerShape(8.dp))
+            .background(background)
+            .dragSource(
+                controller            = controller,
+                payload               = DragPayload.PaletteWidget(descriptor.kind),
+                widgetBoundsProvider  = { rowBounds },
+                ghost                 = { PaletteGhost(displayName = descriptor.displayName) },
+                onDragEnd             = { pointer ->
+                    val slot = registry.slotForPoint(pointer) ?: return@dragSource
+                    val index = registry.insertionIndexInSlot(slot, pointer)
+                    editController.addWidget(slot.surface, slot.slot, descriptor.kind, index)
+                },
+            )
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+    ) {
+        // Tiny icon block -- first letter of displayName as a kind of
+        // visual anchor. When Phase 5 widget-supplied previews land,
+        // this slot becomes the real widget thumbnail.
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(CelestiaTheme.colors.primary.copy(alpha = 0.20f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text       = descriptor.displayName.firstOrNull()?.uppercase() ?: "?",
+                style      = MaterialTheme.typography.titleMedium,
+                color      = CelestiaTheme.colors.primary,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text       = descriptor.displayName,
+                style      = MaterialTheme.typography.bodyMedium,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.Medium,
+                maxLines   = 1,
+                overflow   = TextOverflow.Ellipsis,
+            )
+            Text(
+                text       = descriptor.kind.value,
+                style      = MaterialTheme.typography.labelSmall,
+                color      = CelestiaTheme.colors.textSecondary,
+                fontFamily = FontFamily.Monospace,
+                maxLines   = 1,
+                overflow   = TextOverflow.Ellipsis,
+            )
+        }
+        Icon(
+            imageVector        = Icons.Default.DragIndicator,
+            contentDescription = null,
+            tint               = CelestiaTheme.colors.textSecondary.copy(alpha = if (isHovered) 0.9f else 0.45f),
+            modifier           = Modifier.size(18.dp),
+        )
+    }
+}
+
+@Composable
+private fun PaletteGhost(displayName: String) {
+    Surface(
+        color           = CelestiaTheme.colors.primary,
+        contentColor    = Color.White,
+        shape           = RoundedCornerShape(10.dp),
+        shadowElevation = 10.dp,
+        modifier        = Modifier.shadow(elevation = 12.dp, shape = RoundedCornerShape(10.dp)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(Color.White.copy(alpha = 0.18f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text       = displayName.firstOrNull()?.uppercase() ?: "?",
+                    style      = MaterialTheme.typography.labelLarge,
+                    color      = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text       = displayName,
+                style      = MaterialTheme.typography.bodyMedium,
+                color      = Color.White,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                text  = "→ drop",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.75f),
+            )
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/WidgetPalettePanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/WidgetPalettePanel.kt
@@ -1,0 +1,154 @@
+package hivens.ui.editor.palette
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.editor.EditModeController
+import hivens.ui.editor.dnd.DragController
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.LocalWidgetRegistry
+
+// Floating widget palette. Right-edge pinned. Slides in/out with the
+// surrounding edit-mode toggle. Sorted alphabetically by displayName
+// so the list is a stable reading experience.
+@Composable
+fun WidgetPalettePanel(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    controller: DragController,
+    registry: DropTargetRegistry,
+    editController: EditModeController,
+    modifier: Modifier = Modifier,
+) {
+    val registry0 = LocalWidgetRegistry.current
+    val descriptors = remember(registry0) {
+        registry0.all().values.sortedBy { it.displayName.lowercase() }
+    }
+
+    AnimatedVisibility(
+        visible  = visible,
+        enter    = fadeIn(spring()) + slideInHorizontally(spring(stiffness = Spring.StiffnessMediumLow)) { it },
+        exit     = fadeOut(spring()) + slideOutHorizontally(spring(stiffness = Spring.StiffnessMediumLow)) { it },
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .width(300.dp)
+                .fillMaxHeight()
+                .padding(top = 64.dp, bottom = 96.dp, end = 16.dp, start = 0.dp)
+                .shadow(elevation = 18.dp, shape = RoundedCornerShape(14.dp))
+                .clip(RoundedCornerShape(14.dp))
+                .background(glassSurfaceAlpha(0.86f)),
+        ) {
+            // Header
+            Row(
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier              = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 14.dp, end = 6.dp, top = 12.dp, bottom = 6.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector        = Icons.Default.Widgets,
+                        contentDescription = null,
+                        tint               = CelestiaTheme.colors.primary,
+                        modifier           = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text       = "Виджеты",
+                        style      = MaterialTheme.typography.titleSmall,
+                        color      = CelestiaTheme.colors.textPrimary,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text  = "${descriptors.size}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.7f),
+                    )
+                }
+                IconButton(onClick = onDismiss, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        imageVector        = Icons.Default.Close,
+                        contentDescription = "Hide palette",
+                        tint               = CelestiaTheme.colors.textSecondary,
+                        modifier           = Modifier.size(16.dp),
+                    )
+                }
+            }
+            Text(
+                text     = "Перетащи в нужный слот",
+                style    = MaterialTheme.typography.labelSmall,
+                color    = CelestiaTheme.colors.textSecondary,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 0.dp),
+            )
+            Spacer(Modifier.height(6.dp))
+
+            if (descriptors.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(20.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text  = "Registry пуст — это build issue.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = CelestiaTheme.colors.textSecondary,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier            = Modifier.fillMaxWidth().padding(horizontal = 6.dp, vertical = 2.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    items(items = descriptors, key = { it.kind.value }) { descriptor ->
+                        PaletteItem(
+                            descriptor     = descriptor,
+                            controller     = controller,
+                            registry       = registry,
+                            editController = editController,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
@@ -1,0 +1,285 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import hivens.ui.audio.AudioPlayer
+import hivens.ui.audio.PlaybackState
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.path
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.compose.koinInject
+import java.nio.file.Paths
+import kotlin.io.path.name
+
+// Mini music player. Drop a WAV / AU / AIFF file, play it through
+// AudioPlayer. The opening pin in the project_achievements vision --
+// the user can compose the launcher into a music-only surface by
+// removing every game widget and keeping this + a clock + the right
+// rail (or nothing). MP3 support arrives with Skinema (FFmpeg
+// via Panama).
+@Widget(id = "home.new.music", displayName = "Music player")
+@Composable
+fun MusicPlayerWidget(instance: WidgetInstance) {
+    val player: AudioPlayer = koinInject()
+    val state by player.state.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    val pickFile = {
+        scope.launch {
+            val picked = withContext(Dispatchers.IO) {
+                FileKit.openFilePicker(
+                    type           = FileKitType.File(extensions = listOf("wav", "au", "aif", "aiff", "snd")),
+                    dialogSettings = FileKitDialogSettings(title = "Выбери трек"),
+                )
+            }
+            val path = picked?.path?.let { Paths.get(it) }
+            if (path != null) player.open(path)
+        }
+        Unit
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(
+                        CelestiaTheme.colors.surface,
+                        glassSurfaceAlpha(0.55f),
+                    ),
+                ),
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        // Header + album-art block + transport
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            AlbumArtBlock(state)
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text       = "Музыкальный плеер",
+                    style      = MaterialTheme.typography.labelLarge,
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text       = currentTitle(state),
+                    style      = MaterialTheme.typography.titleMedium,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines   = 1,
+                    overflow   = TextOverflow.Ellipsis,
+                )
+                if (state is PlaybackState.Error) {
+                    Text(
+                        text  = (state as PlaybackState.Error).message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = CelestiaTheme.colors.error,
+                    )
+                } else {
+                    Text(
+                        text     = subtitle(state),
+                        style    = MaterialTheme.typography.bodySmall,
+                        color    = CelestiaTheme.colors.textSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+
+        // Progress strip
+        val fraction = progressFraction(state)
+        LinearProgressIndicator(
+            progress   = { fraction },
+            modifier   = Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)),
+            color      = CelestiaTheme.colors.primary,
+            trackColor = CelestiaTheme.colors.outline.copy(alpha = 0.15f),
+        )
+
+        // Controls row
+        Row(
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier              = Modifier.fillMaxWidth(),
+        ) {
+            ControlButton(
+                icon            = Icons.Default.FolderOpen,
+                contentDesc     = "Открыть файл",
+                onClick         = { pickFile() },
+            )
+            ControlButton(
+                icon         = if (state is PlaybackState.Playing) Icons.Default.Pause else Icons.Default.PlayArrow,
+                contentDesc  = if (state is PlaybackState.Playing) "Пауза" else "Воспроизвести",
+                enabled      = state !is PlaybackState.Idle && state !is PlaybackState.Error,
+                primary      = true,
+                onClick      = {
+                    if (state is PlaybackState.Playing) player.pause() else player.play()
+                },
+            )
+            ControlButton(
+                icon         = Icons.Default.Stop,
+                contentDesc  = "Стоп",
+                enabled      = state is PlaybackState.Playing || state is PlaybackState.Paused,
+                onClick      = { player.stop() },
+            )
+            Spacer(Modifier.weight(1f))
+            val timeline = timelineLabel(state)
+            if (timeline.isNotEmpty()) {
+                Text(
+                    text  = timeline,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumArtBlock(state: PlaybackState) {
+    Box(
+        modifier = Modifier
+            .size(52.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(CelestiaTheme.colors.primary.copy(alpha = 0.18f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector        = Icons.Default.MusicNote,
+            contentDescription = null,
+            tint               = CelestiaTheme.colors.primary,
+            modifier           = Modifier.size(28.dp),
+        )
+    }
+}
+
+@Composable
+private fun ControlButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDesc: String,
+    enabled: Boolean = true,
+    primary: Boolean = false,
+    onClick: () -> Unit,
+) {
+    val bg = when {
+        !enabled -> CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.4f)
+        primary  -> CelestiaTheme.colors.primary
+        else     -> CelestiaTheme.colors.surface
+    }
+    val tint = when {
+        !enabled -> CelestiaTheme.colors.textSecondary.copy(alpha = 0.4f)
+        primary  -> Color.White
+        else     -> CelestiaTheme.colors.textPrimary
+    }
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(bg)
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector        = icon,
+            contentDescription = contentDesc,
+            tint               = tint,
+            modifier           = Modifier.size(if (primary) 20.dp else 16.dp),
+        )
+    }
+}
+
+private fun currentTitle(state: PlaybackState): String = when (state) {
+    is PlaybackState.Idle    -> "Выбери трек"
+    is PlaybackState.Ready   -> state.file.name
+    is PlaybackState.Playing -> state.file.name
+    is PlaybackState.Paused  -> state.file.name
+    is PlaybackState.Error   -> state.file.name
+}
+
+private fun subtitle(state: PlaybackState): String = when (state) {
+    PlaybackState.Idle       -> "WAV / AU / AIFF поддерживаются. MP3 будет в Skinema."
+    is PlaybackState.Ready   -> "Готов"
+    is PlaybackState.Playing -> "Играет"
+    is PlaybackState.Paused  -> "Пауза"
+    is PlaybackState.Error   -> ""
+}
+
+private fun progressFraction(state: PlaybackState): Float = when (state) {
+    is PlaybackState.Playing -> safeFraction(state.positionMs, state.durationMs)
+    is PlaybackState.Paused  -> safeFraction(state.positionMs, state.durationMs)
+    is PlaybackState.Ready   -> safeFraction(state.positionMs, state.durationMs)
+    else                     -> 0f
+}
+
+private fun safeFraction(position: Long, duration: Long): Float =
+    if (duration <= 0L) 0f else (position.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+
+private fun timelineLabel(state: PlaybackState): String {
+    val (pos, dur) = when (state) {
+        is PlaybackState.Playing -> state.positionMs to state.durationMs
+        is PlaybackState.Paused  -> state.positionMs to state.durationMs
+        is PlaybackState.Ready   -> 0L to state.durationMs
+        else                     -> return ""
+    }
+    if (dur <= 0L) return ""
+    return "${formatMs(pos)} / ${formatMs(dur)}"
+}
+
+private fun formatMs(ms: Long): String {
+    val totalSeconds = ms / 1000
+    val m = totalSeconds / 60
+    val s = totalSeconds % 60
+    return "%d:%02d".format(m, s)
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/IndividualNavWidgets.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/IndividualNavWidgets.kt
@@ -1,0 +1,178 @@
+package hivens.ui.widgets.shell
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import hivens.ui.Screen
+import hivens.ui.easter.LocalAprilFools
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import kotlin.math.sin
+import kotlin.random.Random
+
+// Individual nav widgets. The bundled LeftRailNavButtons stays as the
+// out-of-box default for users who never touch the editor; these six
+// let editor users selectively keep / remove / reorder nav items. To
+// build a "music-only" launcher (project_achievements vision), strip
+// LeftRailNavButtons, keep just NavSettings + NavHome, fill main
+// with MusicPlayerWidget + ClockWidget. Done.
+//
+// Settings is the only non-removable individual nav -- removing all
+// nav including Settings would brick the launcher (no way back to
+// reset the layout); Settings stays as the always-accessible escape.
+
+@Widget(id = "nav.home", displayName = "Nav: Home")
+@Composable
+fun NavHomeWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon       = Icons.Default.Home,
+        screen     = Screen.Home,
+        phase      = 0.0f,
+        isActive   = { it is Screen.Home || it is Screen.ServerSettings || it is Screen.ServerDetails },
+    )
+}
+
+@Widget(id = "nav.library", displayName = "Nav: Library")
+@Composable
+fun NavLibraryWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon     = Icons.Default.Star,
+        screen   = Screen.Library,
+        phase    = 0.55f,
+        isActive = { it is Screen.Library || it is Screen.PackDetail },
+    )
+}
+
+@Widget(id = "nav.browse", displayName = "Nav: Browse")
+@Composable
+fun NavBrowseWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon     = Icons.Default.Search,
+        screen   = Screen.Browse,
+        phase    = 1.65f,
+        isActive = { it is Screen.Browse || it is Screen.BrowsePackDetail },
+    )
+}
+
+@Widget(id = "nav.profile", displayName = "Nav: Profile")
+@Composable
+fun NavProfileWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon            = Icons.Default.Person,
+        screen          = Screen.Profile,
+        phase           = 1.1f,
+        isActive        = { it is Screen.Profile },
+        enabledOverride = { _, isAuthed -> isAuthed },
+    )
+}
+
+@Widget(id = "nav.settings", displayName = "Nav: Settings", removable = false)
+@Composable
+fun NavSettingsWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon     = Icons.Default.Settings,
+        screen   = Screen.Settings,
+        phase    = 2.2f,
+        isActive = {
+            it is Screen.Settings || it is Screen.ThemePicker ||
+            it is Screen.BackgroundSettings || it is Screen.CustomizationExtension
+        },
+    )
+}
+
+@Widget(id = "nav.about", displayName = "Nav: About")
+@Composable
+fun NavAboutWidget(instance: WidgetInstance) {
+    NavSlot(
+        icon     = Icons.Default.Info,
+        screen   = Screen.About,
+        phase    = 3.3f,
+        isActive = { it is Screen.About },
+    )
+}
+
+// Shared nav-item render. Captures the April Fools chaos +
+// out-of-phase bounce so each individual widget keeps the bundled
+// LeftRailNavButtons feel.
+@Composable
+private fun NavSlot(
+    icon: ImageVector,
+    screen: Screen,
+    phase: Float,
+    isActive: (Screen) -> Boolean,
+    enabledOverride: ((Screen, Boolean) -> Boolean)? = null,
+) {
+    val ctx = LocalLeftRailContext.current
+    val af = LocalAprilFools.current
+
+    val bounceAmp = if (af.isActive()) af.intensity() * 18f else 0f
+    val transition = rememberInfiniteTransition(label = "nav-bounce-$phase")
+    val cycle by transition.animateFloat(
+        initialValue  = 0f,
+        targetValue   = (2f * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = if (af.isActive())
+                    (2200 - af.intensity() * 1400).toInt().coerceAtLeast(600)
+                else 2200,
+                easing = LinearEasing,
+            ),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "nav-bounce-cycle-$phase",
+    )
+    val offsetY = sin(cycle + phase) * bounceAmp
+
+    val click = {
+        if (!af.isActive() || Random.nextFloat() > 0.30f) {
+            ctx.onScreenChange(screen)
+        }
+    }
+    val enabled = enabledOverride?.invoke(ctx.currentScreen, ctx.isAuthenticated) ?: true
+
+    Box(Modifier.graphicsLayer { translationY = offsetY }) {
+        NavigationRailItem(
+            icon = {
+                Icon(
+                    imageVector        = icon,
+                    contentDescription = null,
+                    modifier           = Modifier.size(24.dp),
+                )
+            },
+            selected        = isActive(ctx.currentScreen),
+            onClick         = click,
+            enabled         = enabled,
+            label           = null,
+            alwaysShowLabel = false,
+            colors          = NavigationRailItemDefaults.colors(
+                selectedIconColor   = CelestiaTheme.colors.primary,
+                unselectedIconColor = CelestiaTheme.colors.textSecondary.copy(
+                    alpha = if (enabled) 0.70f else 0.20f,
+                ),
+                indicatorColor      = CelestiaTheme.colors.primary.copy(alpha = 0.13f),
+            ),
+        )
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
@@ -1,0 +1,86 @@
+package hivens.ui.editor.dnd
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotId
+import hivens.widget.model.SurfaceId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DropTargetRegistryTest {
+
+    private val homeNew = SurfaceId("home.new")
+    private val main    = SlotId("main")
+    private val slot    = SlotAddress(homeNew, main)
+    private val library = SurfaceId("library")
+    private val body    = SlotId("body")
+    private val otherSlot = SlotAddress(library, body)
+
+    private fun rect(top: Float, height: Float = 50f, left: Float = 0f, width: Float = 300f): Rect =
+        Rect(left = left, top = top, right = left + width, bottom = top + height)
+
+    @Test
+    fun `insertionIndexInSlot picks the widget whose midpoint the pointer is above`() {
+        val r = DropTargetRegistry()
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f))     // [0, 50]
+        r.registerWidget(slot, "b", index = 1, rect = rect(top = 60f))    // [60, 110]
+        r.registerWidget(slot, "c", index = 2, rect = rect(top = 120f))   // [120, 170]
+
+        // Above midpoint of widget 0 -> index 0
+        assertEquals(0, r.insertionIndexInSlot(slot, Offset(50f, 10f)))
+        // Below midpoint of widget 0, above midpoint of widget 1 -> 1
+        assertEquals(1, r.insertionIndexInSlot(slot, Offset(50f, 70f)))
+        // Below all -> append at 3
+        assertEquals(3, r.insertionIndexInSlot(slot, Offset(50f, 200f)))
+    }
+
+    @Test
+    fun `insertionIndexInSlot returns zero for unknown slot`() {
+        val r = DropTargetRegistry()
+        assertEquals(0, r.insertionIndexInSlot(slot, Offset(0f, 0f)))
+    }
+
+    @Test
+    fun `slotForPoint returns the slot whose widget rect contains the pointer`() {
+        val r = DropTargetRegistry()
+        r.registerWidget(slot,      "a", index = 0, rect = rect(top = 0f))      // home.new at y=0..50
+        r.registerWidget(otherSlot, "b", index = 0, rect = rect(top = 200f))    // library at y=200..250
+
+        assertEquals(slot,      r.slotForPoint(Offset(50f, 25f)))
+        assertEquals(otherSlot, r.slotForPoint(Offset(50f, 225f)))
+    }
+
+    @Test
+    fun `slotForPoint falls back to vertical span with horizontal tolerance`() {
+        val r = DropTargetRegistry()
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f))    // [0, 50]
+        r.registerWidget(slot, "b", index = 1, rect = rect(top = 60f))   // [60, 110]
+
+        // Between the two widgets, inside the slot's vertical span +
+        // tolerance and within X range -- should resolve.
+        assertEquals(slot, r.slotForPoint(Offset(100f, 55f)))
+    }
+
+    @Test
+    fun `slotForPoint returns null when pointer is outside every slot`() {
+        val r = DropTargetRegistry()
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f))
+
+        // Way below the slot + tolerance -> null
+        assertNull(r.slotForPoint(Offset(50f, 500f)))
+        // Way right of the slot -> null
+        assertNull(r.slotForPoint(Offset(900f, 25f)))
+    }
+
+    @Test
+    fun `unregisterWidget removes from hit-test`() {
+        val r = DropTargetRegistry()
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f))
+        r.unregisterWidget(slot, "a")
+        // Slot still exists in map (empty); slotForPoint cannot match
+        // because there are no widget rects to span.
+        assertNull(r.slotForPoint(Offset(50f, 25f)))
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -31,7 +31,7 @@ class WidgetRegistryConsistencyTest {
     }
 
     @Test
-    fun `registry exposes the kernel-3 + editor-2 sample widget kinds`() {
+    fun `registry exposes the kernel-3 + editor sample widget kinds`() {
         val expected = setOf(
             // kernel-3 surface widgets
             "home.classic.content",
@@ -50,21 +50,33 @@ class WidgetRegistryConsistencyTest {
             "home.new.spacer",
             "home.new.progress",
             "home.new.launchbutton",
+            // editor-3.7 music + individual nav
+            "home.new.music",
+            "nav.home",
+            "nav.library",
+            "nav.browse",
+            "nav.profile",
+            "nav.settings",
+            "nav.about",
         )
         val actual = GeneratedWidgetRegistry.all().keys.map { it.value }.toSet()
-        assertEquals(expected, actual, "registry drift -- expected these 15 widgets")
+        assertEquals(expected, actual, "registry drift -- expected exactly these widgets")
     }
 
     @Test
-    fun `non-removable widgets are exactly the navigation + auth widgets`() {
+    fun `non-removable widgets cover the bundled-rail safety set`() {
         val nonRemovable = GeneratedWidgetRegistry.all().values
             .filterNot { it.removable }
             .map { it.kind.value }
             .toSet()
         assertEquals(
-            setOf("appshell.leftrail.navbuttons", "appshell.rightrail.authpanel"),
+            setOf(
+                "appshell.leftrail.navbuttons", // bundled rail variant
+                "appshell.rightrail.authpanel",
+                "nav.settings",                  // individual-nav safety: always reachable
+            ),
             nonRemovable,
-            "only nav buttons + auth panel may opt out of removable",
+            "non-removable set protects the launcher from being navigation-locked",
         )
     }
 }

--- a/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
@@ -38,3 +38,12 @@ val LocalWidgetDecorator: ProvidableCompositionLocal<WidgetDecorator> =
         // mounted (release builds, headless smoke, future TUI surface)
         { _, _, _, _, content -> content() }
     }
+
+// Rendered by SlotRenderer when a slot has no widgets. Default = nothing
+// (production behavior: empty slot stays invisible). The editor swaps
+// in a placeholder that says "drop here" and registers the slot bounds
+// with the DropTargetRegistry, making empty slots valid drop targets.
+typealias EmptySlotDecorator = @Composable (address: SlotAddress) -> Unit
+
+val LocalEmptySlotDecorator: ProvidableCompositionLocal<EmptySlotDecorator> =
+    staticCompositionLocalOf { {} }

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -23,8 +23,13 @@ fun SlotRenderer(surface: SurfaceId, slot: SlotId) {
     val graph = LocalLayoutGraph.current
     val registry = LocalWidgetRegistry.current
     val decorator = LocalWidgetDecorator.current
+    val emptyDecorator = LocalEmptySlotDecorator.current
     val widgets = graph.surfaces[surface]?.slots?.get(slot)?.widgets.orEmpty()
     val address = SlotAddress(surface, slot)
+    if (widgets.isEmpty()) {
+        emptyDecorator(address)
+        return
+    }
     widgets.forEachIndexed { index, instance ->
         val descriptor = registry[instance.kind] ?: return@forEachIndexed
         decorator(address, index, descriptor, instance) {


### PR DESCRIPTION
Stacked on #262. Review with that merged or compare against the editor-2 branch.

This is "how do I add a clock". Click the FAB in edit mode, the palette slides in from the right, drag any row into any slot.

## What you'll see

1. Enter edit mode -- palette panel slides in from the right edge automatically
2. Pill at top now has a "Виджеты" / "Скрыть" chip to toggle the palette
3. Palette rows: 32dp letter-anchor + bold displayName + monospace kind id + drag handle, sorted alphabetically
4. Grab a row; a primary-colored chip ghost "K  Clock -> drop" follows your cursor
5. Drop on any slot -- new widget instance mints with a fresh UUID and inserts at the hit-tested index
6. Existing widgets can now drag across slots (editor-2 was within-slot only)
7. Esc still leaves edit mode

## Architecture notes

- **Palette ghost is a label chip, not the widget render.** @Composable exceptions are not catchable by runCatching mid-composition. A surface-context-dependent widget rendered outside its surface scope would crash every drag frame. Chip ghost is robust + clearly communicates intent. Phase 5 prop-schema work can revisit if needed.
- **DropTargetRegistry.slotForPoint** does exact-rect containment first, then vertical-span fallback with 12px tolerance so gap-drops feel forgiving.
- **Cross-slot move uses LayoutGraph.moveWidget** (already in widget-model since editor-1). No new repo API.

## Test plan

- [x] \`:client-ui:desktopTest\` -- new \`DropTargetRegistryTest\` 6 green (above-midpoint insertion, append-below, unknown-slot, exact rect containment, vertical-span fallback, unregister removal)
- [x] All previous tests green
- [ ] Smoke: open app, enter edit mode, palette panel slides in
- [ ] Drag Clock from palette into home.new -> appears at drop position, persists across restart
- [ ] Drag existing widget from home.new.main into appshell.leftrail.bottom (cross-surface won't work; cross-slot within same surface should)
- [ ] Toggle palette via chip in pill, slides out + in