### PR TITLE
feat(widgets): A.1 -- nested children + SlotPath addressing (Phase A.1)

### DIFF
--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
@@ -1,6 +1,7 @@
 package hivens.widget.api
 
 import androidx.compose.runtime.Composable
+import hivens.widget.model.SlotId
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
 
@@ -11,6 +12,14 @@ interface WidgetDescriptor {
     // false hides the remove affordance in the editor. Drives the
     // safety check on nav rail / auth panel widgets.
     val removable: Boolean
+
+    // Slot ids this widget exposes for nested sub-widgets. Empty for
+    // leaves. Populated by the KSP processor from @Widget(slots = ...).
+    // Editor uses this to drive drop-target discovery inside container
+    // chromes; the layout-graph mutator uses it (indirectly, via the
+    // structural keys in WidgetInstance.children) to validate moves.
+    val slots: List<SlotId>
+        get() = emptyList()
 
     @Composable
     fun Render(instance: WidgetInstance)

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -4,11 +4,23 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
+// Compose stability of this type is intentionally NOT marked here --
+// @Immutable lives in androidx.compose.runtime and widget-model must
+// stay Compose-free (CLI / TUI / launcher consumers don't carry the
+// Compose runtime). Stability is addressed when Phase B.5 introduces
+// typed-props, replacing JsonObject with serializer-registry-backed
+// instances that satisfy Compose's auto-stability heuristics.
 @Serializable
 data class WidgetInstance(
     val kind: WidgetKind,
     @SerialName("instance_id") val instanceId: String,
     val props: JsonObject = JsonObject(emptyMap()),
+    // Sub-widgets for container kinds. Keyed by SlotId of a slot the
+    // descriptor declared via @Widget(slots = ...). Empty for leaves.
+    // Held as a typed field rather than smuggled inside `props` because
+    // future mixin hooks (transformProps in Phase C) must not be able
+    // to corrupt the layout tree.
+    val children: Map<SlotId, SlotContent> = emptyMap(),
 )
 
 @Serializable
@@ -24,87 +36,178 @@ data class LayoutGraph(val surfaces: Map<SurfaceId, SurfaceLayout> = emptyMap())
     }
 }
 
-// (SurfaceId, SlotId) pair. Editor mutations reference slots by this
-// address; passing two value classes around at every call site is
-// noisy and prone to argument-swap mistakes.
+// (SurfaceId, SlotId) pair. Retained for chrome-level callers that
+// only care about the leaf coordinates and do not navigate the path.
+// Internal transforms operate on SlotPath; SlotAddress.toPath() bridges
+// when needed.
 data class SlotAddress(val surface: SurfaceId, val slot: SlotId)
 
-// Immutable transforms on the graph. Each returns a new LayoutGraph;
-// the caller hands the result to LayoutGraphRepository.update. Unknown
-// surfaces, slots, or widgets are no-ops -- editor mutations race with
+// Immutable transforms. Each returns a new LayoutGraph; the caller
+// hands the result to LayoutGraphRepository.update. Unknown surfaces,
+// slots, or widget instances are no-ops -- editor mutations race with
 // disk reloads, and a transform on a vanished slot must not crash.
