### PR TITLE
feat(editor): editor-4 -- extended theme tokens + style overrides

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -57,6 +57,7 @@ import hivens.ui.screens.ConsoleWindow
 import hivens.ui.screens.MigrationScreen
 import hivens.ui.theme.BrutStyle
 import hivens.ui.theme.CelestiaStyle
+import hivens.ui.theme.applyOverrides
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.CustomTheme
 import hivens.ui.theme.ThemeManager
@@ -188,10 +189,16 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
     var homeView      by remember { mutableStateOf(settings.homeView) }
     var uiStyle       by remember { mutableStateOf(settings.uiStyle) }
 
-    val styleSpec = when (uiStyle) {
+    val basePresetStyle = when (uiStyle) {
         UiStyle.Celestia -> CelestiaStyle
         UiStyle.Brut     -> BrutStyle
     }
+    // Preset-only spec at this level -- customization (and the
+    // editor-4 style overrides) live inside AppRoot. AprilFools
+    // tracks the preset value; the overridden value flows through
+    // LocalStyle further down for composables that need the
+    // user-tweaked tokens.
+    val styleSpec = basePresetStyle
 
     // Push style coupling into AprilFools so the chaos engine (a plain
     // singleton, not a Composable) and chaos components pick up the
@@ -576,10 +583,15 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 LocalLayoutGraph                         provides layoutGraph,
                 LocalWidgetRegistry                      provides widgetRegistry,
             ) {
+            val effectiveStyle = if (customization.experimentalColorOverridesEnabled) {
+                styleSpec.applyOverrides(customization.styleOverrides)
+            } else {
+                styleSpec
+            }
             CelestiaTheme(
                 useDarkTheme = isDarkTheme,
                 customTheme  = customTheme,
-                style        = styleSpec,
+                style        = effectiveStyle,
             ) {
                 val migration = boot.pendingMigration
                 if (migration != null) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationSettings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationSettings.kt
@@ -9,10 +9,11 @@ import kotlinx.serialization.Serializable
  * Default state is a no-op -- every field is null / 1.0 / false so an
  * unconfigured user sees the same UI as before customization existed.
  *
- * [experimentalColorOverridesEnabled] gates [colorOverrides] -- by
- * default only [accentOverride] is exposed. Flipping the experimental
- * flag unlocks per-role color picking which is easy to misuse into
- * unreadable combinations.
+ * [experimentalColorOverridesEnabled] gates [colorOverrides] +
+ * [styleOverrides] -- by default only [accentOverride] is exposed.
+ * Flipping the experimental flag unlocks per-role color picking and
+ * per-token style tweaks; both are easy to misuse into unreadable
+ * combinations.
  */
 @Serializable
 data class CustomizationSettings(
@@ -21,19 +22,46 @@ data class CustomizationSettings(
     val accentOverride: String? = null,
     val experimentalColorOverridesEnabled: Boolean = false,
     val colorOverrides: Map<String, String> = emptyMap(),
+    val styleOverrides: StyleOverrides = StyleOverrides(),
 )
 
 /**
  * Per-role keys for [CustomizationSettings.colorOverrides]. Stable
  * strings so existing customization.json files keep working across
- * theme refactors.
+ * theme refactors. Editor-4 extends the role set with text tokens,
+ * the glass alpha float, and the severity accents.
  */
 object ColorRole {
-    const val PRIMARY    = "primary"
-    const val SECONDARY  = "secondary"
-    const val BACKGROUND = "background"
-    const val SURFACE    = "surface"
-    const val SUCCESS    = "success"
-    const val ERROR      = "error"
-    const val OUTLINE    = "outline"
+    const val PRIMARY          = "primary"
+    const val SECONDARY        = "secondary"
+    const val BACKGROUND       = "background"
+    const val SURFACE          = "surface"
+    const val SUCCESS          = "success"
+    const val ERROR            = "error"
+    const val OUTLINE          = "outline"
+    // editor-4 additions
+    const val TEXT_PRIMARY     = "textPrimary"
+    const val TEXT_SECONDARY   = "textSecondary"
+    const val GLASS_ALPHA      = "glassAlpha"        // float, special-cased in theme
+    const val PROGRESS_ACCENT  = "progressAccent"
+    const val WARN_ACCENT      = "warnAccent"
+    const val CRITICAL_ACCENT  = "criticalAccent"
 }
+
+/**
+ * Per-token style overrides layered on top of the active UiStyle
+ * preset (Celestia / Brut). Every field is nullable -- null means
+ * "keep the preset's value". The user picking Brut still sees Brut
+ * as their base; overrides drift individual fields off the base.
+ *
+ * Applied via [hivens.ui.theme.StyleSpec.applyOverrides] in the
+ * theme resolution chain at AppShell.
+ */
+@Serializable
+data class StyleOverrides(
+    val cardCornerDp: Float? = null,
+    val cardBorderDp: Float? = null,
+    val buttonCornerDp: Float? = null,
+    val animationMultiplier: Float? = null,
+    val softGlowEnabled: Boolean? = null,
+)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -204,6 +204,105 @@ fun CustomizationExtensionScreen(
                             },
                         )
                     }
+
+                    Spacer(Modifier.height(12.dp))
+                    SectionTitle("Текст и акценты")
+                    listOf(
+                        ColorRole.TEXT_PRIMARY,
+                        ColorRole.TEXT_SECONDARY,
+                        ColorRole.PROGRESS_ACCENT,
+                        ColorRole.WARN_ACCENT,
+                        ColorRole.CRITICAL_ACCENT,
+                    ).forEach { role ->
+                        ColorRoleRow(
+                            role         = role,
+                            currentHex   = settings.colorOverrides[role],
+                            invalidLabel = s.customizationHexInvalid,
+                            onValidHex   = { hex ->
+                                update {
+                                    val newMap = colorOverrides.toMutableMap().also { it[role] = hex }
+                                    copy(colorOverrides = newMap)
+                                }
+                            },
+                            onClear = {
+                                update {
+                                    val newMap = colorOverrides.toMutableMap().also { it.remove(role) }
+                                    copy(colorOverrides = newMap)
+                                }
+                            },
+                        )
+                    }
+
+                    Spacer(Modifier.height(12.dp))
+                    SectionTitle("Прозрачность стекла")
+                    val glassAlphaValue = settings.colorOverrides[ColorRole.GLASS_ALPHA]?.toFloatOrNull() ?: 0.6f
+                    LabeledSlider(
+                        label  = "Glass alpha",
+                        value  = glassAlphaValue,
+                        range  = 0f..1f,
+                        format = "%.2f",
+                        onValueChange = { v ->
+                            update {
+                                val newMap = colorOverrides.toMutableMap().also {
+                                    it[ColorRole.GLASS_ALPHA] = "%.3f".format(v)
+                                }
+                                copy(colorOverrides = newMap)
+                            }
+                        },
+                    )
+
+                    Spacer(Modifier.height(12.dp))
+                    SectionTitle("Форма и движение")
+                    val so = settings.styleOverrides
+                    LabeledSlider(
+                        label  = "Card corner (dp)",
+                        value  = so.cardCornerDp ?: 12f,
+                        range  = 0f..24f,
+                        format = "%.0fdp",
+                        onValueChange = { v -> update { copy(styleOverrides = styleOverrides.copy(cardCornerDp = v)) } },
+                    )
+                    LabeledSlider(
+                        label  = "Card border (dp)",
+                        value  = so.cardBorderDp ?: 0f,
+                        range  = 0f..3f,
+                        format = "%.1fdp",
+                        onValueChange = { v -> update { copy(styleOverrides = styleOverrides.copy(cardBorderDp = v)) } },
+                    )
+                    LabeledSlider(
+                        label  = "Button corner (dp)",
+                        value  = so.buttonCornerDp ?: 8f,
+                        range  = 0f..20f,
+                        format = "%.0fdp",
+                        onValueChange = { v -> update { copy(styleOverrides = styleOverrides.copy(buttonCornerDp = v)) } },
+                    )
+                    LabeledSlider(
+                        label  = "Animation speed",
+                        value  = so.animationMultiplier ?: 1f,
+                        range  = 0f..2f,
+                        format = "x%.2f",
+                        onValueChange = { v -> update { copy(styleOverrides = styleOverrides.copy(animationMultiplier = v)) } },
+                    )
+                    Row(
+                        modifier              = Modifier.fillMaxWidth().padding(top = 6.dp),
+                        verticalAlignment     = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text  = "Decorative glow",
+                            color = CelestiaTheme.colors.textPrimary,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Switch(
+                            checked         = so.softGlowEnabled ?: true,
+                            onCheckedChange = { v ->
+                                update { copy(styleOverrides = styleOverrides.copy(softGlowEnabled = v)) }
+                            },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = CelestiaTheme.colors.primary,
+                                checkedTrackColor = CelestiaTheme.colors.primary.copy(alpha = 0.5f),
+                            ),
+                        )
+                    }
                 }
 
                 Spacer(Modifier.height(8.dp))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
