### PR TITLE
feat(launcher): A.2 -- debounced layout writes + flush + uniqueness (Phase A.2)

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
@@ -1,14 +1,17 @@
 package hivens.launcher
 
 import hivens.widget.model.LayoutGraph
+import hivens.widget.model.walkInstances
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -18,24 +21,33 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 /**
- * JSON-on-disk store for the widget [LayoutGraph]. Mirrors
- * [JsonPackRepository] in spirit -- single-file envelope with a
- * version tag, atomic write via `<file>.tmp` + ATOMIC_MOVE, malformed-
- * file falls back to the bundled default rather than crashing the
- * launcher.
+ * JSON-on-disk store for the widget [LayoutGraph]. Single-file envelope
+ * with a version tag, atomic write via `<file>.tmp` + ATOMIC_MOVE,
+ * malformed-file falls back to the bundled default rather than crashing
+ * the launcher.
  *
  * Wire format:
  * ```
  * { "schema_version": N, "graph": { "surfaces": { ... } } }
  * ```
  *
- * The wrapper exists so a schema bump can branch on `schema_version`
- * during load and apply migrations between graph shapes -- see
- * [Migrations].
+ * Disk writes are debounced ([DEBOUNCE_MS] after the last [update]) so
+ * a drag-thrash gesture across nested containers produces ~1 write per
+ * 200ms rather than dozens. [flush] forces the pending write
+ * synchronously and is called from a JVM shutdown hook so a SIGTERM
+ * mid-edit does not lose work.
+ *
+ * Each [update] also runs a tree-wide [instanceId] uniqueness check;
+ * a transform that produces duplicate ids (e.g. a buggy mixin in
+ * Phase C, or a paste-with-children that does not rewrite ids) is
+ * rejected with a warn log and identity return -- a single duplicate
+ * instanceId would otherwise corrupt every findByInstanceId-style
+ * traversal in the editor.
  */
 class LayoutGraphRepository(
     private val file: Path,
     private val json: Json,
+    private val scope: CoroutineScope,
     private val defaultGraph: () -> LayoutGraph,
 ) {
 
@@ -43,31 +55,86 @@ class LayoutGraphRepository(
     private val mutex = Mutex()
     private val state: MutableStateFlow<LayoutGraph> = MutableStateFlow(load())
 
+    // Pending debounced persist. Replaced on each update; cancelled by
+    // flush() which then persists synchronously under the same mutex.
+    private var pendingWrite: Job? = null
+
     fun observe(): StateFlow<LayoutGraph> = state.asStateFlow()
 
     fun value(): LayoutGraph = state.value
 
     /**
-     * Read-modify-write under [mutex]; the transform sees the current
-     * graph snapshot and returns the replacement. Persistence happens
-     * after the in-memory update so a write failure does not strand
-     * the observers with an applied-then-rolled-back value.
+     * Read-modify-write under [mutex]. The transform runs synchronously
+     * against the current snapshot; if it returns the same graph
+     * reference (no-op transform) or a graph with duplicate instance
+     * ids (invalid mutation), no state change and no disk write. On
+     * success the StateFlow re-emits immediately and a write is
+     * scheduled [DEBOUNCE_MS] in the future, replacing any previous
+     * pending write.
      */
     suspend fun update(transform: (LayoutGraph) -> LayoutGraph) {
         mutex.withLock {
             val next = transform(state.value)
             if (next == state.value) return@withLock
+
+            // Tree-wide instanceId uniqueness check. Walks the whole
+            // tree including nested children. Sequence-based so we
+            // short-circuit on the first dup.
+            val seen = HashSet<String>()
+            for (widget in next.walkInstances()) {
+                if (!seen.add(widget.instanceId)) {
+                    log.warn(
+                        "Layout update rejected: duplicate instanceId '{}' in tree. " +
+                        "Keeping previous graph to protect findByInstanceId-style traversals.",
+                        widget.instanceId,
+                    )
+                    return@withLock
+                }
+            }
+
             state.value = next
-            persist()
+
+            // Cancel-and-reschedule debounce. Coalesces drag-thrash
+            // gestures into ~1 write per DEBOUNCE_MS window.
+            pendingWrite?.cancel()
+            pendingWrite = scope.launch {
+                try {
+                    delay(DEBOUNCE_MS)
+                    mutex.withLock { writeNow() }
+                } catch (_: CancellationException) {
+                    // Superseded by a later update() or flushed
+                    // synchronously; either way no persist needed here.
+                }
+            }
+        }
+    }
+
+    /**
+     * Forces any pending debounced write to land on disk before
+     * returning. Cancels the in-flight debounce coroutine (if any) and
+     * persists the current state synchronously under [mutex]. Safe to
+     * call from a JVM shutdown hook (does no suspending I/O dispatch
+     * switch; the calling thread does the file write directly).
+     *
+     * No-op when nothing is pending and the on-disk file is already up
+     * to date.
+     */
+    suspend fun flush() {
+        mutex.withLock {
+            val pending = pendingWrite
+            pendingWrite = null
+            if (pending == null) return@withLock
+            pending.cancel()
+            writeNow()
         }
     }
 
     private fun load(): LayoutGraph {
         if (!Files.exists(file)) {
-            // First run: write the bundled default so subsequent
-            // loads operate on the user's editable copy, not the jar
-            // resource. Failure to write is non-fatal -- the launcher
-            // still runs against the in-memory default.
+            // First run: write the bundled default so subsequent loads
+            // operate on the user's editable copy, not the jar resource.
+            // Failure to write is non-fatal -- the launcher still runs
+            // against the in-memory default.
             val def = defaultGraph()
             try {
                 Files.createDirectories(file.parent)
@@ -87,7 +154,10 @@ class LayoutGraphRepository(
         }
     }
 
-    private suspend fun persist() = withContext(Dispatchers.IO) {
+    // Synchronous file ops. Caller MUST hold [mutex] when invoking.
+    // The debounce coroutine acquires the mutex inside its launched
+    // block; flush() invokes from inside its own mutex.withLock.
+    private fun writeNow() {
         try {
             Files.createDirectories(file.parent)
             val tmp = file.resolveSibling("${file.fileName}.tmp")
@@ -105,8 +175,6 @@ class LayoutGraphRepository(
                 )
                 Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
             }
-        } catch (e: CancellationException) {
-            throw e
         } catch (e: Exception) {
             log.error("Failed to persist layout graph at {}", file, e)
         }
@@ -119,15 +187,20 @@ class LayoutGraphRepository(
     )
 
     private companion object {
-        const val SCHEMA_VERSION = 1
+        const val SCHEMA_VERSION = 2
+
+        // 200ms catches a drag-thrash without delaying single drops
+        // noticeably. Verification target in the Phase A plan is "<=5
+        // disk writes over a 1s drag-thrash".
+        const val DEBOUNCE_MS = 200L
     }
 }
 
 /**
  * Schema migration ladder. Each step transforms a graph from version
- * N-1 to version N. Kernel-2 ships v1; the ladder is empty until a
- * future kernel-N introduces the first migration -- present so the
- * load path already routes through it.
+ * N-1 to version N. Phase A bumps to v2 (forward-compat marker for
+ * nested children -- the field defaults to empty, so v1 data parses
+ * transparently as v2).
  */
 internal object Migrations {
     fun apply(fromVersion: Int, graph: LayoutGraph): LayoutGraph {
@@ -137,10 +210,6 @@ internal object Migrations {
         // throwing here routes through load()'s catch and falls back
         // to the bundled default.
         require(fromVersion >= 1) { "schema_version must be >= 1, got $fromVersion" }
-        // Forward-only migration. fromVersion <= current SCHEMA_VERSION
-        // is the only supported direction; reading a file written by a
-        // newer launcher is treated as "ignore unknown fields, keep what
-        // we understand" via the Json instance's `ignoreUnknownKeys`.
         if (fromVersion >= CURRENT) return graph
         var current = graph
         for (step in fromVersion until CURRENT) {
@@ -149,10 +218,13 @@ internal object Migrations {
         return current
     }
 
-    private const val CURRENT = 1
+    private const val CURRENT = 2
 
     private fun step(toVersion: Int): Step = when (toVersion) {
-        // Future: 2 -> Step { graph -> ... merge new slots ... }
+        // v1 -> v2: WidgetInstance gained a children field. Default
+        // value handles backward compat on deserialization, so the
+        // step itself is identity.
+        2 -> Step.IDENTITY
         else -> Step.IDENTITY
     }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/LayoutGraphFlushHook.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/LayoutGraphFlushHook.kt
@@ -1,0 +1,40 @@
+package hivens.launcher.di
+
+import hivens.launcher.LayoutGraphRepository
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+
+/**
+ * JVM shutdown hook that flushes the [LayoutGraphRepository]'s pending
+ * debounced write before the process exits. Counterpart to
+ * [AppCoroutineScopeHook]: the latter cancels the process scope (which
+ * would otherwise terminate the in-flight debounce coroutine mid-delay
+ * and lose the user's last edit); this hook persists the in-memory
+ * state synchronously so a SIGTERM or tray-quit mid-edit cannot drop
+ * work.
+ *
+ * Hooks run in parallel per the JVM shutdown contract. Repository
+ * [flush][LayoutGraphRepository.flush] is mutex-locked and synchronous
+ * with respect to the file I/O, so racing with the scope cancellation
+ * hook is safe -- whichever wins the lock first completes; the other
+ * proceeds against either a cancelled or already-flushed state.
+ */
+class LayoutGraphFlushHook(
+    private val repo: LayoutGraphRepository,
+) {
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread(
+                {
+                    runCatching {
+                        runBlocking { repo.flush() }
+                    }.onFailure { err ->
+                        LoggerFactory.getLogger("LayoutGraphFlushHook")
+                            .warn("Layout flush on shutdown failed", err)
+                    }
+                },
+                "nexira-layout-flush",
+            )
+        )
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -467,9 +467,17 @@ val appModule = module {
         LayoutGraphRepository(
             file         = dataDir.resolve(Storage.LAYOUT_GRAPH_FILE),
             json         = get(),
+            scope        = get(),
             defaultGraph = { DefaultLayout.load(get()) },
         )
     }
+
+    // Flush pending debounced layout writes on JVM shutdown. Lives as
+    // its own createdAtStart=true single so the hook is registered
+    // during startKoin{}. Runs in parallel with AppCoroutineScopeHook
+    // (JVM shutdown hooks run concurrently); flush() is mutex-locked
+    // and cancellation-safe, so racing with scope cancellation is OK.
+    single(createdAtStart = true) { LayoutGraphFlushHook(get()) }
 
     single {
         val dataDir: Path = get()

--- a/client-launcher/src/test/kotlin/hivens/launcher/LayoutGraphRepositoryTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LayoutGraphRepositoryTest.kt
@@ -3,10 +3,17 @@ package hivens.launcher
 import hivens.widget.model.LayoutGraph
 import hivens.widget.model.SlotContent
 import hivens.widget.model.SlotId
+import hivens.widget.model.SlotPath
 import hivens.widget.model.SurfaceId
 import hivens.widget.model.SurfaceLayout
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -25,6 +32,7 @@ class LayoutGraphRepositoryTest {
     private lateinit var tmpDir: Path
     private lateinit var file: Path
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private lateinit var scope: CoroutineScope
 
     private val sampleDefault = LayoutGraph(
         surfaces = mapOf(
@@ -39,17 +47,21 @@ class LayoutGraphRepositoryTest {
         tmpDir = Files.createTempDirectory("layout-repo-test")
         tmpDir.toFile().deleteOnExit()
         file = tmpDir.resolve("layout-graph.json")
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 
     @AfterTest
     fun tearDown() {
+        scope.cancel()
         tmpDir.toFile().deleteRecursively()
     }
+
+    private fun repo() = LayoutGraphRepository(file, json, scope) { sampleDefault }
 
     @Test
     fun `missing file -- seeds the default and writes it`() = runBlocking {
         assertFalse(Files.exists(file))
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         assertEquals(sampleDefault, repo.value())
         assertEquals(sampleDefault, repo.observe().first())
         assertTrue(Files.exists(file), "first-run load should seed the file")
@@ -58,7 +70,7 @@ class LayoutGraphRepositoryTest {
 
     @Test
     fun `update mutates state and survives a reload`() = runBlocking {
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         val widget = WidgetInstance(
             kind = WidgetKind("home.classic.header"),
             instanceId = "i1",
@@ -75,8 +87,10 @@ class LayoutGraphRepositoryTest {
                 }
             )
         }
+        // Wait for the debounced write to land.
+        repo.flush()
 
-        val reloaded = LayoutGraphRepository(file, json) { sampleDefault }
+        val reloaded = LayoutGraphRepository(file, json, scope) { sampleDefault }
         val widgets = reloaded.value()
             .surfaces[SurfaceId("home.classic")]!!
             .slots[SlotId("main")]!!
@@ -86,12 +100,12 @@ class LayoutGraphRepositoryTest {
 
     @Test
     fun `update with identity transform does not rewrite file`() = runBlocking {
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
+        repo.flush()  // ensure seeded write completed
         val beforeMtime = Files.getLastModifiedTime(file)
-        // Sleep beyond filesystem mtime granularity (2s covers FAT32/HFS+
-        // worst case) so a rewrite would be detectable.
         Thread.sleep(50)
         repo.update { it }
+        repo.flush()
         val afterMtime = Files.getLastModifiedTime(file)
         assertEquals(beforeMtime, afterMtime, "no-op update must not touch the file")
     }
@@ -99,22 +113,22 @@ class LayoutGraphRepositoryTest {
     @Test
     fun `corrupt file -- falls back to default without crashing`() = runBlocking {
         Files.writeString(file, "{this is not valid json")
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         assertEquals(sampleDefault, repo.value())
     }
 
     @Test
     fun `negative schema_version is rejected without spinning the migration loop`() = runBlocking {
         // A corrupted or hand-edited envelope with Int.MIN_VALUE would
-        // make `fromVersion until CURRENT` iterate ~2 billion times and
-        // hang the launcher on startup. Migrations.apply must reject
-        // and let load()'s catch fall back to default.
+        // make `fromVersion until CURRENT` iterate billions of times
+        // and hang the launcher on startup. Migrations.apply must
+        // reject and let load()'s catch fall back to default.
         Files.writeString(
             file,
             """{"schema_version":-2147483648,"graph":{"surfaces":{}}}""",
         )
         val started = System.nanoTime()
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         val elapsedMs = (System.nanoTime() - started) / 1_000_000
         assertEquals(sampleDefault, repo.value())
         assertTrue(elapsedMs < 1_000, "load must fail-fast, took ${elapsedMs}ms")
@@ -122,7 +136,7 @@ class LayoutGraphRepositoryTest {
 
     @Test
     fun `observe re-emits after update`() = runBlocking {
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         val flow = repo.observe()
         assertEquals(sampleDefault, flow.first())
 
@@ -132,11 +146,198 @@ class LayoutGraphRepositoryTest {
 
     @Test
     fun `persisted file uses the versioned envelope shape`() = runBlocking {
-        val repo = LayoutGraphRepository(file, json) { sampleDefault }
+        val repo = repo()
         repo.update { LayoutGraph.EMPTY }
+        repo.flush()
         val text = Files.readString(file)
         assertTrue("schema_version" in text)
         assertTrue("graph" in text)
         assertTrue("surfaces" in text)
     }
+
+    // ── Debounce + flush ──────────────────────────────────────────────
+
+    @Test
+    fun `drag-thrash collapses to roughly one write per debounce window`() = runBlocking {
+        val repo = repo()
+        repo.flush()  // settle the seed write
+        val beforeMtime = Files.getLastModifiedTime(file)
+
+        // Fire 30 updates rapidly. Without debounce this would produce
+        // 30 file writes; with 200ms debounce we expect 0 (still pending)
+        // until we flush or wait out the window.
+        repeat(30) { i ->
+            repo.update { graph ->
+                graph.copy(
+                    surfaces = graph.surfaces + (SurfaceId("scratch-$i") to SurfaceLayout()),
+                )
+            }
+        }
+
+        // Immediately after, the file must NOT yet reflect the writes
+        // (within 200ms debounce window, give or take scheduling slop).
+        val midMtime = Files.getLastModifiedTime(file)
+        assertEquals(beforeMtime, midMtime, "writes must not have landed within debounce window")
+
+        // Flush completes the single coalesced write.
+        repo.flush()
+        val afterMtime = Files.getLastModifiedTime(file)
+        assertTrue(afterMtime > beforeMtime, "flush must land the coalesced write on disk")
+    }
+
+    @Test
+    fun `flush() persists the latest state synchronously`() = runBlocking {
+        val repo = repo()
+        repo.flush()  // settle seed
+
+        val widget = WidgetInstance(WidgetKind("k"), "i-flush-test", JsonObject(emptyMap()))
+        repo.update { it.copy(
+            surfaces = it.surfaces + (SurfaceId("fresh") to SurfaceLayout(
+                slots = mapOf(SlotId("only") to SlotContent(listOf(widget)))
+            ))
+        ) }
+        // Immediately flush -- no waiting for debounce.
+        repo.flush()
+
+        val text = Files.readString(file)
+        assertTrue("i-flush-test" in text, "flush must have written the latest state")
+    }
+
+    @Test
+    fun `flush() with no pending write is a no-op and does not touch the file`() = runBlocking {
+        val repo = repo()
+        repo.flush()  // settle seed
+        val beforeMtime = Files.getLastModifiedTime(file)
+        Thread.sleep(50)
+        repo.flush()  // no pending write
+        val afterMtime = Files.getLastModifiedTime(file)
+        assertEquals(beforeMtime, afterMtime)
+    }
+
+    @Test
+    fun `debounce window eventually persists without explicit flush`() = runBlocking {
+        val repo = repo()
+        repo.flush()  // settle seed
+        val beforeMtime = Files.getLastModifiedTime(file)
+        Thread.sleep(50)
+
+        repo.update {
+            it.copy(surfaces = it.surfaces + (SurfaceId("debounce-test") to SurfaceLayout()))
+        }
+
+        // Wait past the debounce window plus dispatch slop.
+        delay(400)
+
+        val afterMtime = Files.getLastModifiedTime(file)
+        assertTrue(afterMtime > beforeMtime, "debounce coroutine must have written on its own")
+    }
+
+    // ── Tree-wide uniqueness ──────────────────────────────────────────
+
+    @Test
+    fun `duplicate instanceId in tree is rejected`() = runBlocking {
+        val repo = repo()
+        val before = repo.value()
+
+        repo.update { graph ->
+            // Inject two widgets with the same instanceId across slots.
+            val w1 = WidgetInstance(WidgetKind("a"), "dup", JsonObject(emptyMap()))
+            val w2 = WidgetInstance(WidgetKind("b"), "dup", JsonObject(emptyMap()))
+            graph.copy(
+                surfaces = mapOf(
+                    SurfaceId("s") to SurfaceLayout(slots = mapOf(
+                        SlotId("a") to SlotContent(listOf(w1)),
+                        SlotId("b") to SlotContent(listOf(w2)),
+                    )),
+                ),
+            )
+        }
+
+        assertEquals(before, repo.value(), "duplicate instanceId update must be rejected")
+    }
+
+    @Test
+    fun `duplicate instanceId across nesting depth is also rejected`() = runBlocking {
+        val repo = repo()
+        val before = repo.value()
+
+        repo.update { _ ->
+            // Container widget at root, with a child that shares the
+            // container's own instanceId.
+            val child = WidgetInstance(WidgetKind("child"), "same", JsonObject(emptyMap()))
+            val container = WidgetInstance(
+                kind       = WidgetKind("container"),
+                instanceId = "same",
+                children   = mapOf(SlotId("body") to SlotContent(listOf(child))),
+            )
+            LayoutGraph(surfaces = mapOf(
+                SurfaceId("s") to SurfaceLayout(slots = mapOf(
+                    SlotId("a") to SlotContent(listOf(container)),
+                )),
+            ))
+        }
+
+        assertEquals(before, repo.value(), "cross-depth dup must be rejected too")
+    }
+
+    // ── Schema v1 -> v2 migration ─────────────────────────────────────
+
+    @Test
+    fun `v1 envelope without children parses cleanly under v2`() = runBlocking {
+        // Hand-write a v1 envelope (no `children` field on widgets).
+        val widget = WidgetInstance(WidgetKind("legacy"), "i1", JsonObject(emptyMap()))
+        val v1 = LayoutGraph(surfaces = mapOf(
+            SurfaceId("s") to SurfaceLayout(slots = mapOf(
+                SlotId("a") to SlotContent(listOf(widget)),
+            )),
+        ))
+        Files.writeString(
+            file,
+            """{"schema_version":1,"graph":${json.encodeToString(LayoutGraph.serializer(), v1)}}""",
+        )
+
+        val repo = repo()
+        val loaded = repo.value()
+        val loadedWidget = loaded
+            .surfaces[SurfaceId("s")]!!
+            .slots[SlotId("a")]!!
+            .widgets.first()
+        assertEquals("i1", loadedWidget.instanceId)
+        assertEquals(emptyMap(), loadedWidget.children)
+    }
+
+    @Test
+    fun `repo can update + persist nested children at depth 1`() = runBlocking {
+        val repo = repo()
+        repo.flush()
+
+        val child = WidgetInstance(WidgetKind("child"), "c1", JsonObject(emptyMap()))
+        val container = WidgetInstance(
+            kind       = WidgetKind("container"),
+            instanceId = "ctr",
+            children   = mapOf(SlotId("body") to SlotContent(listOf(child))),
+        )
+        repo.update { it.copy(
+            surfaces = it.surfaces + (SurfaceId("with-container") to SurfaceLayout(
+                slots = mapOf(SlotId("main") to SlotContent(listOf(container)))
+            ))
+        ) }
+        repo.flush()
+
+        val reloaded = LayoutGraphRepository(file, json, scope) { sampleDefault }
+        val containerLoaded = reloaded.value()
+            .surfaces[SurfaceId("with-container")]!!
+            .slots[SlotId("main")]!!
+            .widgets.first()
+        val childLoaded = containerLoaded.children[SlotId("body")]!!.widgets.first()
+        assertEquals("c1", childLoaded.instanceId)
+    }
+
+    // SlotPath compile-touch: ensure tests can construct one without
+    // relying on widget-model internals leaking.
+    @Suppress("unused")
+    private fun touchSlotPath() = SlotPath(SurfaceId("x"), SlotId("y"))
+
+    @Suppress("unused")
+    private fun touchJob(): Job? = null
 }


### PR DESCRIPTION
## Summary

Phase A.2 of the Modular UI initiative; stacked on top of #268 (A.1).

- `LayoutGraphRepository` takes a `CoroutineScope` constructor param; disk persists are debounced by 200ms via cancel-and-reschedule. A drag-thrash gesture that touches dozens of intermediate states across nested containers collapses to one write per quiet window.
- `suspend fun flush()` cancels the pending debounce Job and runs `writeNow()` synchronously under the same mutex. No `Dispatchers.IO` switch -- the calling thread does the file I/O directly, so the function is safe to call from a JVM shutdown hook.
- `LayoutGraphFlushHook` (Koin `createdAtStart = true`) installs that JVM shutdown hook so SIGTERM / tray-quit / window-close mid-edit cannot drop the last edit. Hooks run in parallel per the JVM contract -- racing with `AppCoroutineScopeHook` is OK because `flush()` is mutex-locked + cancellation-safe.
- Tree-wide `instanceId` uniqueness check on every update; consumes `walkInstances()` from A.1. A duplicate id at any depth -> warn log + identity return; the StateFlow does not re-emit. Without this, a single duplicate would corrupt every `findByInstanceId`-style traversal once nesting lands in A.3.
- Schema bumped to `v2` with an identity `v1 -> v2` migration step. `children` defaults to `emptyMap()` on `WidgetInstance` so a v1 envelope (no `children` key) deserializes cleanly under v2. `default-layout.json` on disk already moved to v2 in A.1.

## Test plan

- [ ] `:client-launcher:test` green.
- [ ] Drag-thrash: 30 rapid updates produce no disk write inside the debounce window; a single coalesced write lands after `flush()` or after 400ms.
- [ ] `flush()` no-op when nothing is pending (file mtime unchanged).
- [ ] Duplicate `instanceId` rejected at flat depth AND at nested depth (container shares id with its own child).
- [ ] V1 envelope round-trips: an old `{"schema_version":1, ...}` file loads, children defaults to empty.
- [ ] Nested children survive persist + reload (container with child widget at depth 1 round-trips through disk).
- [ ] Full `./gradlew check -x :client-ui:createReleaseDistributable` green.