+
+fun LayoutGraph.insertWidget(path: SlotPath, widget: WidgetInstance, index: Int): LayoutGraph =
+    mutate(path) { content ->
+        val coerced = index.coerceIn(0, content.widgets.size)
+        content.copy(widgets = content.widgets.toMutableList().apply { add(coerced, widget) })
+    }
+
+fun LayoutGraph.removeWidget(path: SlotPath, instanceId: String): LayoutGraph =
+    mutate(path) { content ->
+        if (content.widgets.none { it.instanceId == instanceId }) content
+        else content.copy(widgets = content.widgets.filterNot { it.instanceId == instanceId })
+    }
+
+fun LayoutGraph.reorderInSlot(path: SlotPath, fromIndex: Int, toIndex: Int): LayoutGraph =
+    mutate(path) { content ->
+        if (fromIndex !in content.widgets.indices) return@mutate content
+        val target = toIndex.coerceIn(0, content.widgets.size - 1)
+        if (fromIndex == target) return@mutate content
+        content.copy(
+            widgets = content.widgets.toMutableList().apply { add(target, removeAt(fromIndex)) },
+        )
+    }
+
+fun LayoutGraph.moveWidget(
+    from: SlotPath,
+    to: SlotPath,
+    instanceId: String,
+    toIndex: Int,
+): LayoutGraph {
+    // Cycle guard: a container cannot be dropped inside its own subtree.
+    if (to.nested.any { it.parentInstanceId == instanceId }) return this
+
+    val fromContent = traverse(from) ?: return this
+    val widget = fromContent.widgets.firstOrNull { it.instanceId == instanceId } ?: return this
+
+    if (from == to) {
+        val sourceIdx = fromContent.widgets.indexOfFirst { it.instanceId == instanceId }
+        return reorderInSlot(from, sourceIdx, toIndex)
+    }
+
+    // Destination must exist (top-level slot or nested container slot).
+    if (traverse(to) == null) return this
+
+    return removeWidget(from, instanceId).insertWidget(to, widget, toIndex)
+}
+
+// Walks the path and returns the SlotContent at the leaf, or null if
+// any intermediate surface / slot / parent widget is missing.
+fun LayoutGraph.traverse(path: SlotPath): SlotContent? {
+    var content = surfaces[path.surface]?.slots?.get(path.rootSlot) ?: return null
+    for (segment in path.nested) {
+        val container = content.widgets.firstOrNull { it.instanceId == segment.parentInstanceId } ?: return null
+        content = container.children[segment.slot] ?: return null
+    }
+    return content
+}
+
+// Walks every WidgetInstance in the graph (including nested children)
+// in pre-order. Used by the launcher's tree-wide instanceId uniqueness
+// check.
+fun LayoutGraph.walkInstances(): Sequence<WidgetInstance> = sequence {
+    for ((_, layout) in surfaces) {
+        for ((_, content) in layout.slots) {
+            yieldAll(content.walkInstances())
+        }
+    }
+}
+
+private fun SlotContent.walkInstances(): Sequence<WidgetInstance> = sequence {
+    for (widget in widgets) {
+        yield(widget)
+        for ((_, child) in widget.children) {
+            yieldAll(child.walkInstances())
+        }
+    }
+}
+
+// ── Internal traversal + rebuild ──────────────────────────────────────
+
+// Applies `mutator` to the SlotContent at `path`. If the mutator
+// returns the same content reference, the graph is returned unchanged
+// (`===` identity preserved by callers so no-op transforms allocate
+// nothing). Otherwise rebuilds the chain back up to the surface.
+private fun LayoutGraph.mutate(
+    path: SlotPath,
+    mutator: (SlotContent) -> SlotContent,
+): LayoutGraph {
+    val rootLayout = surfaces[path.surface] ?: return this
+    val rootContent = rootLayout.slots[path.rootSlot] ?: return this
+
+    val newRootContent: SlotContent = if (path.nested.isEmpty()) {
+        mutator(rootContent)
+    } else {
+        val descendantId = path.nested.first().parentInstanceId
+        val container = rootContent.widgets.firstOrNull { it.instanceId == descendantId } ?: return this
+        val updated = mutateNested(container, path.nested, mutator)
+        if (updated === container) return this
+        rootContent.copy(widgets = rootContent.widgets.map {
+            if (it.instanceId == descendantId) updated else it
+        })
+    }
+
+    if (newRootContent === rootContent) return this
+    val newSlots = rootLayout.slots.toMutableMap().apply { put(path.rootSlot, newRootContent) }
+    val newSurfaces = surfaces.toMutableMap().apply { put(path.surface, rootLayout.copy(slots = newSlots)) }
+    return copy(surfaces = newSurfaces)
+}
+
+private fun mutateNested(
+    container: WidgetInstance,
+    pathFromContainer: List<NestedSegment>,
+    mutator: (SlotContent) -> SlotContent,
+): WidgetInstance {
+    val segment = pathFromContainer.first()
+    val rest = pathFromContainer.drop(1)
+    val childContent = container.children[segment.slot] ?: return container
+
+    val newChildContent: SlotContent = if (rest.isEmpty()) {
+        mutator(childContent)
+    } else {
+        val deeperId = rest.first().parentInstanceId
+        val deeperContainer = childContent.widgets.firstOrNull { it.instanceId == deeperId } ?: return container
+        val updated = mutateNested(deeperContainer, rest, mutator)
+        if (updated === deeperContainer) return container
+        childContent.copy(widgets = childContent.widgets.map {
+            if (it.instanceId == deeperId) updated else it
+        })
+    }
+
+    if (newChildContent === childContent) return container
+    val newChildren = container.children.toMutableMap().apply { put(segment.slot, newChildContent) }
+    return container.copy(children = newChildren)
+}
+
+// ── Compat overloads ──────────────────────────────────────────────────
+// These delegate to the SlotPath form; callers that still hand flat
+// (surface, slot) pairs keep working. New code should construct
+// SlotPath directly.
+
 fun LayoutGraph.insertWidget(
     surface: SurfaceId,
     slot: SlotId,
     widget: WidgetInstance,
     index: Int,
-): LayoutGraph {
-    val layout = surfaces[surface] ?: return this
-    val content = layout.slots[slot] ?: return this
-    val coerced = index.coerceIn(0, content.widgets.size)
-    val updated = content.copy(
-        widgets = content.widgets.toMutableList().apply { add(coerced, widget) },
-    )
-    return withSlot(surface, slot, updated)
-}
+): LayoutGraph = insertWidget(SlotPath(surface, slot), widget, index)
 
 fun LayoutGraph.removeWidget(
     surface: SurfaceId,
     slot: SlotId,
     instanceId: String,
-): LayoutGraph {
-    val layout = surfaces[surface] ?: return this
-    val content = layout.slots[slot] ?: return this
-    if (content.widgets.none { it.instanceId == instanceId }) return this
-    return withSlot(
-        surface,
-        slot,
-        content.copy(widgets = content.widgets.filterNot { it.instanceId == instanceId }),
-    )
-}
+): LayoutGraph = removeWidget(SlotPath(surface, slot), instanceId)
 
 fun LayoutGraph.reorderInSlot(
     surface: SurfaceId,
     slot: SlotId,
     fromIndex: Int,
     toIndex: Int,
-): LayoutGraph {
-    val layout = surfaces[surface] ?: return this
-    val content = layout.slots[slot] ?: return this
-    if (fromIndex !in content.widgets.indices) return this
-    val target = toIndex.coerceIn(0, content.widgets.size - 1)
-    if (fromIndex == target) return this
-    val reordered = content.widgets.toMutableList().apply {
-        add(target, removeAt(fromIndex))
-    }
-    return withSlot(surface, slot, content.copy(widgets = reordered))
-}
+): LayoutGraph = reorderInSlot(SlotPath(surface, slot), fromIndex, toIndex)
 
 fun LayoutGraph.moveWidget(
     from: SlotAddress,
     to: SlotAddress,
     instanceId: String,
     toIndex: Int,
-): LayoutGraph {
-    val fromContent = surfaces[from.surface]?.slots?.get(from.slot) ?: return this
-    val widget = fromContent.widgets.firstOrNull { it.instanceId == instanceId } ?: return this
-    if (from == to) {
-        val sourceIdx = fromContent.widgets.indexOfFirst { it.instanceId == instanceId }
-        return reorderInSlot(from.surface, from.slot, sourceIdx, toIndex)
-    }
-    if (surfaces[to.surface]?.slots?.get(to.slot) == null) return this
-    return this
-        .removeWidget(from.surface, from.slot, instanceId)
-        .insertWidget(to.surface, to.slot, widget, toIndex)
-}
-
-private fun LayoutGraph.withSlot(
-    surface: SurfaceId,
-    slot: SlotId,
-    content: SlotContent,
-): LayoutGraph {
-    val layout = surfaces[surface] ?: return this
-    val newSlots = layout.slots.toMutableMap().apply { put(slot, content) }
-    val newSurfaces = surfaces.toMutableMap().apply { put(surface, layout.copy(slots = newSlots)) }
-    return copy(surfaces = newSurfaces)
-}
+): LayoutGraph = moveWidget(from.toPath(), to.toPath(), instanceId, toIndex)

