### PR TITLE
feat(editor): editor-5 -- presets (Phase 2 done)

### DIFF
--- a/client-config/src/main/kotlin/hivens/config/Storage.kt
+++ b/client-config/src/main/kotlin/hivens/config/Storage.kt
@@ -9,4 +9,5 @@ object Storage {
     const val PACKS_FILE            = "packs.json"
     const val SERVERS_CACHE_FILE    = "servers-cache.json"
     const val LAYOUT_GRAPH_FILE     = "layout-graph.json"
+    const val PRESETS_DIR           = "presets"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -112,7 +112,14 @@ fun AppLayout(
 
         // ── Main content ──────────────────────────────────────────────────
         Box(Modifier.weight(1f).fillMaxHeight()) {
-          EditorSurfaceHost(currentScreen = currentScreen, homeView = homeView) {
+          EditorSurfaceHost(
+              currentScreen          = currentScreen,
+              homeView               = homeView,
+              customization          = customization,
+              onCustomizationChanged = onCustomizationChanged,
+              uiStyle                = uiStyle,
+              onUiStyleChanged       = onUiStyleChanged,
+          ) {
             // Screen-to-screen Crossfade duration follows the active
             // style. Under Brut (animationMultiplier = 0) the swap is
             // effectively instant; under Celestia keeps the 180ms fade.

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -11,9 +11,12 @@ import hivens.ui.notifications.NotificationCenter
 import hivens.ui.notifications.SessionRegistry
 import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetServerLoader
+import hivens.config.Storage
 import hivens.ui.audio.AudioPlayer
 import hivens.ui.editor.EditModeController
+import hivens.ui.editor.presets.PresetRepository
 import hivens.ui.utils.GameConsoleService
+import java.nio.file.Path
 import hivens.widget.api.WidgetRegistry
 import hivens.widget.generated.GeneratedWidgetRegistry
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -45,6 +48,17 @@ val uiModule = module {
     // playback state lives in the singleton so swapping the widget
     // out of the layout does not stop playback.
     single { AudioPlayer(scope = get()) }
+
+    // Preset storage. One file per preset under <dataDir>/presets/.
+    // Atomic write + share-by-file design lets users export to
+    // anywhere.
+    single {
+        val dataDir: Path = get()
+        PresetRepository(
+            presetsDir = dataDir.resolve(Storage.PRESETS_DIR),
+            json       = get(),
+        )
+    }
 
     // Notification subsystem: data-only state holders (Center +
     // Registry) are pure singletons; PackLaunchDriver bridges them

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.ViewQuilt
 import androidx.compose.material.icons.filled.ViewSidebar
@@ -69,7 +70,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import hivens.core.data.HomeView
+import hivens.core.data.UiStyle
+import hivens.launcher.LayoutGraphRepository
 import hivens.ui.Screen
+import hivens.ui.customization.CustomizationSettings
+import hivens.widget.api.LocalLayoutGraph
+import kotlinx.coroutines.CoroutineScope as KotlinCoroutineScope
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
 import hivens.ui.editor.decoration.EditableWidgetChrome
 import hivens.ui.editor.decoration.EmptySlotPlaceholder
 import hivens.ui.editor.dnd.DragController
@@ -78,6 +86,10 @@ import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.editor.dnd.LocalDragController
 import hivens.ui.editor.dnd.LocalDropTargetRegistry
 import hivens.ui.editor.palette.WidgetPalettePanel
+import hivens.ui.editor.presets.PresetEnvelope
+import hivens.ui.editor.presets.PresetManagerPanel
+import hivens.ui.editor.presets.PresetMeta
+import hivens.ui.editor.presets.PresetRepository
 import hivens.ui.widgets.home.classic.LocalHomeClassicContext
 import hivens.ui.widgets.home.new.LocalHomeNewContext
 import hivens.ui.widgets.library.LocalLibraryContext
@@ -111,19 +123,28 @@ import org.koin.compose.koinInject
 fun EditorSurfaceHost(
     currentScreen: Screen,
     homeView: HomeView,
+    customization: CustomizationSettings = CustomizationSettings(),
+    onCustomizationChanged: (CustomizationSettings) -> Unit = {},
+    uiStyle: UiStyle = UiStyle.Celestia,
+    onUiStyleChanged: (UiStyle) -> Unit = {},
     content: @Composable () -> Unit,
 ) {
     val availableSurfaces: List<SurfaceId> = remember(currentScreen, homeView) {
         availableSurfacesFor(currentScreen, homeView)
     }
     val controller: EditModeController = koinInject()
+    val layoutRepo: LayoutGraphRepository = koinInject()
+    val presetRepo: PresetRepository      = koinInject()
+    val coroutineScope = rememberCoroutineScope()
 
     var editing       by remember(availableSurfaces) { mutableStateOf(false) }
     var paletteOpen   by remember(availableSurfaces) { mutableStateOf(true) }
     var previewing    by remember(availableSurfaces) { mutableStateOf(false) }
+    var presetPanelOpen by remember(availableSurfaces) { mutableStateOf(false) }
     var selectedSurface by remember(availableSurfaces) {
         mutableStateOf(availableSurfaces.firstOrNull())
     }
+    val currentGraph = LocalLayoutGraph.current
     // Leaving a surface drops edit mode -- avoids a stale edit state
     // pointed at the wrong surface after navigation.
     val state: EditModeState = remember(editing, selectedSurface) {
@@ -264,7 +285,59 @@ fun EditorSurfaceHost(
                     onTogglePalette   = { paletteOpen = !paletteOpen },
                     previewing        = previewing,
                     onTogglePreview   = { previewing = !previewing },
+                    onOpenPresets     = { presetPanelOpen = true },
                     modifier          = Modifier.align(Alignment.TopCenter).padding(top = 16.dp),
+                )
+
+                PresetManagerPanel(
+                    visible       = editing && presetPanelOpen,
+                    onDismiss     = { presetPanelOpen = false },
+                    onSaveCurrent = { name ->
+                        val envelope = PresetEnvelope(
+                            name          = name,
+                            createdAt     = System.currentTimeMillis(),
+                            graph         = currentGraph,
+                            customization = customization,
+                            uiStyle       = uiStyle,
+                        )
+                        coroutineScope.launch {
+                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                presetRepo.save(envelope)
+                            }
+                        }
+                    },
+                    onLoad = { meta ->
+                        coroutineScope.launch {
+                            val env = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                presetRepo.load(meta.name)
+                            } ?: return@launch
+                            layoutRepo.update { env.graph }
+                            onCustomizationChanged(env.customization)
+                            onUiStyleChanged(env.uiStyle)
+                            presetPanelOpen = false
+                        }
+                    },
+                    onDelete = { meta ->
+                        coroutineScope.launch {
+                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                presetRepo.delete(meta.name)
+                            }
+                        }
+                    },
+                    onExport = { meta ->
+                        // Open the parent dir in the OS file manager and
+                        // let the user copy from there. Avoids depending
+                        // on a save-file dialog API that the current
+                        // FileKit version does not expose.
+                        coroutineScope.launch {
+                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                runCatching {
+                                    java.awt.Desktop.getDesktop().open(meta.sourcePath.parent.toFile())
+                                }
+                            }
+                        }
+                    },
+                    listProvider = { presetRepo.list() },
                 )
 
                 WidgetPalettePanel(
@@ -377,6 +450,7 @@ private fun EditModePill(
     onTogglePalette: () -> Unit,
     previewing: Boolean,
     onTogglePreview: () -> Unit,
+    onOpenPresets: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -433,6 +507,15 @@ private fun EditModePill(
                     label    = if (paletteOpen) "Скрыть" else "Виджеты",
                     selected = paletteOpen,
                     onClick  = onTogglePalette,
+                )
+                Spacer(Modifier.width(4.dp))
+
+                // Presets dialog.
+                ToolChip(
+                    icon     = Icons.Default.Inventory2,
+                    label    = "Пресеты",
+                    selected = false,
+                    onClick  = onOpenPresets,
                 )
                 Spacer(Modifier.width(10.dp))
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetEnvelope.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetEnvelope.kt
@@ -1,0 +1,32 @@
+package hivens.ui.editor.presets
+
+import hivens.core.data.UiStyle
+import hivens.ui.customization.CustomizationSettings
+import hivens.widget.model.LayoutGraph
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// One named preset = a snapshot of (LayoutGraph + CustomizationSettings
+// + UiStyle). Save: capture current state. Load: restore all three at
+// once. Persisted as one file per preset under <dataDir>/presets/.
+//
+// schema_version: bump when the shape changes. Forward-compat handled
+// by Json { ignoreUnknownKeys = true } in PresetRepository.
+@Serializable
+data class PresetEnvelope(
+    @SerialName("schema_version") val schemaVersion: Int = 1,
+    val name: String,
+    @SerialName("created_at") val createdAt: Long,
+    val graph: LayoutGraph,
+    val customization: CustomizationSettings,
+    val uiStyle: UiStyle,
+)
+
+// Light metadata for listing without loading the full envelope. Useful
+// for the PresetManagerPanel which only needs name + mtime for the
+// row UI.
+data class PresetMeta(
+    val name: String,
+    val createdAt: Long,
+    val sourcePath: java.nio.file.Path,
+)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetManagerPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetManagerPanel.kt
@@ -1,0 +1,293 @@
+package hivens.ui.editor.presets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import hivens.ui.theme.CelestiaTheme
+import java.text.DateFormat
+import java.util.Date
+
+// Modal preset manager. Reached via the "Presets" chip on the
+// edit-mode pill. Lists existing presets with Load / Delete / Export
+// per row, plus a "Save current as..." text field at top.
+@Composable
+fun PresetManagerPanel(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onSaveCurrent: (String) -> Unit,
+    onLoad: (PresetMeta) -> Unit,
+    onDelete: (PresetMeta) -> Unit,
+    onExport: (PresetMeta) -> Unit,
+    listProvider: () -> List<PresetMeta>,
+) {
+    if (!visible) return
+
+    var presets by remember(visible) { mutableStateOf(listProvider()) }
+    var newName by remember(visible) { mutableStateOf("") }
+    LaunchedEffect(visible) {
+        if (visible) presets = listProvider()
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            color           = CelestiaTheme.colors.surface,
+            shape           = RoundedCornerShape(16.dp),
+            shadowElevation = 18.dp,
+            modifier        = Modifier
+                .width(520.dp)
+                .height(620.dp)
+                .shadow(elevation = 24.dp, shape = RoundedCornerShape(16.dp)),
+        ) {
+            Column(Modifier.fillMaxSize().padding(20.dp)) {
+                // Header
+                Row(
+                    verticalAlignment     = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier              = Modifier.fillMaxWidth(),
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector        = Icons.Default.Inventory2,
+                            contentDescription = null,
+                            tint               = CelestiaTheme.colors.primary,
+                            modifier           = Modifier.size(22.dp),
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Text(
+                            text       = "Пресеты",
+                            style      = MaterialTheme.typography.titleMedium,
+                            color      = CelestiaTheme.colors.textPrimary,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "Закрыть",
+                             tint = CelestiaTheme.colors.textSecondary)
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text  = "Снимок layout + темы + стиля. Сохрани сейчас, загрузи когда угодно.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                // Save row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.55f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                ) {
+                    BasicTextField(
+                        value         = newName,
+                        onValueChange = { newName = it },
+                        singleLine    = true,
+                        textStyle     = TextStyle(
+                            color    = CelestiaTheme.colors.textPrimary,
+                            fontSize = 14.sp,
+                        ),
+                        cursorBrush   = SolidColor(CelestiaTheme.colors.primary),
+                        modifier      = Modifier.weight(1f),
+                        decorationBox = { inner ->
+                            if (newName.isEmpty()) {
+                                Text(
+                                    text  = "Имя пресета...",
+                                    color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                            inner()
+                        },
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Button(
+                        onClick = {
+                            val n = newName.trim()
+                            if (n.isNotEmpty()) {
+                                onSaveCurrent(n)
+                                newName = ""
+                                presets = listProvider()
+                            }
+                        },
+                        shape   = RoundedCornerShape(8.dp),
+                        enabled = newName.isNotBlank(),
+                        colors  = ButtonDefaults.buttonColors(
+                            containerColor = CelestiaTheme.colors.primary,
+                            contentColor   = Color.White,
+                        ),
+                    ) {
+                        Icon(Icons.Default.Save, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("Сохранить", fontWeight = FontWeight.Medium)
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text(
+                    text       = "Сохранённые (${presets.size})",
+                    style      = MaterialTheme.typography.labelMedium,
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(Modifier.height(8.dp))
+
+                if (presets.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.35f)),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text  = "Пусто. Сохрани текущий layout как первый пресет.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = CelestiaTheme.colors.textSecondary,
+                        )
+                    }
+                } else {
+                    LazyColumn(
+                        modifier            = Modifier.fillMaxWidth().weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        items(items = presets, key = { it.name }) { meta ->
+                            PresetRow(
+                                meta     = meta,
+                                onLoad   = { onLoad(meta) },
+                                onDelete = {
+                                    onDelete(meta)
+                                    presets = listProvider()
+                                },
+                                onExport = { onExport(meta) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetRow(
+    meta: PresetMeta,
+    onLoad: () -> Unit,
+    onDelete: () -> Unit,
+    onExport: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.55f))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text       = meta.name,
+                style      = MaterialTheme.typography.bodyLarge,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.SemiBold,
+                maxLines   = 1,
+                overflow   = TextOverflow.Ellipsis,
+            )
+            Text(
+                text       = formatTime(meta.createdAt),
+                style      = MaterialTheme.typography.labelSmall,
+                color      = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f),
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        Button(
+            onClick = onLoad,
+            shape   = RoundedCornerShape(8.dp),
+            colors  = ButtonDefaults.buttonColors(
+                containerColor = CelestiaTheme.colors.primary,
+                contentColor   = Color.White,
+            ),
+        ) {
+            Text("Применить", fontWeight = FontWeight.Medium, style = MaterialTheme.typography.labelMedium)
+        }
+        Spacer(Modifier.width(4.dp))
+        IconButton(onClick = onExport, modifier = Modifier.size(36.dp)) {
+            Icon(
+                imageVector        = Icons.Default.Upload,
+                contentDescription = "Экспорт",
+                tint               = CelestiaTheme.colors.textSecondary,
+                modifier           = Modifier.size(18.dp),
+            )
+        }
+        IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+            Icon(
+                imageVector        = Icons.Default.Delete,
+                contentDescription = "Удалить",
+                tint               = CelestiaTheme.colors.error,
+                modifier           = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+private fun formatTime(epochMs: Long): String {
+    if (epochMs <= 0L) return ""
+    return DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(epochMs))
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetRepository.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/presets/PresetRepository.kt
@@ -1,0 +1,95 @@
+package hivens.ui.editor.presets
+
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.copyTo
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
+
+// File-per-preset under <dataDir>/presets/<safe-name>.json. Per-file
+// scheme makes share / import dead simple (just hand someone the
+// file). Atomic write via .tmp + ATOMIC_MOVE mirrors
+// LayoutGraphRepository.persist.
+class PresetRepository(
+    private val presetsDir: Path,
+    private val json: Json,
+) {
+    private val log = LoggerFactory.getLogger(PresetRepository::class.java)
+
+    fun list(): List<PresetMeta> {
+        if (!Files.exists(presetsDir)) return emptyList()
+        return Files.list(presetsDir).use { stream ->
+            stream
+                .filter { it.isRegularFile() && it.name.endsWith(".json") }
+                .map { path ->
+                    val name = path.name.removeSuffix(".json")
+                    val mtime = runCatching { Files.getLastModifiedTime(path).toMillis() }
+                        .getOrDefault(0L)
+                    PresetMeta(name = name, createdAt = mtime, sourcePath = path)
+                }
+                .sorted(compareByDescending { it.createdAt })
+                .toList()
+        }
+    }
+
+    fun load(name: String): PresetEnvelope? {
+        val path = presetsDir.resolve("${sanitize(name)}.json")
+        if (!Files.exists(path)) return null
+        return try {
+            json.decodeFromString<PresetEnvelope>(Files.readString(path))
+        } catch (e: Exception) {
+            log.warn("Failed to load preset {}: {}", name, e.message)
+            null
+        }
+    }
+
+    fun save(envelope: PresetEnvelope) {
+        Files.createDirectories(presetsDir)
+        val target = presetsDir.resolve("${sanitize(envelope.name)}.json")
+        val tmp = target.resolveSibling("${target.fileName}.tmp")
+        Files.writeString(tmp, json.encodeToString(envelope))
+        try {
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+            log.warn(
+                "Filesystem at {} does not support ATOMIC_MOVE; falling back to non-atomic rename for preset {}",
+                presetsDir, envelope.name,
+            )
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    fun delete(name: String): Boolean {
+        val path = presetsDir.resolve("${sanitize(name)}.json")
+        return Files.deleteIfExists(path)
+    }
+
+    fun export(name: String, destination: Path): Boolean {
+        val source = presetsDir.resolve("${sanitize(name)}.json")
+        if (!Files.exists(source)) return false
+        source.copyTo(destination, overwrite = true)
+        return true
+    }
+
+    fun import(source: Path): PresetEnvelope? {
+        return try {
+            val envelope = json.decodeFromString<PresetEnvelope>(Files.readString(source))
+            save(envelope)
+            envelope
+        } catch (e: Exception) {
+            log.warn("Failed to import preset from {}: {}", source, e.message)
+            null
+        }
+    }
+
+    // Filename sanitization. [A-Za-z0-9_-] passes; everything else
+    // becomes underscore. Empty result coerces to "preset". Prevents
+    // path traversal + filesystem-illegal chars (slash, colon, etc.).
+    private fun sanitize(name: String): String {
+        val cleaned = name.trim().replace(Regex("[^A-Za-z0-9_\\-]"), "_")
+        return cleaned.ifBlank { "preset" }
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/presets/PresetRepositoryTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/presets/PresetRepositoryTest.kt
@@ -1,0 +1,122 @@
+package hivens.ui.editor.presets
+
+import hivens.core.data.UiStyle
+import hivens.ui.customization.CustomizationSettings
+import hivens.widget.model.LayoutGraph
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PresetRepositoryTest {
+
+    private lateinit var tmp: Path
+    private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true; coerceInputValues = true }
+
+    @BeforeTest
+    fun setup() {
+        tmp = Files.createTempDirectory("preset-repo-test")
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(tmp).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    private fun newRepo() = PresetRepository(tmp.resolve("presets"), json)
+
+    private fun envelope(name: String) = PresetEnvelope(
+        name          = name,
+        createdAt     = 1_700_000_000L,
+        graph         = LayoutGraph.EMPTY,
+        customization = CustomizationSettings(),
+        uiStyle       = UiStyle.Celestia,
+    )
+
+    @Test
+    fun `save round-trips through load`() {
+        val repo = newRepo()
+        repo.save(envelope("Music mode"))
+        val back = repo.load("Music mode")
+        assertNotNull(back)
+        assertEquals("Music mode", back.name)
+        assertEquals(UiStyle.Celestia, back.uiStyle)
+    }
+
+    @Test
+    fun `list returns presets newest-first`() {
+        val repo = newRepo()
+        repo.save(envelope("Alpha"))
+        Thread.sleep(15)
+        repo.save(envelope("Beta"))
+        val list = repo.list()
+        assertEquals(listOf("Beta", "Alpha"), list.map { it.name })
+    }
+
+    @Test
+    fun `delete removes the file`() {
+        val repo = newRepo()
+        repo.save(envelope("Doomed"))
+        assertTrue(tmp.resolve("presets/Doomed.json").exists())
+        assertTrue(repo.delete("Doomed"))
+        assertFalse(tmp.resolve("presets/Doomed.json").exists())
+        assertNull(repo.load("Doomed"))
+    }
+
+    @Test
+    fun `delete of unknown name returns false`() {
+        val repo = newRepo()
+        assertFalse(repo.delete("ghost"))
+    }
+
+    @Test
+    fun `sanitization replaces unsafe chars and prevents traversal`() {
+        val repo = newRepo()
+        repo.save(envelope("../../etc/passwd"))
+        // Sanitized to underscores; original path traversal does not
+        // escape the presets dir.
+        val files = Files.list(tmp.resolve("presets")).use { it.toList() }
+        assertEquals(1, files.size)
+        assertTrue(files.first().name.endsWith(".json"))
+        assertFalse(files.first().name.contains("/"))
+        assertFalse(files.first().name.contains(".."))
+    }
+
+    @Test
+    fun `export copies the file to destination`() {
+        val repo = newRepo()
+        repo.save(envelope("Backup"))
+        val dest = tmp.resolve("out/Backup.json")
+        Files.createDirectories(dest.parent)
+        assertTrue(repo.export("Backup", dest))
+        assertTrue(dest.exists())
+    }
+
+    @Test
+    fun `import round-trips through the presets dir`() {
+        val repo = newRepo()
+        val external = tmp.resolve("incoming.json")
+        Files.writeString(external, json.encodeToString(envelope("Imported")))
+        val imported = repo.import(external)
+        assertNotNull(imported)
+        assertEquals("Imported", imported.name)
+        assertNotNull(repo.load("Imported"))
+    }
+
+    @Test
+    fun `corrupt file returns null on load instead of throwing`() {
+        val repo = newRepo()
+        Files.createDirectories(tmp.resolve("presets"))
+        Files.writeString(tmp.resolve("presets/Bad.json"), "{this is not json")
+        assertNull(repo.load("Bad"))
+    }
+}


### PR DESCRIPTION
Stacked on #265. Final sub-PR of Phase 2.

## What you get

- **"Пресеты" chip** on the edit-mode pill opens a modal dialog
- **Save current as...** with a text field at top
- **Per-preset row:** name + creation date + Apply / Export (opens parent dir in OS file manager) / Delete
- **One file per preset** at \`<dataDir>/presets/<safe-name>.json\` -- share = hand someone the JSON
- **Filename sanitization** prevents traversal + filesystem-illegal chars
- **Atomic write** via .tmp + ATOMIC_MOVE (same as LayoutGraphRepository / JsonPackRepository)

## Architecture

- \`PresetEnvelope\` snapshots \`LayoutGraph + CustomizationSettings + UiStyle\` together
- \`PresetRepository\` (Koin singleton) does file IO; \`PresetManagerPanel\` is the UI
- \`EditorSurfaceHost\` threads \`customization + onCustomizationChanged + uiStyle + onUiStyleChanged\` from AppLayout so Apply can restore all three at once

## Phase 2 status: closed

editor-1 through editor-5 + the in-between bug fixes ship the full widget editor. Remaining umbrella work (plugins, node-graph, per-widget prop schema, FileKit saver) is Phase 3+.

## Test plan

- [x] \`:client-ui:desktopTest\` -- 8 \`PresetRepositoryTest\` green (round-trip / newest-first / delete / sanitization / export / import / corrupt-fallback)
- [ ] Smoke: edit mode -> Пресеты chip -> save -> rearrange -> load -> restored
- [ ] Smoke: Export -> system file manager opens at presets directory