### PR TITLE
fix(editor): post-Phase 2 smoke + audio polish

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/audio/AudioPlayer.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/audio/AudioPlayer.kt
@@ -7,17 +7,21 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.DataLine
+import javax.sound.sampled.FloatControl
 import javax.sound.sampled.LineUnavailableException
 import javax.sound.sampled.SourceDataLine
 import javax.sound.sampled.UnsupportedAudioFileException
 import kotlin.io.path.name
+import kotlin.math.log10
 
 // In-process audio playback for the MusicPlayerWidget. Pure
 // javax.sound.sampled -- WAV / AU / AIFF / SND supported out of the
@@ -35,14 +39,22 @@ class AudioPlayer(private val scope: CoroutineScope) {
     private val _state = MutableStateFlow<PlaybackState>(PlaybackState.Idle)
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
+    private val _volume = MutableStateFlow(1.0f)
+    val volume: StateFlow<Float> = _volume.asStateFlow()
+
     private var line: SourceDataLine? = null
     private var playbackJob: Job? = null
     private var currentFile: Path? = null
     private var currentFormat: AudioFormat? = null
     private var totalFrames: Long = 0L
+    // Frame offset to start the next play() at -- nonzero only when we
+    // resumed from pause. Reset when a new file opens, stop fires, or
+    // playback ends naturally.
+    private var resumeFrameOffset: Long = 0L
 
     fun open(file: Path) {
         stop()
+        resumeFrameOffset = 0L
         currentFile = file
         try {
             val stream = AudioSystem.getAudioInputStream(file.toAbsolutePath().toFile())
@@ -74,6 +86,21 @@ class AudioPlayer(private val scope: CoroutineScope) {
         if (current is PlaybackState.Playing) return
         val format = currentFormat ?: return
 
+        val startOffset = resumeFrameOffset
+        val frameRate = format.frameRate
+        val initialDurationMs = if (frameRate > 0f && totalFrames > 0L) {
+            totalFrames * 1000L / frameRate.toLong()
+        } else 0L
+        val initialPositionMs = if (frameRate > 0f) {
+            startOffset * 1000L / frameRate.toLong()
+        } else 0L
+        // Set Playing up-front so pause() racing against the coroutine
+        // has a clear sentinel to flip. The position-update loop below
+        // only emits Playing when the current state is still Playing --
+        // any pause() that lands during a blocking newLine.write will
+        // not be overwritten by a trailing emit.
+        _state.value = PlaybackState.Playing(file, initialPositionMs, initialDurationMs)
+
         playbackJob?.cancel()
         playbackJob = scope.launch(Dispatchers.IO) {
             var newStream = AudioSystem.getAudioInputStream(file.toAbsolutePath().toFile())
@@ -81,13 +108,17 @@ class AudioPlayer(private val scope: CoroutineScope) {
                 val info = DataLine.Info(SourceDataLine::class.java, format)
                 val newLine = AudioSystem.getLine(info) as SourceDataLine
                 newLine.open(format)
+                applyVolumeTo(newLine)
                 newLine.start()
                 line = newLine
 
                 val frameSize = format.frameSize
+                if (startOffset > 0L) {
+                    skipExact(newStream, startOffset * frameSize.toLong())
+                }
                 val buffer = ByteArray(4096)
                 var bytesRead = newStream.read(buffer)
-                var framesPlayed = 0L
+                var framesPlayed = startOffset
                 while (isActive && bytesRead != -1) {
                     newLine.write(buffer, 0, bytesRead)
                     framesPlayed += bytesRead / frameSize
@@ -97,17 +128,27 @@ class AudioPlayer(private val scope: CoroutineScope) {
                     val durationMs = if (format.frameRate > 0f && totalFrames > 0L) {
                         totalFrames * 1000L / format.frameRate.toLong()
                     } else 0L
-                    _state.value = PlaybackState.Playing(
-                        file       = file,
-                        positionMs = positionMs,
-                        durationMs = durationMs,
-                    )
+                    // Atomic update: a pause() landing between the read
+                    // and the write would flip state to Paused. Without
+                    // CAS, this branch could overwrite Paused back to
+                    // Playing (the original double-click bug).
+                    _state.update { snapshot ->
+                        if (snapshot is PlaybackState.Playing) {
+                            PlaybackState.Playing(file, positionMs, durationMs)
+                        } else snapshot
+                    }
                     bytesRead = newStream.read(buffer)
                 }
-                newLine.drain()
-                newLine.close()
-                line = null
-                if (isActive) {
+                // Cleanup is best-effort: pause()/stop() may have already
+                // stopped+flushed (or closed) the line. drain on a
+                // stopped/flushed line returns immediately, but a second
+                // close throws -- runCatching keeps us out of the Error
+                // branch on that benign race.
+                runCatching { newLine.drain() }
+                runCatching { newLine.close() }
+                if (line === newLine) line = null
+                if (isActive && _state.value is PlaybackState.Playing) {
+                    resumeFrameOffset = 0L
                     _state.value = PlaybackState.Ready(file, positionMs = 0L, durationMs = 0L)
                 }
             } catch (e: LineUnavailableException) {
@@ -123,17 +164,27 @@ class AudioPlayer(private val scope: CoroutineScope) {
     }
 
     fun pause() {
-        // javax.sound.sampled has no pause primitive; stop the line
-        // and remember where we are. resume = play() (restarts the
-        // stream from beginning -- limitation of the simple shape;
-        // proper seek requires building a buffered position-stream).
-        line?.stop()
-        line?.close()
-        line = null
+        // javax.sound.sampled has no pause primitive. Stop and flush
+        // the line to unblock any pending newLine.write, then update
+        // state via CAS so a trailing emit from the play coroutine
+        // (already past its is-Playing check) cannot flip us back.
+        // Real seek lands with Skinema (FFmpeg via Panama).
         val current = _state.value
-        if (current is PlaybackState.Playing) {
-            _state.value = PlaybackState.Paused(current.file, current.positionMs, current.durationMs)
+        if (current !is PlaybackState.Playing) return
+        val frameRate = currentFormat?.frameRate ?: 0f
+        resumeFrameOffset = if (frameRate > 0f) {
+            (current.positionMs * frameRate.toDouble() / 1000.0).toLong()
+        } else 0L
+        _state.update { snapshot ->
+            if (snapshot is PlaybackState.Playing) {
+                PlaybackState.Paused(snapshot.file, snapshot.positionMs, snapshot.durationMs)
+            } else snapshot
         }
+        // Unblock the writer and cancel cleanup. Line is owned by the
+        // play coroutine -- it drains+closes in its finally path; we
+        // only signal here.
+        line?.stop()
+        line?.flush()
         playbackJob?.cancel()
         playbackJob = null
     }
@@ -144,6 +195,7 @@ class AudioPlayer(private val scope: CoroutineScope) {
         line?.stop()
         line?.close()
         line = null
+        resumeFrameOffset = 0L
         val current = _state.value
         if (current is PlaybackState.Playing || current is PlaybackState.Paused) {
             val file = currentFile
@@ -152,6 +204,55 @@ class AudioPlayer(private val scope: CoroutineScope) {
             } else {
                 _state.value = PlaybackState.Idle
             }
+        }
+    }
+
+    // Linear 0..1. The line's MASTER_GAIN control is preferred (every
+    // SourceDataLine on every JDK platform supports it). VOLUME falls
+    // back where the device exposes one but not the other.
+    fun setVolume(level: Float) {
+        val clamped = level.coerceIn(0f, 1f)
+        _volume.value = clamped
+        line?.let { applyVolumeTo(it) }
+    }
+
+    private fun applyVolumeTo(target: SourceDataLine) {
+        runCatching {
+            when {
+                target.isControlSupported(FloatControl.Type.MASTER_GAIN) -> {
+                    val control = target.getControl(FloatControl.Type.MASTER_GAIN) as FloatControl
+                    control.value = linearToDb(_volume.value, control.minimum, control.maximum)
+                }
+                target.isControlSupported(FloatControl.Type.VOLUME) -> {
+                    val control = target.getControl(FloatControl.Type.VOLUME) as FloatControl
+                    control.value = _volume.value.coerceIn(control.minimum, control.maximum)
+                }
+            }
+        }.onFailure { log.warn("Failed to apply volume to audio line", it) }
+    }
+
+    private fun linearToDb(linear: Float, min: Float, max: Float): Float {
+        if (linear <= 0f) return min
+        val db = (20.0 * log10(linear.toDouble())).toFloat()
+        return db.coerceIn(min, max)
+    }
+
+    // AudioInputStream.skip is not contractually exact -- platforms can
+    // return 0 if the stream is unbuffered or refuse to skip past a
+    // mark. Loop until satisfied; fall back to read-and-discard when
+    // skip stops making progress.
+    private fun skipExact(stream: AudioInputStream, bytesToSkip: Long) {
+        var remaining = bytesToSkip
+        val scratch = ByteArray(4096)
+        while (remaining > 0L) {
+            val skipped = stream.skip(remaining)
+            if (skipped > 0L) {
+                remaining -= skipped
+                continue
+            }
+            val n = stream.read(scratch, 0, minOf(remaining, scratch.size.toLong()).toInt())
+            if (n <= 0) return
+            remaining -= n
         }
     }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -64,6 +64,8 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -222,16 +224,15 @@ fun EditorSurfaceHost(
         }
     }
 
-    // Empty-slot decorator: placeholder only on the selected surface
-    // and only when not previewing. Other surfaces' empty slots stay
-    // invisible (matches normal-mode behavior).
+    // Empty-slot decorator: placeholder on every editable surface
+    // while edit mode is on. Chrome filtering is keyed to selection
+    // (interaction focus), but a palette drop should be able to land
+    // on any visible empty slot regardless of which surface chip the
+    // user happens to have active.
     val emptyDecorator: EmptySlotDecorator = remember(state, registry, previewing) {
         if (state is EditModeState.On && !previewing) {
-            val selected = state.surface
             { address ->
-                if (address.surface == selected) {
-                    EmptySlotPlaceholder(address = address, registry = registry)
-                }
+                EmptySlotPlaceholder(address = address, registry = registry)
             }
         } else {
             {}
@@ -649,13 +650,15 @@ private fun EditModeVignette(active: Boolean) {
 @Composable
 private fun DragGhostOverlay(dragController: DragController) {
     val active = dragController.active ?: return
-    val density = LocalDensity.current
-    // pointerInWindow + pickupOffset is the widget-origin in window
-    // coords; the ghost should sit there. We render through graphicsLayer
-    // to avoid layout invalidation when the offset changes.
+    // The OS cursor is hidden for the duration of the drag by attaching
+    // a transparent AWT cursor as the hover icon of this fullscreen
+    // overlay. pointerHoverIcon does not intercept pointer events, so
+    // the underlying drag handler keeps receiving updates.
+    val transparentCursor = remember { transparentPointerIcon() }
     Box(
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .pointerHoverIcon(icon = transparentCursor, overrideDescendants = true),
     ) {
         Box(
             modifier = Modifier
@@ -673,6 +676,13 @@ private fun DragGhostOverlay(dragController: DragController) {
             active.ghost()
         }
     }
+}
+
+private fun transparentPointerIcon(): PointerIcon {
+    val image = java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    val cursor = java.awt.Toolkit.getDefaultToolkit()
+        .createCustomCursor(image, java.awt.Point(0, 0), "drag-ghost")
+    return PointerIcon(cursor)
 }
 
 // ── Surface routing ─────────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -45,6 +48,7 @@ import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.editor.dnd.dragSource
 import hivens.ui.editor.dnd.widgetBounds
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.LocalLayoutGraph
 import hivens.widget.api.WidgetDescriptor
 import hivens.widget.model.SlotAddress
 import hivens.widget.model.WidgetInstance
@@ -75,6 +79,20 @@ fun EditableWidgetChrome(
     val isThisDragging = (activeDrag?.payload as? DragPayload.ExistingWidget)
         ?.instance?.instanceId == instance.instanceId
 
+    // Drop-indicator hit test. Reading controller.active recomposes on
+    // every pointer update; the registry queries are O(widgets-in-slot)
+    // and cheap enough to do per-frame for the few dozen widgets a
+    // surface can hold.
+    val graph = LocalLayoutGraph.current
+    val slotCount = graph.surfaces[address.surface]?.slots?.get(address.slot)?.widgets?.size ?: 0
+    val isLastInSlot = index == slotCount - 1
+    val dropTargetSlot = activeDrag?.let { registry.slotForPoint(it.pointerInWindow) }
+    val dropInsertionIdx = if (activeDrag != null && dropTargetSlot == address) {
+        registry.insertionIndexInSlot(address, activeDrag.pointerInWindow)
+    } else -1
+    val showIndicatorBefore = dropInsertionIdx == index
+    val showIndicatorAfter  = isLastInSlot && dropInsertionIdx == slotCount
+
     // The ghost lambda is invoked by DragGhostOverlay at the host
     // level -- outside the surface composable's CompositionLocalProvider
     // chain. Widgets like HomeNewRecent read surface-scoped locals
@@ -97,84 +115,103 @@ fun EditableWidgetChrome(
         label         = "edit-border-alpha",
     )
 
-    Box(
-        modifier = Modifier
-            .hoverable(interaction)
-            .onGloballyPositioned { coords: LayoutCoordinates ->
-                val rect = coords.boundsInWindow()
-                widgetWindowBounds = rect
-                registry.registerWidget(address, instance.instanceId, index, rect)
-            }
-            .widgetBounds(registry, address, instance.instanceId, index)
-            .padding(2.dp)
-            .border(
-                width = 1.dp,
-                color = CelestiaTheme.colors.primary.copy(alpha = borderAlpha),
-                shape = RoundedCornerShape(8.dp),
-            ),
-    ) {
-        Box(Modifier.alpha(sourceAlpha)) { content() }
-
-        // Drag handle: always visible (so the user discovers it),
-        // brightens on hover. Attached pointerInput drives the drag.
-        Surface(
-            color    = CelestiaTheme.colors.surface.copy(alpha = if (isHovered) 0.95f else 0.65f),
-            shape    = RoundedCornerShape(6.dp),
-            shadowElevation = 0.dp,
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (showIndicatorBefore) DropIndicator()
+        Box(
             modifier = Modifier
-                .align(Alignment.TopStart)
-                .padding(4.dp)
-                .size(22.dp)
-                .dragSource(
-                    controller            = controller,
-                    payload               = DragPayload.ExistingWidget(address, index, instance),
-                    widgetBoundsProvider  = { widgetWindowBounds },
-                    ghost                 = {
-                        CompositionLocalProvider(capturedLocals) { content() }
-                    },
-                    onDragEnd             = onCommitDrop,
+                .padding(vertical = 4.dp)
+                .hoverable(interaction)
+                .onGloballyPositioned { coords: LayoutCoordinates ->
+                    val rect = coords.boundsInWindow()
+                    widgetWindowBounds = rect
+                    registry.registerWidget(address, instance.instanceId, index, rect)
+                }
+                .widgetBounds(registry, address, instance.instanceId, index)
+                .padding(2.dp)
+                .border(
+                    width = 1.dp,
+                    color = CelestiaTheme.colors.primary.copy(alpha = borderAlpha),
+                    shape = RoundedCornerShape(8.dp),
                 ),
         ) {
-            Icon(
-                imageVector        = Icons.Default.DragIndicator,
-                contentDescription = "Drag to reorder",
-                tint               = CelestiaTheme.colors.textSecondary,
-                modifier           = Modifier.size(16.dp).padding(0.dp),
-            )
-        }
+            Box(Modifier.alpha(sourceAlpha)) { content() }
 
-        // Remove button: hover-only, hidden on non-removable widgets.
-        // Animated fade so it does not pop in jarringly.
-        AnimatedVisibility(
-            visible  = isHovered && descriptor.removable,
-            enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
-            exit     = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
-            modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
-        ) {
+            // Drag handle: always visible (so the user discovers it),
+            // brightens on hover. Attached pointerInput drives the drag.
             Surface(
-                color    = CelestiaTheme.colors.error.copy(alpha = 0.85f),
+                color    = CelestiaTheme.colors.surface.copy(alpha = if (isHovered) 0.95f else 0.65f),
                 shape    = RoundedCornerShape(6.dp),
+                shadowElevation = 0.dp,
                 modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(4.dp)
                     .size(22.dp)
-                    .pointerInput(instance.instanceId) {
-                        awaitPointerEventScope {
-                            while (true) {
-                                val event = awaitPointerEvent()
-                                if (event.type == PointerEventType.Release) {
-                                    onRemove()
-                                    event.changes.forEach { it.consume() }
-                                }
-                            }
-                        }
-                    },
+                    .dragSource(
+                        controller            = controller,
+                        payload               = DragPayload.ExistingWidget(address, index, instance),
+                        widgetBoundsProvider  = { widgetWindowBounds },
+                        ghost                 = {
+                            CompositionLocalProvider(capturedLocals) { content() }
+                        },
+                        onDragEnd             = onCommitDrop,
+                    ),
             ) {
                 Icon(
-                    imageVector        = Icons.Default.Close,
-                    contentDescription = "Remove widget",
-                    tint               = Color.White,
-                    modifier           = Modifier.size(14.dp).padding(0.dp).graphicsLayer { },
+                    imageVector        = Icons.Default.DragIndicator,
+                    contentDescription = "Drag to reorder",
+                    tint               = CelestiaTheme.colors.textSecondary,
+                    modifier           = Modifier.size(16.dp).padding(0.dp),
                 )
             }
+
+            // Remove button: hover-only, hidden on non-removable widgets.
+            // Animated fade so it does not pop in jarringly. Qualified
+            // with this@Column because the inner Box sits inside the
+            // outer drop-indicator Column, and Kotlin would otherwise
+            // try ColumnScope.AnimatedVisibility against a BoxScope `this`.
+            this@Column.AnimatedVisibility(
+                visible  = isHovered && descriptor.removable,
+                enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
+                exit     = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
+                modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
+            ) {
+                Surface(
+                    color    = CelestiaTheme.colors.error.copy(alpha = 0.85f),
+                    shape    = RoundedCornerShape(6.dp),
+                    modifier = Modifier
+                        .size(22.dp)
+                        .pointerInput(instance.instanceId) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    if (event.type == PointerEventType.Release) {
+                                        onRemove()
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        },
+                ) {
+                    Icon(
+                        imageVector        = Icons.Default.Close,
+                        contentDescription = "Remove widget",
+                        tint               = Color.White,
+                        modifier           = Modifier.size(14.dp).padding(0.dp).graphicsLayer { },
+                    )
+                }
+            }
         }
+        if (showIndicatorAfter) DropIndicator()
     }
+}
+
+@Composable
+private fun DropIndicator() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(2.dp)
+            .padding(horizontal = 4.dp)
+            .background(CelestiaTheme.colors.primary),
+    )
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/WidgetPalettePanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/WidgetPalettePanel.kt
@@ -58,8 +58,16 @@ fun WidgetPalettePanel(
     modifier: Modifier = Modifier,
 ) {
     val registry0 = LocalWidgetRegistry.current
+    // Only removable descriptors enter the palette. Non-removable
+    // widgets (auth panel, nav.settings, bundled navbuttons) are
+    // surface-essential: shipping a default layout pins exactly one
+    // instance, and the chrome hides the remove button for them. If
+    // the palette also exposed them, the user could drop duplicates
+    // into arbitrary slots and never be able to remove them.
     val descriptors = remember(registry0) {
-        registry0.all().values.sortedBy { it.displayName.lowercase() }
+        registry0.all().values
+            .filter { it.removable }
+            .sortedBy { it.displayName.lowercase() }
     }
 
     AnimatedVisibility(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
@@ -1,5 +1,6 @@
 package hivens.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -40,7 +41,10 @@ fun NewHomeScreen(
         )
     }
     CompositionLocalProvider(LocalHomeNewContext provides ctx) {
-        Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
+        Column(
+            modifier            = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             SlotRenderer(SurfaceId(SURFACE), SlotId("main"))
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -1,6 +1,6 @@
 package hivens.ui.screens.library
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,10 +37,16 @@ fun LibraryScreen(
     }
     CompositionLocalProvider(LocalLibraryContext provides ctx) {
         Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
-            Box(Modifier.fillMaxWidth()) {
+            Column(
+                modifier            = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 SlotRenderer(SurfaceId(SURFACE), SlotId("header"))
             }
-            Box(Modifier.weight(1f).fillMaxWidth()) {
+            Column(
+                modifier            = Modifier.weight(1f).fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 SlotRenderer(SurfaceId(SURFACE), SlotId("body"))
             }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
@@ -1,7 +1,17 @@
 package hivens.ui.widgets.sample
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,12 +19,17 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeDown
+import androidx.compose.material.icons.automirrored.filled.VolumeMute
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Pause
@@ -37,8 +52,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import hivens.ui.audio.AudioPlayer
 import hivens.ui.audio.PlaybackState
@@ -69,6 +89,7 @@ import kotlin.io.path.name
 fun MusicPlayerWidget(instance: WidgetInstance) {
     val player: AudioPlayer = koinInject()
     val state by player.state.collectAsState()
+    val volume by player.volume.collectAsState()
     val scope = rememberCoroutineScope()
 
     val pickFile = {
@@ -184,7 +205,122 @@ fun MusicPlayerWidget(instance: WidgetInstance) {
                 )
             }
         }
+
+        // Volume row: icon + bar. Bar is a custom thin track with a
+        // dot thumb that only appears on hover/drag -- the default
+        // Material slider's fat thumb reads as an out-of-place form
+        // control here.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier          = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector        = volumeIcon(volume),
+                contentDescription = "Громкость",
+                tint               = CelestiaTheme.colors.textSecondary,
+                modifier           = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(10.dp))
+            VolumeBar(
+                value         = volume,
+                onValueChange = { player.setVolume(it) },
+                modifier      = Modifier.weight(1f),
+            )
+        }
     }
+}
+
+// Thin horizontal track + small dot thumb. Track grows from 3dp to
+// 4dp on hover; thumb fades in on hover/press. Drag updates the value
+// continuously; tap jumps to the tapped position. Designed to read as
+// a player slider rather than a generic form control.
+@Composable
+private fun VolumeBar(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    var pressing by remember { mutableStateOf(false) }
+    val active = isHovered || pressing
+
+    val trackHeight by animateDpAsState(
+        targetValue   = if (active) 4.dp else 3.dp,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "vol-track-height",
+    )
+    val thumbAlpha by animateFloatAsState(
+        targetValue   = if (active) 1f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "vol-thumb-alpha",
+    )
+    val thumbSizeDp by animateDpAsState(
+        targetValue   = if (pressing) 12.dp else 10.dp,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "vol-thumb-size",
+    )
+
+    var widthPx by remember { mutableStateOf(0) }
+
+    Box(
+        modifier = modifier
+            .height(20.dp)
+            .hoverable(interaction)
+            .onSizeChanged { widthPx = it.width }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    pressing = true
+                    val w = size.width.coerceAtLeast(1).toFloat()
+                    onValueChange((down.position.x / w).coerceIn(0f, 1f))
+                    drag(down.id) { change ->
+                        val newValue = (change.position.x / w).coerceIn(0f, 1f)
+                        onValueChange(newValue)
+                        change.consume()
+                    }
+                    pressing = false
+                }
+            },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        // Inactive track (full bar background).
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(trackHeight)
+                .clip(RoundedCornerShape(50))
+                .background(CelestiaTheme.colors.outline.copy(alpha = 0.20f)),
+        )
+        // Active fill (left edge to current value).
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(value)
+                .height(trackHeight)
+                .clip(RoundedCornerShape(50))
+                .background(CelestiaTheme.colors.primary),
+        )
+        // Thumb dot at the active edge -- only visible on hover/press.
+        if (widthPx > 0 && thumbAlpha > 0.01f) {
+            val thumbHalfPx = with(LocalDensity.current) { thumbSizeDp.toPx() / 2f }
+            val xPx = (value * widthPx - thumbHalfPx).toInt()
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(xPx, 0) }
+                    .size(thumbSizeDp)
+                    .graphicsLayer { alpha = thumbAlpha }
+                    .clip(CircleShape)
+                    .background(CelestiaTheme.colors.primary),
+            )
+        }
+    }
+}
+
+private fun volumeIcon(volume: Float): androidx.compose.ui.graphics.vector.ImageVector = when {
+    volume <= 0.001f -> Icons.AutoMirrored.Filled.VolumeOff
+    volume < 0.34f   -> Icons.AutoMirrored.Filled.VolumeMute
+    volume < 0.67f   -> Icons.AutoMirrored.Filled.VolumeDown
+    else             -> Icons.AutoMirrored.Filled.VolumeUp
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Two commits on top of #266:

- **fix(editor): post-Phase 2 smoke fixes** -- OS cursor hidden during drag (transparent AWT cursor via pointerHoverIcon on ghost overlay), empty-slot placeholders render on every editable surface (palette drops land anywhere), drop-indicator line at computed insertion index, vertical spacing in main / library slots + chrome padding, palette filtered to removable descriptors so auth-panel and nav.settings can not be duplicated into surfaces where they cannot be removed.

- **feat(audio): volume + pause-position + custom slider** -- linear 0..1 volume mapped to MASTER_GAIN (VOLUME fallback). pause() now stores frame offset, play() skip-exacts into a fresh stream so resume continues mid-song. Pause double-click race fixed via MutableStateFlow.update CAS in both the play loop and pause() -- a trailing emit from a mid-write coroutine can no longer flip state back to Playing. Custom VolumeBar replaces Material Slider: thin capsule track that thickens on hover, dot thumb fades in on hover / press, icon switches Off / Mute / Down / Up by level.

## Test plan

- [ ] Edit mode: drag any widget. OS cursor invisible while dragging; ghost follows pointer.
- [ ] Edit mode: clear a slot completely. Palette drop still lands on the now-empty placeholder.
- [ ] Edit mode: drag within a slot. Primary-tinted line appears at insertion position; widgets settle with visible gap.
- [ ] Palette: open it. AuthPanel and nav.settings are absent.
- [ ] MusicPlayer: load a WAV, hover the bar -- track thickens, thumb appears. Drag = volume tracks; tap = jumps.
- [ ] MusicPlayer: pause mid-song, hit play. Resumes from same spot (within ~1ms tolerance).
- [ ] MusicPlayer: hit pause once -- the icon flips to Play immediately (not on second click).