--- a/widget-model/src/main/kotlin/hivens/widget/model/SlotPath.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/SlotPath.kt
@@ -1,0 +1,49 @@
+package hivens.widget.model
+
+// Canonical address for a slot in the layout tree.
+//
+// A path starts at a top-level (surface, rootSlot) pair and may descend
+// through one or more nested segments, each of which identifies the
+// WidgetInstance whose `children[slot]` we are entering. An empty
+// `nested` list means the path points at a top-level slot -- behavior
+// is identical to the legacy SlotAddress.
+//
+// The first hop is structurally different from nested hops (the graph
+// keys top-level slots by surface, but nested slots by a parent widget
+// instance id), so the type carries `rootSlot` separately rather than
+// modelling it as the head of a uniform segment list with a nullable
+// parent.
+data class SlotPath(
+    val surface: SurfaceId,
+    val rootSlot: SlotId,
+    val nested: List<NestedSegment> = emptyList(),
+) {
+    val leafSlot: SlotId
+        get() = nested.lastOrNull()?.slot ?: rootSlot
+
+    val leafAddress: SlotAddress
+        get() = SlotAddress(surface, leafSlot)
+
+    val parentPath: SlotPath?
+        get() = if (nested.isEmpty()) null else copy(nested = nested.dropLast(1))
+
+    fun child(parentInstanceId: String, slot: SlotId): SlotPath =
+        copy(nested = nested + NestedSegment(parentInstanceId, slot))
+
+    override fun toString(): String = buildString {
+        append(surface.value).append(':').append(rootSlot.value)
+        for (segment in nested) {
+            append(" > ").append(segment.parentInstanceId).append(':').append(segment.slot.value)
+        }
+    }
+}
+
+// One hop into a container widget. `parentInstanceId` identifies the
+// WidgetInstance whose `children[slot]` we are entering. The slot
+// itself is the destination.
+data class NestedSegment(
+    val parentInstanceId: String,
+    val slot: SlotId,
+)
+
+fun SlotAddress.toPath(): SlotPath = SlotPath(surface, slot)

--- a/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
@@ -22,4 +22,9 @@ annotation class Widget(
     // buttons, the auth panel) -- the user can still rearrange but
     // cannot delete. Defaults true; opt-out is explicit.
     val removable: Boolean = true,
+    // Slot ids this widget exposes as drop targets for its own
+    // sub-widgets (container widgets). Empty for leaves. Walked by
+    // the editor's drop hit-test and by the KSP processor to validate
+    // that container.children references only declared slots.
+    val slots: Array<String> = [],
 )