@@ -127,13 +127,22 @@ fun CelestiaTheme(
         if (customization.experimentalColorOverridesEnabled && customization.colorOverrides.isNotEmpty()) {
             val o = customization.colorOverrides
             c = c.copy(
-                primary    = o[ColorRole.PRIMARY]?.let(::parseHexColorOrNull)    ?: c.primary,
-                secondary  = o[ColorRole.SECONDARY]?.let(::parseHexColorOrNull)  ?: c.secondary,
-                background = o[ColorRole.BACKGROUND]?.let(::parseHexColorOrNull) ?: c.background,
-                surface    = o[ColorRole.SURFACE]?.let(::parseHexColorOrNull)    ?: c.surface,
-                success    = o[ColorRole.SUCCESS]?.let(::parseHexColorOrNull)    ?: c.success,
-                error      = o[ColorRole.ERROR]?.let(::parseHexColorOrNull)      ?: c.error,
-                outline    = o[ColorRole.OUTLINE]?.let(::parseHexColorOrNull)    ?: c.outline,
+                primary        = o[ColorRole.PRIMARY]?.let(::parseHexColorOrNull)        ?: c.primary,
+                secondary      = o[ColorRole.SECONDARY]?.let(::parseHexColorOrNull)      ?: c.secondary,
+                background     = o[ColorRole.BACKGROUND]?.let(::parseHexColorOrNull)     ?: c.background,
+                surface        = o[ColorRole.SURFACE]?.let(::parseHexColorOrNull)        ?: c.surface,
+                success        = o[ColorRole.SUCCESS]?.let(::parseHexColorOrNull)        ?: c.success,
+                error          = o[ColorRole.ERROR]?.let(::parseHexColorOrNull)          ?: c.error,
+                outline        = o[ColorRole.OUTLINE]?.let(::parseHexColorOrNull)        ?: c.outline,
+                // editor-4 additions
+                textPrimary    = o[ColorRole.TEXT_PRIMARY]?.let(::parseHexColorOrNull)   ?: c.textPrimary,
+                textSecondary  = o[ColorRole.TEXT_SECONDARY]?.let(::parseHexColorOrNull) ?: c.textSecondary,
+                progressAccent = o[ColorRole.PROGRESS_ACCENT]?.let(::parseHexColorOrNull) ?: c.progressAccent,
+                warnAccent     = o[ColorRole.WARN_ACCENT]?.let(::parseHexColorOrNull)    ?: c.warnAccent,
+                criticalAccent = o[ColorRole.CRITICAL_ACCENT]?.let(::parseHexColorOrNull) ?: c.criticalAccent,
+                // GLASS_ALPHA stored as plain "0.55" string in the
+                // overrides map; parse to Float and clamp.
+                glassAlpha     = o[ColorRole.GLASS_ALPHA]?.toFloatOrNull()?.coerceIn(0f, 1f) ?: c.glassAlpha,
             )
         }
         c

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/theme/StyleSpec.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/theme/StyleSpec.kt
@@ -90,3 +90,24 @@ val BrutStyle = StyleSpec(
 )
 
 val LocalStyle = staticCompositionLocalOf { CelestiaStyle }
+
+/**
+ * Layer per-token user overrides on top of this preset. Null fields
+ * in [overrides] keep the preset's value; non-null fields drift the
+ * named token only. Editor-4 wires this into the AppShell theme
+ * resolution chain so the user can fine-tune corner radius, border
+ * weight, animation speed, etc. without abandoning the active
+ * UiStyle preset entirely.
+ */
+fun StyleSpec.applyOverrides(
+    overrides: hivens.ui.customization.StyleOverrides?,
+): StyleSpec {
+    if (overrides == null) return this
+    return copy(
+        cardCorner          = overrides.cardCornerDp?.let { it.dp } ?: cardCorner,
+        cardBorder          = overrides.cardBorderDp?.let { it.dp } ?: cardBorder,
+        buttonCorner        = overrides.buttonCornerDp?.let { it.dp } ?: buttonCorner,
+        animationMultiplier = overrides.animationMultiplier ?: animationMultiplier,
+        softGlowEnabled     = overrides.softGlowEnabled ?: softGlowEnabled,
+    )
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/theme/StyleSpecOverridesTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/theme/StyleSpecOverridesTest.kt
@@ -1,0 +1,51 @@
+package hivens.ui.theme
+
+import androidx.compose.ui.unit.dp
+import hivens.ui.customization.StyleOverrides
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class StyleSpecOverridesTest {
+
+    @Test
+    fun `null overrides return the same spec instance`() {
+        assertSame(CelestiaStyle, CelestiaStyle.applyOverrides(null))
+    }
+
+    @Test
+    fun `empty overrides leaves every field untouched`() {
+        val out = CelestiaStyle.applyOverrides(StyleOverrides())
+        assertEquals(CelestiaStyle.cardCorner, out.cardCorner)
+        assertEquals(CelestiaStyle.cardBorder, out.cardBorder)
+        assertEquals(CelestiaStyle.buttonCorner, out.buttonCorner)
+        assertEquals(CelestiaStyle.animationMultiplier, out.animationMultiplier)
+        assertEquals(CelestiaStyle.softGlowEnabled, out.softGlowEnabled)
+        assertEquals(CelestiaStyle.cardSurface, out.cardSurface)
+    }
+
+    @Test
+    fun `partial overrides only touch the named fields`() {
+        val out = CelestiaStyle.applyOverrides(
+            StyleOverrides(
+                cardCornerDp        = 4f,
+                animationMultiplier = 0.5f,
+            ),
+        )
+        assertEquals(4.dp, out.cardCorner)
+        assertEquals(0.5f, out.animationMultiplier)
+        // Unchanged fields keep preset values
+        assertEquals(CelestiaStyle.cardBorder, out.cardBorder)
+        assertEquals(CelestiaStyle.buttonCorner, out.buttonCorner)
+        assertEquals(CelestiaStyle.softGlowEnabled, out.softGlowEnabled)
+    }
+
+    @Test
+    fun `softGlow override flips the boolean`() {
+        val out = CelestiaStyle.applyOverrides(StyleOverrides(softGlowEnabled = false))
+        assertEquals(false, out.softGlowEnabled)
+        // Brut-base + soft-glow-on override should restore the glow
+        val outBrut = BrutStyle.applyOverrides(StyleOverrides(softGlowEnabled = true))
+        assertEquals(true, outBrut.softGlowEnabled)
+    }
+}


### PR DESCRIPTION
Stacked on #264.

Closes the "theme tokens not editable" gap. CustomizationExtensionScreen now exposes the previously palette-locked color tokens (text, severity, glass alpha) + the StyleSpec form/motion tokens (corners, border, animation speed, glow). Live preview via existing LocalCustomization recomposition.

## Tokens added (all gated behind experimentalColorOverridesEnabled)

- ColorRole: TEXT_PRIMARY, TEXT_SECONDARY, GLASS_ALPHA, PROGRESS_ACCENT, WARN_ACCENT, CRITICAL_ACCENT
- StyleOverrides: cardCornerDp, cardBorderDp, buttonCornerDp, animationMultiplier, softGlowEnabled

## UI

Three new sections appended to CustomizationExtensionScreen:
- "Текст и акценты" -- HexField rows
- "Прозрачность стекла" -- slider on glass alpha
- "Форма и движение" -- sliders + glow switch

## Test plan

- [x] \`:client-ui:desktopTest\` -- new \`StyleSpecOverridesTest\` 4 green
- [ ] Smoke: Settings -> Customization Extension -> enable experimental -> see new sections
- [ ] Smoke: pull a slider -> launcher re-themes live