--- a/widget-model/src/main/resources/widget/default-layout.json
+++ b/widget-model/src/main/resources/widget/default-layout.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "graph": {
     "surfaces": {
       "home.classic": {

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -3,6 +3,8 @@ package hivens.widget.model
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 class LayoutGraphMutationsTest {
@@ -22,53 +24,57 @@ class LayoutGraphMutationsTest {
     private fun LayoutGraph.mainWidgets(): List<WidgetInstance> =
         surfaces[home]?.slots?.get(main)?.widgets ?: emptyList()
 
+    private val rootPath: SlotPath = SlotPath(home, main)
+
+    // ── Existing transform behavior (root-level via SlotPath) ─────────
+
     @Test
     fun `insertWidget at zero pushes existing widgets back`() {
-        val out = seed(w1, w2).insertWidget(home, main, w3, 0)
+        val out = seed(w1, w2).insertWidget(rootPath, w3, 0)
         assertEquals(listOf(w3, w1, w2), out.mainWidgets())
     }
 
     @Test
     fun `insertWidget past end coerces to append`() {
-        val out = seed(w1).insertWidget(home, main, w2, 999)
+        val out = seed(w1).insertWidget(rootPath, w2, 999)
         assertEquals(listOf(w1, w2), out.mainWidgets())
     }
 
     @Test
     fun `insertWidget into unknown slot is a no-op identity return`() {
         val graph = seed(w1)
-        val out = graph.insertWidget(home, SlotId("nope"), w2, 0)
+        val out = graph.insertWidget(SlotPath(home, SlotId("nope")), w2, 0)
         assertSame(graph, out, "no-op must return the same instance (no allocation)")
     }
 
     @Test
     fun `removeWidget filters by instanceId`() {
-        val out = seed(w1, w2, w3).removeWidget(home, main, "i2")
+        val out = seed(w1, w2, w3).removeWidget(rootPath, "i2")
         assertEquals(listOf(w1, w3), out.mainWidgets())
     }
 
     @Test
     fun `removeWidget of unknown id is identity`() {
         val graph = seed(w1)
-        assertSame(graph, graph.removeWidget(home, main, "ghost"))
+        assertSame(graph, graph.removeWidget(rootPath, "ghost"))
     }
 
     @Test
     fun `reorderInSlot swaps positions`() {
-        val out = seed(w1, w2, w3).reorderInSlot(home, main, fromIndex = 0, toIndex = 2)
+        val out = seed(w1, w2, w3).reorderInSlot(rootPath, fromIndex = 0, toIndex = 2)
         assertEquals(listOf(w2, w3, w1), out.mainWidgets())
     }
 
     @Test
     fun `reorderInSlot with same index is identity`() {
         val graph = seed(w1, w2)
-        assertSame(graph, graph.reorderInSlot(home, main, fromIndex = 0, toIndex = 0))
+        assertSame(graph, graph.reorderInSlot(rootPath, fromIndex = 0, toIndex = 0))
     }
 
     @Test
     fun `reorderInSlot out-of-range fromIndex is identity`() {
         val graph = seed(w1, w2)
-        assertSame(graph, graph.reorderInSlot(home, main, fromIndex = 5, toIndex = 0))
+        assertSame(graph, graph.reorderInSlot(rootPath, fromIndex = 5, toIndex = 0))
     }
 
     @Test
@@ -82,8 +88,8 @@ class LayoutGraphMutationsTest {
             ),
         )
         val out = twoSlots.moveWidget(
-            from       = SlotAddress(home, SlotId("top")),
-            to         = SlotAddress(home, SlotId("bottom")),
+            from       = SlotPath(home, SlotId("top")),
+            to         = SlotPath(home, SlotId("bottom")),
             instanceId = "i1",
             toIndex    = 0,
         )
@@ -96,8 +102,8 @@ class LayoutGraphMutationsTest {
     @Test
     fun `moveWidget within same slot delegates to reorderInSlot`() {
         val out = seed(w1, w2, w3).moveWidget(
-            from       = SlotAddress(home, main),
-            to         = SlotAddress(home, main),
+            from       = rootPath,
+            to         = rootPath,
             instanceId = "i3",
             toIndex    = 0,
         )
@@ -108,11 +114,154 @@ class LayoutGraphMutationsTest {
     fun `moveWidget of unknown instanceId is identity`() {
         val graph = seed(w1)
         val out = graph.moveWidget(
-            from       = SlotAddress(home, main),
-            to         = SlotAddress(home, main),
+            from       = rootPath,
+            to         = rootPath,
             instanceId = "ghost",
             toIndex    = 0,
         )
         assertSame(graph, out)
+    }
+
+    // ── Compat overloads still work ───────────────────────────────────
+
+    @Test
+    fun `compat overload of insertWidget on a flat SurfaceId-SlotId pair still works`() {
+        val out = seed(w1).insertWidget(home, main, w2, 999)
+        assertEquals(listOf(w1, w2), out.mainWidgets())
+    }
+
+    @Test
+    fun `compat overload of moveWidget on a SlotAddress pair still works`() {
+        val twoSlots = LayoutGraph(
+            surfaces = mapOf(
+                home to SurfaceLayout(slots = mapOf(
+                    SlotId("top")    to SlotContent(listOf(w1)),
+                    SlotId("bottom") to SlotContent(listOf(w2)),
+                )),
+            ),
+        )
+        val out = twoSlots.moveWidget(
+            from       = SlotAddress(home, SlotId("top")),
+            to         = SlotAddress(home, SlotId("bottom")),
+            instanceId = "i1",
+            toIndex    = 0,
+        )
+        assertEquals(listOf(w1, w2), out.surfaces[home]!!.slots[SlotId("bottom")]!!.widgets)
+    }
+
+    // ── Nested transforms ─────────────────────────────────────────────
+
+    private val container = WidgetInstance(
+        kind       = WidgetKind("container.group"),
+        instanceId = "container1",
+        children   = mapOf(SlotId("body") to SlotContent(listOf(w1, w2))),
+    )
+
+    private fun seedNested(): LayoutGraph = LayoutGraph(
+        surfaces = mapOf(
+            home to SurfaceLayout(slots = mapOf(main to SlotContent(listOf(container)))),
+        ),
+    )
+
+    private val nestedBody: SlotPath = SlotPath(
+        surface  = home,
+        rootSlot = main,
+        nested   = listOf(NestedSegment("container1", SlotId("body"))),
+    )
+
+    @Test
+    fun `insertWidget at depth 1 grows the container's body slot`() {
+        val out = seedNested().insertWidget(nestedBody, w3, 1)
+        val containerNow = out.surfaces[home]!!.slots[main]!!.widgets[0]
+        val bodyWidgets = containerNow.children[SlotId("body")]!!.widgets
+        assertEquals(listOf(w1, w3, w2), bodyWidgets)
+    }
+
+    @Test
+    fun `removeWidget at depth 1 strips a child without touching siblings`() {
+        val out = seedNested().removeWidget(nestedBody, "i2")
+        val containerNow = out.surfaces[home]!!.slots[main]!!.widgets[0]
+        assertEquals(listOf(w1), containerNow.children[SlotId("body")]!!.widgets)
+    }
+
+    @Test
+    fun `reorderInSlot at depth 1 reorders within the container`() {
+        val out = seedNested().reorderInSlot(nestedBody, fromIndex = 0, toIndex = 1)
+        val containerNow = out.surfaces[home]!!.slots[main]!!.widgets[0]
+        assertEquals(listOf(w2, w1), containerNow.children[SlotId("body")]!!.widgets)
+    }
+
+    @Test
+    fun `moveWidget out of nested slot up to root level`() {
+        val out = seedNested().moveWidget(
+            from       = nestedBody,
+            to         = rootPath,
+            instanceId = "i1",
+            toIndex    = 0,
+        )
+        val rootWidgets = out.surfaces[home]!!.slots[main]!!.widgets
+        assertEquals(2, rootWidgets.size)
+        assertEquals("i1", rootWidgets[0].instanceId)
+        // Container still present, body now has just w2.
+        val containerNow = rootWidgets[1]
+        assertEquals(listOf(w2), containerNow.children[SlotId("body")]!!.widgets)
+    }
+
+    @Test
+    fun `moveWidget from root level into nested container`() {
+        val withRootWidget = seedNested().insertWidget(rootPath, w3, 1)
+        // Now: root = [container, w3]; container body = [w1, w2]
+        val out = withRootWidget.moveWidget(
+            from       = rootPath,
+            to         = nestedBody,
+            instanceId = "i3",
+            toIndex    = 1,
+        )
+        val rootWidgets = out.surfaces[home]!!.slots[main]!!.widgets
+        assertEquals(1, rootWidgets.size, "w3 leaves root slot")
+        val bodyNow = rootWidgets[0].children[SlotId("body")]!!.widgets
+        assertEquals(listOf(w1, w3, w2), bodyNow, "w3 landed at index 1 inside container")
+    }
+
+    @Test
+    fun `moveWidget rejects a cycle (container into its own subtree)`() {
+        // Try to drop the container into its own body slot -- would form
+        // a self-cycle.
+        val cyclePath = SlotPath(
+            surface  = home,
+            rootSlot = main,
+            nested   = listOf(NestedSegment("container1", SlotId("body"))),
+        )
+        val graph = seedNested()
+        val out = graph.moveWidget(
+            from       = rootPath,
+            to         = cyclePath,
+            instanceId = "container1",
+            toIndex    = 0,
+        )
+        assertSame(graph, out)
+    }
+
+    @Test
+    fun `traverse returns content at the leaf path`() {
+        val content = seedNested().traverse(nestedBody)
+        assertNotNull(content)
+        assertEquals(listOf(w1, w2), content.widgets)
+    }
+
+    @Test
+    fun `traverse returns null for an unknown nested segment`() {
+        val unknown = SlotPath(
+            surface  = home,
+            rootSlot = main,
+            nested   = listOf(NestedSegment("does-not-exist", SlotId("body"))),
+        )
+        assertNull(seedNested().traverse(unknown))
+    }
+
+    @Test
+    fun `walkInstances yields every widget across nesting`() {
+        val ids = seedNested().walkInstances().map { it.instanceId }.toList()
+        assertEquals(listOf("container1", "i1", "i2"), ids)
     }
 }

--- a/widget-model/src/test/kotlin/hivens/widget/model/SlotPathTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/SlotPathTest.kt
@@ -1,0 +1,77 @@
+package hivens.widget.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SlotPathTest {
+
+    private val surface = SurfaceId("home.new")
+    private val body = SlotId("body")
+    private val main = SlotId("main")
+
+    @Test
+    fun `root path has no nested segments`() {
+        val path = SlotPath(surface, main)
+        assertEquals(emptyList(), path.nested)
+        assertEquals(main, path.leafSlot)
+        assertEquals(SlotAddress(surface, main), path.leafAddress)
+        assertNull(path.parentPath, "root path has no parent")
+    }
+
+    @Test
+    fun `child appends a segment and bumps leafSlot`() {
+        val root = SlotPath(surface, main)
+        val nested = root.child("container1", body)
+        assertEquals(1, nested.nested.size)
+        assertEquals("container1", nested.nested[0].parentInstanceId)
+        assertEquals(body, nested.leafSlot)
+        assertEquals(SlotAddress(surface, body), nested.leafAddress)
+    }
+
+    @Test
+    fun `parentPath of a one-level-deep path is the root path`() {
+        val root = SlotPath(surface, main)
+        val nested = root.child("container1", body)
+        assertEquals(root, nested.parentPath)
+    }
+
+    @Test
+    fun `parentPath of a two-level-deep path drops the deepest hop`() {
+        val deep = SlotPath(surface, main)
+            .child("container1", body)
+            .child("container2", SlotId("nested"))
+        val expectedParent = SlotPath(surface, main).child("container1", body)
+        assertEquals(expectedParent, deep.parentPath)
+    }
+
+    @Test
+    fun `equality holds across structurally identical paths`() {
+        val a = SlotPath(surface, main).child("c1", body)
+        val b = SlotPath(surface, main).child("c1", body)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `equality fails when nested chains differ`() {
+        val a = SlotPath(surface, main).child("c1", body)
+        val b = SlotPath(surface, main).child("c2", body)
+        kotlin.test.assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `SlotAddress toPath bridges to a root SlotPath`() {
+        val addr = SlotAddress(surface, main)
+        val path = addr.toPath()
+        assertEquals(surface, path.surface)
+        assertEquals(main, path.rootSlot)
+        assertEquals(emptyList(), path.nested)
+    }
+
+    @Test
+    fun `toString format is path-readable for diagnostics`() {
+        val deep = SlotPath(surface, main).child("c1", body)
+        assertEquals("home.new:main > c1:body", deep.toString())
+    }
+}

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
@@ -7,11 +7,8 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.Modifier
 
 private const val WIDGET_ANNOTATION_FQN = "hivens.widget.model.Widget"
-private const val COMPOSABLE_ANNOTATION_FQN = "androidx.compose.runtime.Composable"
-private const val WIDGET_INSTANCE_FQN = "hivens.widget.model.WidgetInstance"
 
 private const val GENERATED_PACKAGE = "hivens.widget.generated"
 private const val GENERATED_FILE_NAME = "GeneratedWidgetRegistry"
@@ -38,7 +35,17 @@ class WidgetRegistryProcessor(
                 env.logger.error("@Widget is only valid on functions", symbol)
                 return@mapNotNull null
             }
-            validateAndExtract(symbol)
+            val extracted = WidgetValidator.validate(symbol, env) ?: return@mapNotNull null
+            val packageName = symbol.packageName.asString()
+            val funcName = symbol.simpleName.asString()
+            WidgetEntry(
+                id = extracted.id,
+                displayName = extracted.displayName.ifBlank { funcName },
+                removable = extracted.removable,
+                slots = extracted.slots,
+                functionFqn = if (packageName.isEmpty()) funcName else "$packageName.$funcName",
+                containingFile = symbol.containingFile,
+            )
         }
 
         if (widgets.isEmpty() && symbols.isNotEmpty()) {
@@ -51,73 +58,6 @@ class WidgetRegistryProcessor(
         emitGeneratedFile(widgets)
         emitted = true
         return emptyList()
-    }
-
-    private fun validateAndExtract(symbol: KSFunctionDeclaration): WidgetEntry? {
-        val widgetAnnotation = symbol.annotations.firstOrNull {
-            it.shortName.asString() == "Widget" &&
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == WIDGET_ANNOTATION_FQN
-        } ?: run {
-            env.logger.error("missing @Widget annotation", symbol)
-            return null
-        }
-
-        val composable = symbol.annotations.any {
-            it.shortName.asString() == "Composable" &&
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSABLE_ANNOTATION_FQN
-        }
-        if (!composable) {
-            env.logger.error("@Widget functions must also be @Composable", symbol)
-            return null
-        }
-
-        // Top-level only -- anonymous + class-member composables would
-        // require a receiver to invoke from the generated registry.
-        if (symbol.parentDeclaration != null) {
-            env.logger.error("@Widget composables must be top-level", symbol)
-            return null
-        }
-
-        val params = symbol.parameters
-        if (params.size != 1) {
-            env.logger.error("@Widget composables must take exactly one parameter (instance: WidgetInstance)", symbol)
-            return null
-        }
-        val paramType = params[0].type.resolve().declaration.qualifiedName?.asString()
-        if (paramType != WIDGET_INSTANCE_FQN) {
-            env.logger.error("@Widget composable parameter must be hivens.widget.model.WidgetInstance, got $paramType", symbol)
-            return null
-        }
-
-        // Inline / suspend / extension / receiver composables make the
-        // generated indirection awkward; reject up front.
-        if (Modifier.INLINE in symbol.modifiers || Modifier.SUSPEND in symbol.modifiers) {
-            env.logger.error("@Widget composables cannot be inline or suspend", symbol)
-            return null
-        }
-        if (symbol.extensionReceiver != null) {
-            env.logger.error("@Widget composables cannot have an extension receiver", symbol)
-            return null
-        }
-
-        val args = widgetAnnotation.arguments.associate { it.name?.asString() to it.value }
-        val id = (args["id"] as? String).orEmpty()
-        val displayName = (args["displayName"] as? String).orEmpty()
-        val removable = (args["removable"] as? Boolean) ?: true
-        if (id.isBlank()) {
-            env.logger.error("@Widget id must be non-blank", symbol)
-            return null
-        }
-
-        val packageName = symbol.packageName.asString()
-        val funcName = symbol.simpleName.asString()
-        return WidgetEntry(
-            id = id,
-            displayName = displayName.ifBlank { funcName },
-            removable = removable,
-            functionFqn = if (packageName.isEmpty()) funcName else "$packageName.$funcName",
-            containingFile = symbol.containingFile,
-        )
     }
 
     private fun emitGeneratedFile(widgets: List<WidgetEntry>) {
@@ -146,6 +86,7 @@ class WidgetRegistryProcessor(
         appendLine("import androidx.compose.runtime.Composable")
         appendLine("import hivens.widget.api.WidgetDescriptor")
         appendLine("import hivens.widget.api.WidgetRegistry")
+        appendLine("import hivens.widget.model.SlotId")
         appendLine("import hivens.widget.model.WidgetInstance")
         appendLine("import hivens.widget.model.WidgetKind")
         appendLine()
@@ -157,6 +98,7 @@ class WidgetRegistryProcessor(
             appendLine("            override val kind: WidgetKind = $kindLiteral")
             appendLine("            override val displayName: String = \"${entry.displayName.kotlinEscape()}\"")
             appendLine("            override val removable: Boolean = ${entry.removable}")
+            appendLine("            override val slots: List<SlotId> = ${entry.slots.toSlotIdListLiteral()}")
             appendLine("            @Composable override fun Render(instance: WidgetInstance) {")
             appendLine("                ${entry.functionFqn}(instance)")
             appendLine("            }")
@@ -169,6 +111,10 @@ class WidgetRegistryProcessor(
         appendLine("}")
     }
 
+    private fun List<String>.toSlotIdListLiteral(): String =
+        if (isEmpty()) "emptyList()"
+        else joinToString(prefix = "listOf(", postfix = ")") { "SlotId(\"${it.kotlinEscape()}\")" }
+
     private fun String.kotlinEscape(): String =
         replace("\\", "\\\\").replace("\"", "\\\"")
 }
@@ -177,6 +123,7 @@ private data class WidgetEntry(
     val id: String,
     val displayName: String,
     val removable: Boolean,
+    val slots: List<String>,
     val functionFqn: String,
     val containingFile: com.google.devtools.ksp.symbol.KSFile?,
 )

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
@@ -1,0 +1,100 @@
+package hivens.widget.processor
+
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+
+// Shared rule-set for what a @Widget composable must look like. The KSP
+// processor validates Kotlin sources at compile time; Phase E's plugin
+// loader will validate java.lang.reflect.Method at runtime. The rules
+// are the same: top-level + @Composable + single WidgetInstance param
+// + no inline/suspend/extension + non-blank id. Centralising them here
+// keeps the two entry points consistent.
+internal object WidgetValidator {
+
+    private const val WIDGET_ANNOTATION_FQN = "hivens.widget.model.Widget"
+    private const val COMPOSABLE_ANNOTATION_FQN = "androidx.compose.runtime.Composable"
+    private const val WIDGET_INSTANCE_FQN = "hivens.widget.model.WidgetInstance"
+
+    // Annotation args extracted from a valid @Widget declaration.
+    data class Extracted(
+        val id: String,
+        val displayName: String,
+        val removable: Boolean,
+        val slots: List<String>,
+    )
+
+    // KSP entry point. Returns the extracted annotation args, or null
+    // if validation failed; in the null case, every failure has already
+    // been reported through `env.logger.error` and the build will fail.
+    fun validate(symbol: KSFunctionDeclaration, env: SymbolProcessorEnvironment): Extracted? {
+        val widgetAnnotation = symbol.annotations.firstOrNull {
+            it.shortName.asString() == "Widget" &&
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == WIDGET_ANNOTATION_FQN
+        } ?: run {
+            env.logger.error("missing @Widget annotation", symbol)
+            return null
+        }
+
+        val composable = symbol.annotations.any {
+            it.shortName.asString() == "Composable" &&
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSABLE_ANNOTATION_FQN
+        }
+        if (!composable) {
+            env.logger.error("@Widget functions must also be @Composable", symbol)
+            return null
+        }
+
+        if (symbol.parentDeclaration != null) {
+            env.logger.error("@Widget composables must be top-level", symbol)
+            return null
+        }
+
+        val params = symbol.parameters
+        if (params.size != 1) {
+            env.logger.error(
+                "@Widget composables must take exactly one parameter (instance: WidgetInstance)",
+                symbol,
+            )
+            return null
+        }
+        val paramType = params[0].type.resolve().declaration.qualifiedName?.asString()
+        if (paramType != WIDGET_INSTANCE_FQN) {
+            env.logger.error(
+                "@Widget composable parameter must be hivens.widget.model.WidgetInstance, got $paramType",
+                symbol,
+            )
+            return null
+        }
+
+        if (Modifier.INLINE in symbol.modifiers || Modifier.SUSPEND in symbol.modifiers) {
+            env.logger.error("@Widget composables cannot be inline or suspend", symbol)
+            return null
+        }
+        if (symbol.extensionReceiver != null) {
+            env.logger.error("@Widget composables cannot have an extension receiver", symbol)
+            return null
+        }
+
+        val args = widgetAnnotation.arguments.associate { it.name?.asString() to it.value }
+        val id = (args["id"] as? String).orEmpty()
+        val displayName = (args["displayName"] as? String).orEmpty()
+        val removable = (args["removable"] as? Boolean) ?: true
+        // KSP reports Array<String> annotation values as List<*>. Filter
+        // defensively; an empty list is the leaf default.
+        val rawSlots = args["slots"] as? List<*>
+        val slots = rawSlots?.filterIsInstance<String>()?.filter { it.isNotBlank() }.orEmpty()
+
+        if (id.isBlank()) {
+            env.logger.error("@Widget id must be non-blank", symbol)
+            return null
+        }
+
+        return Extracted(
+            id = id,
+            displayName = displayName,
+            removable = removable,
+            slots = slots,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Phase A.1 of the Modular UI initiative. Foundation for nested widget addressing -- container widgets land in A.3, the editor recursion and DropTargetRegistry rewrite that depends on A.1 and A.2.

- WidgetInstance gains a typed `children: Map<SlotId, SlotContent>` field, separate from `props`. Structure stays out of user-config payload so Phase C's mixin `transformProps` hook cannot corrupt the layout tree.
- @Widget gains `slots: Array<String> = []`; the KSP processor reads it into the generated descriptor's `slots: List<SlotId>` (default empty for leaves).
- WidgetDescriptor exposes `slots` with an `emptyList()` default so existing manual impls stay source-compatible.
- SlotPath replaces (SurfaceId, SlotId) for transforms. First hop carries (surface, rootSlot); each NestedSegment carries (parentInstanceId, slot) pointing into a container's children.
- `mutate(path)` walks down + rebuilds. Mutator-returns-same-ref preserves whole-graph identity (no allocation on no-ops -- matches existing transform contract).
- `moveWidget` rejects cycles (drop container into own subtree -> identity).
- `walkInstances` yields the full tree pre-order -- A.2's uniqueness check consumes this.
- Compat overloads on (SurfaceId, SlotId) and SlotAddress delegate to SlotPath; client-ui keeps compiling unchanged. A.3 migrates the editor side.
- WidgetValidator extracted from the processor: shared rule-set for KSP today, ready for the reflect.Method entry point Phase E will add for plugin loading.
- default-layout.json `schema_version` 1 -> 2 (forward-compat marker; field defaults make v1 data parse transparently).
- Compose stability of WidgetInstance NOT marked here -- widget-model stays Compose-free. Phase B.5 will address it via typed-props.

## Test plan

- [ ] `:widget-model:test` green (existing 11 root-level tests pass; new nested tests at depth 1 cover insert/remove/reorder/move into and out of containers; cycle rejection covered; walkInstances pre-order covered; SlotPath has its own unit suite).
- [ ] `:widget-processor:test` green (no test sources today; compile-only).
- [ ] Full `./gradlew check -x :client-ui:createReleaseDistributable` green -- compat overloads keep all downstream callers compiling without churn.
- [ ] Existing default-layout.json round-trips through the launcher repo (parse -> serialize) with schema v2 marker.