### PR TITLE
feat(widgets): Phase A.3 -- editor recursion + container sample + slot validation

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
@@ -1,6 +1,7 @@
 package hivens.launcher
 
 import hivens.widget.model.LayoutGraph
+import hivens.widget.model.SurfaceId
 import hivens.widget.model.walkInstances
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -105,6 +106,31 @@ class LayoutGraphRepository(
                     // Superseded by a later update() or flushed
                     // synchronously; either way no persist needed here.
                 }
+            }
+        }
+    }
+
+    /**
+     * Resets one surface to its bundled default. Useful as an escape
+     * hatch when the user has dropped a non-removable widget into a
+     * surface it doesn't belong on, or wants to roll back accidental
+     * structural changes. Goes through the standard [update] path, so
+     * the tree-wide uniqueness check still runs, the StateFlow
+     * re-emits, and the disk write is debounced.
+     *
+     * Surface absent from the bundled default = removed entirely from
+     * the live graph (matches "this surface no longer exists in the
+     * default layout" semantics, e.g. a plugin-introduced surface that
+     * was uninstalled).
+     */
+    suspend fun resetSurface(surface: SurfaceId) {
+        val def = defaultGraph()
+        update { graph ->
+            val defaultLayout = def.surfaces[surface]
+            if (defaultLayout != null) {
+                graph.copy(surfaces = graph.surfaces + (surface to defaultLayout))
+            } else {
+                graph.copy(surfaces = graph.surfaces - surface)
             }
         }
     }

--- a/client-launcher/src/test/kotlin/hivens/launcher/LayoutGraphRepositoryTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LayoutGraphRepositoryTest.kt
@@ -333,6 +333,59 @@ class LayoutGraphRepositoryTest {
         assertEquals("c1", childLoaded.instanceId)
     }
 
+    // ── Surface reset ─────────────────────────────────────────────────
+
+    @Test
+    fun `resetSurface restores one surface from the bundled default without touching others`() = runBlocking {
+        val repo = repo()
+        repo.flush()
+
+        // Mutate two surfaces: home.classic gains a widget, plus a
+        // brand-new surface gets introduced.
+        val extra = WidgetInstance(WidgetKind("k"), "extra-w", JsonObject(emptyMap()))
+        repo.update { graph ->
+            graph.copy(
+                surfaces = graph.surfaces
+                    .mapValues { (sid, layout) ->
+                        if (sid == SurfaceId("home.classic")) {
+                            layout.copy(
+                                slots = layout.slots.mapValues { (_, content) ->
+                                    content.copy(widgets = content.widgets + extra)
+                                }
+                            )
+                        } else layout
+                    } + (SurfaceId("scratch") to SurfaceLayout()),
+            )
+        }
+        repo.flush()
+
+        // Reset home.classic. Surface should match the bundled default
+        // again; scratch surface must remain untouched.
+        repo.resetSurface(SurfaceId("home.classic"))
+        repo.flush()
+
+        val resetLayout = repo.value().surfaces[SurfaceId("home.classic")]
+        assertEquals(sampleDefault.surfaces[SurfaceId("home.classic")], resetLayout)
+        assertTrue(SurfaceId("scratch") in repo.value().surfaces, "non-target surface must be left alone")
+    }
+
+    @Test
+    fun `resetSurface removes a surface that is absent from the default`() = runBlocking {
+        val repo = repo()
+        repo.flush()
+
+        // Introduce a surface that the bundled default does NOT have.
+        repo.update { graph ->
+            graph.copy(surfaces = graph.surfaces + (SurfaceId("ghost") to SurfaceLayout()))
+        }
+        assertTrue(SurfaceId("ghost") in repo.value().surfaces)
+
+        repo.resetSurface(SurfaceId("ghost"))
+        repo.flush()
+
+        assertFalse(SurfaceId("ghost") in repo.value().surfaces, "absent-from-default surface should be removed on reset")
+    }
+
     // SlotPath compile-touch: ensure tests can construct one without
     // relying on widget-model internals leaking.
     @Suppress("unused")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -1,9 +1,7 @@
 package hivens.ui.editor
 
 import hivens.launcher.LayoutGraphRepository
-import hivens.widget.model.SlotAddress
-import hivens.widget.model.SlotId
-import hivens.widget.model.SurfaceId
+import hivens.widget.model.SlotPath
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
 import hivens.widget.model.insertWidget
@@ -21,30 +19,33 @@ import java.util.UUID
 //
 // Methods fire-and-forget on the supplied scope. The repo's StateFlow
 // drives recomposition; the caller never awaits the write.
+//
+// SlotPath is the canonical form. Each call corresponds to one
+// LayoutGraph transform applied at the path's leaf SlotContent.
 class EditModeController(
     private val repo: LayoutGraphRepository,
     private val scope: CoroutineScope,
 ) {
-    fun addWidget(surface: SurfaceId, slot: SlotId, kind: WidgetKind, index: Int) {
+    fun addWidget(path: SlotPath, kind: WidgetKind, index: Int) {
         scope.launch {
             val widget = WidgetInstance(kind = kind, instanceId = newInstanceId())
-            repo.update { it.insertWidget(surface, slot, widget, index) }
+            repo.update { it.insertWidget(path, widget, index) }
         }
     }
 
-    fun removeWidget(surface: SurfaceId, slot: SlotId, instanceId: String) {
+    fun removeWidget(path: SlotPath, instanceId: String) {
         scope.launch {
-            repo.update { it.removeWidget(surface, slot, instanceId) }
+            repo.update { it.removeWidget(path, instanceId) }
         }
     }
 
-    fun reorderInSlot(surface: SurfaceId, slot: SlotId, fromIndex: Int, toIndex: Int) {
+    fun reorderInSlot(path: SlotPath, fromIndex: Int, toIndex: Int) {
         scope.launch {
-            repo.update { it.reorderInSlot(surface, slot, fromIndex, toIndex) }
+            repo.update { it.reorderInSlot(path, fromIndex, toIndex) }
         }
     }
 
-    fun moveWidget(from: SlotAddress, to: SlotAddress, instanceId: String, toIndex: Int) {
+    fun moveWidget(from: SlotPath, to: SlotPath, instanceId: String, toIndex: Int) {
         scope.launch {
             repo.update { it.moveWidget(from, to, instanceId, toIndex) }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -4,6 +4,7 @@ import hivens.launcher.LayoutGraphRepository
 import hivens.widget.model.SlotContent
 import hivens.widget.model.SlotId
 import hivens.widget.model.SlotPath
+import hivens.widget.model.SurfaceId
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
 import hivens.widget.model.insertWidget
@@ -70,6 +71,16 @@ class EditModeController(
     fun moveWidget(from: SlotPath, to: SlotPath, instanceId: String, toIndex: Int) {
         scope.launch {
             repo.update { it.moveWidget(from, to, instanceId, toIndex) }
+        }
+    }
+
+    // Surface reset = restore from bundled default. Escape hatch for
+    // when a non-removable widget ends up out-of-place, or the user
+    // wants to undo a chain of edits on one surface without nuking
+    // their whole layout.
+    fun resetSurface(surface: SurfaceId) {
+        scope.launch {
+            repo.resetSurface(surface)
         }
     }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -1,6 +1,8 @@
 package hivens.ui.editor
 
 import hivens.launcher.LayoutGraphRepository
+import hivens.widget.model.SlotContent
+import hivens.widget.model.SlotId
 import hivens.widget.model.SlotPath
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
@@ -26,9 +28,29 @@ class EditModeController(
     private val repo: LayoutGraphRepository,
     private val scope: CoroutineScope,
 ) {
-    fun addWidget(path: SlotPath, kind: WidgetKind, index: Int) {
+    // `slots` comes from the widget's descriptor and pre-seeds the
+    // WidgetInstance.children map with empty SlotContent for every
+    // declared slot. Without this, a freshly palette-added container
+    // ships with children == emptyMap; LayoutGraph.mutateNested then
+    // sees `container.children[slot] == null` and identity-returns
+    // when the user tries to drop something INTO the container --
+    // the container appears "alive" because the empty placeholder
+    // registers bounds, but nothing actually persists. Pre-seeding
+    // happens at the editor layer because the LayoutGraph layer
+    // intentionally rejects undeclared slots (no auto-create), so
+    // typo-protection stays at the model boundary.
+    fun addWidget(path: SlotPath, kind: WidgetKind, slots: List<SlotId>, index: Int) {
         scope.launch {
-            val widget = WidgetInstance(kind = kind, instanceId = newInstanceId())
+            val children = if (slots.isEmpty()) {
+                emptyMap()
+            } else {
+                slots.associateWith { SlotContent() }
+            }
+            val widget = WidgetInstance(
+                kind       = kind,
+                instanceId = newInstanceId(),
+                children   = children,
+            )
             repo.update { it.insertWidget(path, widget, index) }
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -69,6 +69,8 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -726,18 +728,30 @@ private fun DragGhostOverlay(dragController: DragController) {
     // overlay. pointerHoverIcon does not intercept pointer events, so
     // the underlying drag handler keeps receiving updates.
     val transparentCursor = remember { transparentPointerIcon() }
+    // graphicsLayer.translationX/Y translates relative to the host
+    // Box's natural untranslated position, NOT window (0, 0). When the
+    // EditorSurfaceHost mounts inside AppLayout after the left rail
+    // (~64dp wide), the host's local origin is at window (railWidth,
+    // topbarHeight) -- applying pointer-in-window coords directly as
+    // translation drags the ghost away from the cursor by exactly that
+    // offset. Track the overlay's own window origin and subtract it so
+    // the ghost lands at the real pointer position.
+    var overlayOriginInWindow by remember { mutableStateOf(Offset.Zero) }
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .pointerHoverIcon(icon = transparentCursor, overrideDescendants = true),
+            .pointerHoverIcon(icon = transparentCursor, overrideDescendants = true)
+            .onGloballyPositioned { coords ->
+                overlayOriginInWindow = coords.boundsInWindow().topLeft
+            },
     ) {
         Box(
             modifier = Modifier
                 .graphicsLayer {
-                    val x = (active.pointerInWindow.x - active.pickupOffset.x)
-                    val y = (active.pointerInWindow.y - active.pickupOffset.y)
-                    translationX = x
-                    translationY = y
+                    val targetWindowX = active.pointerInWindow.x - active.pickupOffset.x
+                    val targetWindowY = active.pointerInWindow.y - active.pickupOffset.y
+                    translationX = targetWindowX - overlayOriginInWindow.x
+                    translationY = targetWindowY - overlayOriginInWindow.y
                     alpha        = 0.78f
                     scaleX       = 1.04f
                     scaleY       = 1.04f

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -29,13 +29,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ViewQuilt
+import androidx.compose.material.icons.automirrored.filled.ViewSidebar
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material.icons.filled.ViewQuilt
-import androidx.compose.material.icons.filled.ViewSidebar
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Widgets
@@ -99,6 +99,7 @@ import hivens.ui.widgets.shell.LocalLeftRailContext
 import hivens.ui.widgets.shell.LocalRightRailContext
 import hivens.widget.api.EmptySlotDecorator
 import hivens.widget.api.LocalEmptySlotDecorator
+import hivens.widget.api.LocalSlotPath
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.widget.api.LocalWidgetDecorator
@@ -168,6 +169,13 @@ fun EditorSurfaceHost(
     // Wrong-surface widgets render plain. Previewing temporarily
     // suppresses all chrome so the user can see the real look without
     // leaving edit mode.
+    //
+    // The decorator reads LocalSlotPath inside the @Composable lambda
+    // body (the lambda runs in composition because it's invoked from
+    // SlotRenderer's render path). The path identifies the full nested
+    // address of the widget being rendered; chrome uses it both as the
+    // registry key for drop-target bounds and to compose into nested
+    // slots correctly.
     val chromeDecorator: WidgetDecorator = remember(state, previewing) {
         if (state is EditModeState.On && !previewing) {
             val selected = state.surface
@@ -176,29 +184,29 @@ fun EditorSurfaceHost(
                     content()
                     return@decorator
                 }
+                val path = LocalSlotPath.current
                 EditableWidgetChrome(
-                    address      = address,
+                    path         = path,
                     index        = index,
                     descriptor   = descriptor,
                     instance     = instance,
                     controller   = dragController,
                     registry     = registry,
                     onRemove     = {
-                        controller.removeWidget(address.surface, address.slot, instance.instanceId)
+                        controller.removeWidget(path, instance.instanceId)
                     },
                     onCommitDrop = { committedPointer ->
                         // Hit-test which slot received the drop. Null =
                         // pointer is off any slot; treat as cancel.
-                        val targetSlot = registry.slotForPoint(committedPointer)
+                        val targetPath = registry.slotForPoint(committedPointer)
                             ?: return@EditableWidgetChrome
-                        val targetIdx = registry.insertionIndexInSlot(targetSlot, committedPointer)
-                        if (targetSlot == address) {
+                        val targetIdx = registry.insertionIndexInSlot(targetPath, committedPointer)
+                        if (targetPath == path) {
                             // Same slot -- reorder. -1 when moving down
                             // because removing the source shifts indices.
                             if (targetIdx != index) {
                                 controller.reorderInSlot(
-                                    surface   = address.surface,
-                                    slot      = address.slot,
+                                    path      = path,
                                     fromIndex = index,
                                     toIndex   = if (targetIdx > index) targetIdx - 1 else targetIdx,
                                 )
@@ -209,8 +217,8 @@ fun EditorSurfaceHost(
                             // index adjustment needed since the source
                             // slot is different.
                             controller.moveWidget(
-                                from       = address,
-                                to         = targetSlot,
+                                from       = path,
+                                to         = targetPath,
                                 instanceId = instance.instanceId,
                                 toIndex    = targetIdx,
                             )
@@ -225,14 +233,15 @@ fun EditorSurfaceHost(
     }
 
     // Empty-slot decorator: placeholder on every editable surface
-    // while edit mode is on. Chrome filtering is keyed to selection
-    // (interaction focus), but a palette drop should be able to land
-    // on any visible empty slot regardless of which surface chip the
-    // user happens to have active.
+    // while edit mode is on. Reads LocalSlotPath so a nested empty
+    // slot (container with no children) registers its bounds against
+    // the nested path key rather than colliding with another container
+    // at the same (surface, slot) leaf coords.
     val emptyDecorator: EmptySlotDecorator = remember(state, registry, previewing) {
         if (state is EditModeState.On && !previewing) {
-            { address ->
-                EmptySlotPlaceholder(address = address, registry = registry)
+            { _ ->
+                val path = LocalSlotPath.current
+                EmptySlotPlaceholder(path = path, registry = registry)
             }
         } else {
             {}
@@ -600,8 +609,8 @@ private fun ToolChip(
 
 private fun surfaceIcon(surface: SurfaceId): androidx.compose.ui.graphics.vector.ImageVector =
     when (surface.value) {
-        "appshell.leftrail"  -> Icons.Default.ViewSidebar
-        "appshell.rightrail" -> Icons.Default.ViewQuilt
+        "appshell.leftrail"  -> Icons.AutoMirrored.Filled.ViewSidebar
+        "appshell.rightrail" -> Icons.AutoMirrored.Filled.ViewQuilt
         else                 -> Icons.Default.Home
     }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -35,15 +35,18 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -144,6 +147,7 @@ fun EditorSurfaceHost(
     var paletteOpen   by remember(availableSurfaces) { mutableStateOf(true) }
     var previewing    by remember(availableSurfaces) { mutableStateOf(false) }
     var presetPanelOpen by remember(availableSurfaces) { mutableStateOf(false) }
+    var resetSurfaceConfirm by remember(availableSurfaces) { mutableStateOf(false) }
     var selectedSurface by remember(availableSurfaces) {
         mutableStateOf(availableSurfaces.firstOrNull())
     }
@@ -296,8 +300,38 @@ fun EditorSurfaceHost(
                     previewing        = previewing,
                     onTogglePreview   = { previewing = !previewing },
                     onOpenPresets     = { presetPanelOpen = true },
+                    onRequestReset    = { if (selectedSurface != null) resetSurfaceConfirm = true },
                     modifier          = Modifier.align(Alignment.TopCenter).padding(top = 16.dp),
                 )
+
+                val surfaceForReset = selectedSurface
+                if (resetSurfaceConfirm && surfaceForReset != null) {
+                    AlertDialog(
+                        onDismissRequest = { resetSurfaceConfirm = false },
+                        title            = { Text("Сбросить поверхность к умолчанию?") },
+                        text             = {
+                            Text(
+                                text = buildString {
+                                    append("\"")
+                                    append(humanSurfaceName(surfaceForReset))
+                                    append("\" вернётся к расстановке виджетов из встроенного default-layout. ")
+                                    append("Все локальные изменения на этой поверхности (добавленные виджеты, ")
+                                    append("перестановки, удаления) пропадут. Другие поверхности не тронем.")
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                controller.resetSurface(surfaceForReset)
+                                resetSurfaceConfirm = false
+                            }) { Text("Сбросить", color = CelestiaTheme.colors.error) }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { resetSurfaceConfirm = false }) { Text("Отмена") }
+                        },
+                    )
+                }
 
                 PresetManagerPanel(
                     visible       = editing && presetPanelOpen,
@@ -461,6 +495,7 @@ private fun EditModePill(
     previewing: Boolean,
     onTogglePreview: () -> Unit,
     onOpenPresets: () -> Unit,
+    onRequestReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -526,6 +561,17 @@ private fun EditModePill(
                     label    = "Пресеты",
                     selected = false,
                     onClick  = onOpenPresets,
+                )
+                Spacer(Modifier.width(4.dp))
+
+                // Escape hatch: reset the currently selected surface
+                // to its bundled default. Confirmation dialog handled
+                // at host level; the chip just signals intent.
+                ToolChip(
+                    icon     = Icons.Default.RestartAlt,
+                    label    = "Сбросить",
+                    selected = false,
+                    onClick  = onRequestReset,
                 )
                 Spacer(Modifier.width(10.dp))
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -565,13 +565,18 @@ private fun EditModePill(
                 Spacer(Modifier.width(4.dp))
 
                 // Escape hatch: reset the currently selected surface
-                // to its bundled default. Confirmation dialog handled
-                // at host level; the chip just signals intent.
+                // to its bundled default. Destructive tint signals it
+                // is a different class of action from the neutral
+                // toggles next to it; confirmation dialog handled at
+                // host level. Disabled when no surface is selected so
+                // the chip cannot pretend to be live.
                 ToolChip(
-                    icon     = Icons.Default.RestartAlt,
-                    label    = "Сбросить",
-                    selected = false,
-                    onClick  = onRequestReset,
+                    icon        = Icons.Default.RestartAlt,
+                    label       = "Сбросить",
+                    selected    = false,
+                    onClick     = onRequestReset,
+                    destructive = true,
+                    enabled     = selectedSurface != null,
                 )
                 Spacer(Modifier.width(10.dp))
 
@@ -625,15 +630,26 @@ private fun ToolChip(
     label: String,
     selected: Boolean,
     onClick: () -> Unit,
+    destructive: Boolean = false,
+    enabled: Boolean = true,
 ) {
-    val bg = if (selected) CelestiaTheme.colors.primary.copy(alpha = 0.18f)
-             else CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.6f)
-    val fg = if (selected) CelestiaTheme.colors.primary else CelestiaTheme.colors.textPrimary
+    val bg = when {
+        !enabled    -> CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.3f)
+        destructive -> CelestiaTheme.colors.error.copy(alpha = 0.12f)
+        selected    -> CelestiaTheme.colors.primary.copy(alpha = 0.18f)
+        else        -> CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.6f)
+    }
+    val fg = when {
+        !enabled    -> CelestiaTheme.colors.textSecondary.copy(alpha = 0.45f)
+        destructive -> CelestiaTheme.colors.error
+        selected    -> CelestiaTheme.colors.primary
+        else        -> CelestiaTheme.colors.textPrimary
+    }
     Surface(color = bg, shape = RoundedCornerShape(12.dp)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .clickable { onClick() }
+                .clickable(enabled = enabled) { onClick() }
                 .padding(horizontal = 10.dp, vertical = 5.dp),
         ) {
             Icon(
@@ -647,7 +663,7 @@ private fun ToolChip(
                 text       = label,
                 style      = MaterialTheme.typography.labelSmall,
                 color      = fg,
-                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                fontWeight = if (selected || destructive) FontWeight.SemiBold else FontWeight.Medium,
             )
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -50,8 +50,9 @@ import hivens.ui.editor.dnd.widgetBounds
 import hivens.ui.theme.CelestiaTheme
 import hivens.widget.api.LocalLayoutGraph
 import hivens.widget.api.WidgetDescriptor
-import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotPath
 import hivens.widget.model.WidgetInstance
+import hivens.widget.model.traverse
 
 // Wraps a single widget with edit-mode chrome: drag handle (always
 // visible, opacity boosts on hover), remove button (hover-only, hidden
@@ -62,7 +63,7 @@ import hivens.widget.model.WidgetInstance
 // during a drag.
 @Composable
 fun EditableWidgetChrome(
-    address: SlotAddress,
+    path: SlotPath,
     index: Int,
     descriptor: WidgetDescriptor,
     instance: WidgetInstance,
@@ -80,18 +81,23 @@ fun EditableWidgetChrome(
         ?.instance?.instanceId == instance.instanceId
 
     // Drop-indicator hit test. Reading controller.active recomposes on
-    // every pointer update; the registry queries are O(widgets-in-slot)
-    // and cheap enough to do per-frame for the few dozen widgets a
-    // surface can hold.
+    // every pointer update; traverse + registry queries are O(depth +
+    // widgets-in-slot) and cheap enough to do per-frame for the few
+    // dozen widgets a surface can hold.
     val graph = LocalLayoutGraph.current
-    val slotCount = graph.surfaces[address.surface]?.slots?.get(address.slot)?.widgets?.size ?: 0
+    val slotCount = graph.traverse(path)?.widgets?.size ?: 0
     val isLastInSlot = index == slotCount - 1
-    val dropTargetSlot = activeDrag?.let { registry.slotForPoint(it.pointerInWindow) }
-    val dropInsertionIdx = if (activeDrag != null && dropTargetSlot == address) {
-        registry.insertionIndexInSlot(address, activeDrag.pointerInWindow)
+    val dropTargetPath = activeDrag?.let { registry.slotForPoint(it.pointerInWindow) }
+    val dropInsertionIdx = if (activeDrag != null && dropTargetPath == path) {
+        registry.insertionIndexInSlot(path, activeDrag.pointerInWindow)
     } else -1
     val showIndicatorBefore = dropInsertionIdx == index
     val showIndicatorAfter  = isLastInSlot && dropInsertionIdx == slotCount
+
+    // Nesting depth -> subtle border alpha boost. Depth 0 (root surface
+    // slot) keeps the original 0.18/0.55 alpha; each level adds 0.06
+    // and we clip at 0.40/0.85 so deep stacks stay readable.
+    val depthBoost = (path.nested.size * 0.06f).coerceAtMost(0.22f)
 
     // The ghost lambda is invoked by DragGhostOverlay at the host
     // level -- outside the surface composable's CompositionLocalProvider
@@ -110,7 +116,7 @@ fun EditableWidgetChrome(
         label         = "edit-source-alpha",
     )
     val borderAlpha by animateFloatAsState(
-        targetValue   = if (isHovered) 0.55f else 0.18f,
+        targetValue   = if (isHovered) 0.55f + depthBoost else 0.18f + depthBoost,
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
         label         = "edit-border-alpha",
     )
@@ -124,9 +130,9 @@ fun EditableWidgetChrome(
                 .onGloballyPositioned { coords: LayoutCoordinates ->
                     val rect = coords.boundsInWindow()
                     widgetWindowBounds = rect
-                    registry.registerWidget(address, instance.instanceId, index, rect)
+                    registry.registerWidget(path, instance.instanceId, index, rect)
                 }
-                .widgetBounds(registry, address, instance.instanceId, index)
+                .widgetBounds(registry, path, instance.instanceId, index)
                 .padding(2.dp)
                 .border(
                     width = 1.dp,
@@ -148,7 +154,7 @@ fun EditableWidgetChrome(
                     .size(22.dp)
                     .dragSource(
                         controller            = controller,
-                        payload               = DragPayload.ExistingWidget(address, index, instance),
+                        payload               = DragPayload.ExistingWidget(path, index, instance),
                         widgetBoundsProvider  = { widgetWindowBounds },
                         ghost                 = {
                             CompositionLocalProvider(capturedLocals) { content() }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -20,9 +20,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentCompositionLocalContext
@@ -76,6 +81,7 @@ fun EditableWidgetChrome(
     val interaction = remember { MutableInteractionSource() }
     val isHovered by interaction.collectIsHoveredAsState()
     var widgetWindowBounds by remember { mutableStateOf<Rect?>(null) }
+    var forceRemoveOpen by remember { mutableStateOf(false) }
     val activeDrag = controller.active
     val isThisDragging = (activeDrag?.payload as? DragPayload.ExistingWidget)
         ?.instance?.instanceId == instance.instanceId
@@ -170,11 +176,13 @@ fun EditableWidgetChrome(
                 )
             }
 
-            // Remove button: hover-only, hidden on non-removable widgets.
-            // Animated fade so it does not pop in jarringly. Qualified
-            // with this@Column because the inner Box sits inside the
-            // outer drop-indicator Column, and Kotlin would otherwise
-            // try ColumnScope.AnimatedVisibility against a BoxScope `this`.
+            // Remove button: hover-only, red close icon. Hidden on
+            // non-removable widgets (those get the force-remove
+            // affordance below instead). Animated fade so it does not
+            // pop in jarringly. Qualified with this@Column because the
+            // inner Box sits inside the outer drop-indicator Column,
+            // and Kotlin would otherwise try ColumnScope.AnimatedVisibility
+            // against a BoxScope `this`.
             this@Column.AnimatedVisibility(
                 visible  = isHovered && descriptor.removable,
                 enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
@@ -206,8 +214,79 @@ fun EditableWidgetChrome(
                     )
                 }
             }
+
+            // Force-remove affordance for non-removable widgets. Same
+            // top-right slot as the regular remove button, but uses a
+            // warning-tinted DeleteForever icon and gates the action
+            // behind a confirmation dialog. Without this, a non-
+            // removable widget that ends up in the wrong slot (preset
+            // import, plugin install, or a user-driven move out of its
+            // home surface) has no exit path short of editing
+            // layout-graph.json by hand or invoking the per-surface
+            // reset on the edit pill.
+            this@Column.AnimatedVisibility(
+                visible  = isHovered && !descriptor.removable,
+                enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
+                exit     = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
+                modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
+            ) {
+                Surface(
+                    color    = CelestiaTheme.colors.warnAccent.copy(alpha = 0.85f),
+                    shape    = RoundedCornerShape(6.dp),
+                    modifier = Modifier
+                        .size(22.dp)
+                        .pointerInput(instance.instanceId) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    if (event.type == PointerEventType.Release) {
+                                        forceRemoveOpen = true
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        },
+                ) {
+                    Icon(
+                        imageVector        = Icons.Default.DeleteForever,
+                        contentDescription = "Force remove non-removable widget",
+                        tint               = Color.White,
+                        modifier           = Modifier.size(14.dp).padding(0.dp),
+                    )
+                }
+            }
         }
         if (showIndicatorAfter) DropIndicator()
+    }
+
+    if (forceRemoveOpen) {
+        AlertDialog(
+            onDismissRequest = { forceRemoveOpen = false },
+            title            = { Text("Удалить виджет принудительно?") },
+            text             = {
+                Text(
+                    text = buildString {
+                        append("\"")
+                        append(descriptor.displayName)
+                        append("\" помечен как неудаляемый. ")
+                        append("Обычно такие виджеты держат на месте, чтобы пользователь не остался ")
+                        append("без навигации. Если ты уверен, что виджет тут не нужен, можно ")
+                        append("снести его прямо сейчас -- а если что, сбрось поверхность к умолчанию ")
+                        append("через меню справа от чипа поверхности.")
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    forceRemoveOpen = false
+                    onRemove()
+                }) { Text("Удалить", color = CelestiaTheme.colors.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { forceRemoveOpen = false }) { Text("Отмена") }
+            },
+        )
     }
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -208,8 +208,8 @@ fun EditableWidgetChrome(
                 ) {
                     Icon(
                         imageVector        = Icons.Default.Close,
-                        contentDescription = "Remove widget",
-                        tint               = Color.White,
+                        contentDescription = "Удалить",
+                        tint               = CelestiaTheme.colors.onPrimary,
                         modifier           = Modifier.size(14.dp).padding(0.dp).graphicsLayer { },
                     )
                 }
@@ -249,8 +249,8 @@ fun EditableWidgetChrome(
                 ) {
                     Icon(
                         imageVector        = Icons.Default.DeleteForever,
-                        contentDescription = "Force remove non-removable widget",
-                        tint               = Color.White,
+                        contentDescription = "Удалить принудительно",
+                        tint               = CelestiaTheme.colors.onPrimary,
                         modifier           = Modifier.size(14.dp).padding(0.dp),
                     )
                 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EmptySlotPlaceholder.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EmptySlotPlaceholder.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.theme.CelestiaTheme
-import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotPath
 
 // Rendered by SlotRenderer when a slot has no widgets and the editor
 // has supplied this decorator. Two purposes:
@@ -48,7 +48,7 @@ import hivens.widget.model.SlotAddress
 // but not noisy".
 @Composable
 fun EmptySlotPlaceholder(
-    address: SlotAddress,
+    path: SlotPath,
     registry: DropTargetRegistry,
 ) {
     val breath by rememberInfiniteTransition(label = "empty-slot-breath").animateFloat(
@@ -67,7 +67,7 @@ fun EmptySlotPlaceholder(
             .height(80.dp)
             .padding(vertical = 6.dp)
             .onGloballyPositioned { c: LayoutCoordinates ->
-                registry.registerSlot(address, c.boundsInWindow())
+                registry.registerSlot(path, c.boundsInWindow())
             },
         contentAlignment = Alignment.Center,
     ) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -134,7 +134,14 @@ class DropTargetRegistry {
         fun consider(rect: Rect, path: SlotPath) {
             if (!rect.contains(pointInWindow)) return
             val area = rect.width * rect.height
-            if (area < bestArea) {
+            // Tie-break by nested depth so two overlapping rects of
+            // identical area resolve deterministically -- without this
+            // the winner depends on SnapshotStateMap iteration order
+            // (unspecified), and a hit-test that flickers between two
+            // candidates would feel like the editor is jumping.
+            val current = best
+            val currentDepth = current?.nested?.size ?: -1
+            if (area < bestArea || (area == bestArea && path.nested.size > currentDepth)) {
                 best = path
                 bestArea = area
             }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotPath
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
 
@@ -28,12 +29,13 @@ import hivens.widget.model.WidgetKind
 
 sealed class DragPayload {
     data class ExistingWidget(
-        val source: SlotAddress,
+        val source: SlotPath,
         val sourceIndex: Int,
         val instance: WidgetInstance,
     ) : DragPayload()
 
-    // Palette drag arrives in editor-3. ExistingWidget covers editor-2.
+    // Palette-originated drag. Resolves to an EditModeController.addWidget
+    // at drop time; the target SlotPath comes from the registry hit-test.
     data class PaletteWidget(val kind: WidgetKind) : DragPayload()
 }
 
@@ -81,75 +83,96 @@ class DragController {
 
 // ── Drop target registry ────────────────────────────────────────────────────
 
-// Per-widget bounds in window coords. Keyed by SlotAddress then by
-// position-in-slot (matches LayoutGraph ordering). Empty slots are
-// registered with an empty rect list so the registry knows the slot
-// exists but has no widgets to hit-test against.
 data class WidgetBounds(val index: Int, val rect: Rect)
 
+// Hierarchical drop targets. Keys are SlotPath (full address through
+// nested containers), so a drop into "container body" on home.new is
+// distinct from a drop into the same slot id on the right rail.
+//
+// slotForPoint returns the INNERMOST slot whose rect (widget rect,
+// vertical span fallback, or empty-slot placeholder rect) contains the
+// pointer -- "innermost" = smallest area. Without that ordering, a
+// container's outer rect would always win over its own children and
+// the user could never drop into a nested slot.
 class DropTargetRegistry {
-    private val widgets: SnapshotStateMap<SlotAddress, SnapshotStateMap<String, WidgetBounds>> =
+    private val widgets: SnapshotStateMap<SlotPath, SnapshotStateMap<String, WidgetBounds>> =
         mutableStateMapOf()
-    private val slotBounds: SnapshotStateMap<SlotAddress, Rect> = mutableStateMapOf()
+    private val slotBounds: SnapshotStateMap<SlotPath, Rect> = mutableStateMapOf()
 
-    fun registerSlot(slot: SlotAddress, rect: Rect) {
-        slotBounds[slot] = rect
+    fun registerSlot(path: SlotPath, rect: Rect) {
+        slotBounds[path] = rect
     }
 
-    fun unregisterSlot(slot: SlotAddress) {
-        slotBounds.remove(slot)
-        widgets.remove(slot)
+    fun unregisterSlot(path: SlotPath) {
+        slotBounds.remove(path)
+        widgets.remove(path)
     }
 
-    fun registerWidget(slot: SlotAddress, instanceId: String, index: Int, rect: Rect) {
-        val byId = widgets.getOrPut(slot) { mutableStateMapOf() }
+    fun registerWidget(path: SlotPath, instanceId: String, index: Int, rect: Rect) {
+        val byId = widgets.getOrPut(path) { mutableStateMapOf() }
         byId[instanceId] = WidgetBounds(index, rect)
     }
 
-    fun unregisterWidget(slot: SlotAddress, instanceId: String) {
-        widgets[slot]?.remove(instanceId)
+    fun unregisterWidget(path: SlotPath, instanceId: String) {
+        widgets[path]?.remove(instanceId)
     }
 
-    // Locates which slot the pointer is currently over. Three passes:
-    // 1) exact rect hit on any widget, 2) the slot whose tracked
-    // widget rects most-nearly bracket the pointer Y, 3) empty-slot
-    // bounds registered by EmptySlotDecorator. Returns null when the
-    // pointer is outside every registered slot.
-    fun slotForPoint(pointInWindow: Offset): SlotAddress? {
-        widgets.forEach { (slot, byId) ->
-            byId.values.forEach { wb ->
-                if (wb.rect.contains(pointInWindow)) return slot
+    // Two passes:
+    //   1) exact rect hit across all registered sources (widget rects +
+    //      empty-slot placeholder bounds), innermost (smallest area)
+    //      wins. Both kinds compete in the same pass so a nested empty
+    //      slot beats its enclosing container's widget rect.
+    //   2) vertical-span-with-12px-tolerance fallback for "in-between"
+    //      gap drops where the pointer is in a slot's vertical bracket
+    //      but not over any of its widgets. Only consulted when pass 1
+    //      finds no exact hit.
+    // Returns null when the pointer is outside every registered slot.
+    fun slotForPoint(pointInWindow: Offset): SlotPath? {
+        var best: SlotPath? = null
+        var bestArea = Float.POSITIVE_INFINITY
+
+        fun consider(rect: Rect, path: SlotPath) {
+            if (!rect.contains(pointInWindow)) return
+            val area = rect.width * rect.height
+            if (area < bestArea) {
+                best = path
+                bestArea = area
             }
         }
-        // Fallback: pick the slot whose vertical span covers the
-        // pointer, plus a 12px tolerance to make gap drops feel
-        // forgiving. Horizontal span must also cover the pointer.
+
+        // Pass 1: every exact rect competes by area. Crucially, the
+        // empty-slot placeholder rect of a container's child slot must
+        // be eligible against the container widget's own rect -- the
+        // child slot is strictly smaller and the user means to drop
+        // INTO it.
+        widgets.forEach { (path, byId) ->
+            byId.values.forEach { wb -> consider(wb.rect, path) }
+        }
+        slotBounds.forEach { (path, rect) -> consider(rect, path) }
+        if (best != null) return best
+
+        // Pass 2: vertical-span fallback. Per-slot virtual bounding
+        // rect across all that slot's widgets, with horizontal extent
+        // matching widest widget and vertical padding for gap drops.
         val tolerance = 12f
-        widgets.forEach { (slot, byId) ->
+        widgets.forEach { (path, byId) ->
             val items = byId.values
             if (items.isEmpty()) return@forEach
             val minY = items.minOf { it.rect.top } - tolerance
             val maxY = items.maxOf { it.rect.bottom } + tolerance
             val minX = items.minOf { it.rect.left }
             val maxX = items.maxOf { it.rect.right }
-            if (pointInWindow.y in minY..maxY && pointInWindow.x in minX..maxX) {
-                return slot
-            }
+            consider(Rect(minX, minY, maxX, maxY), path)
         }
-        // Empty slot fallback: EmptySlotDecorator registers slot
-        // bounds; drop into the empty placeholder lands here.
-        slotBounds.forEach { (slot, rect) ->
-            if (rect.contains(pointInWindow)) return slot
-        }
-        return null
+        return best
     }
 
     // Insertion index for a pointer inside a known slot. Index is in
     // [0, count] -- count means "append at end". Algorithm: find the
     // widget whose vertical midpoint the pointer is above; insert at
     // that widget's position. If pointer is below all widgets, append.
-    fun insertionIndexInSlot(slot: SlotAddress, pointInWindow: Offset): Int {
-        val items = widgets[slot]?.values?.sortedBy { it.index } ?: return 0
+    fun insertionIndexInSlot(path: SlotPath, pointInWindow: Offset): Int {
+        val items = widgets[path]?.values?.sortedBy { it.index } ?: return 0
         if (items.isEmpty()) return 0
         items.forEach { wb ->
             val midY = wb.rect.top + wb.rect.height / 2f
@@ -171,7 +194,7 @@ val LocalDropTargetRegistry: ProvidableCompositionLocal<DropTargetRegistry> =
 
 // Attach to the drag handle, not the whole widget -- prevents accidental
 // drag of an interactive control (button, slider). The lambda
-// `widgetBoundsProvider` returns the widget's window-coord bounds so the
+// widgetBoundsProvider returns the widget's window-coord bounds so the
 // ghost can position itself at the right pickup offset.
 fun Modifier.dragSource(
     controller: DragController,
@@ -185,7 +208,7 @@ fun Modifier.dragSource(
         val drag = awaitTouchSlopOrCancellation(down.id) { change, _ -> change.consume() }
             ?: return@awaitEachGesture
         val bounds = widgetBoundsProvider() ?: return@awaitEachGesture
-        val pickup = drag.position - Offset(0f, 0f)  // pointer offset within source
+        val pickup = drag.position - Offset(0f, 0f)
         controller.begin(
             payload         = payload,
             pointerInWindow = bounds.topLeft + drag.position,
@@ -209,24 +232,31 @@ fun Modifier.dragSource(
 
 // ── Drop-target modifier ────────────────────────────────────────────────────
 
-// Registers the slot's bounds with the registry. Per-widget bounds are
-// registered separately by EditableWidgetChrome via widgetBounds().
 fun Modifier.slotBounds(
     registry: DropTargetRegistry,
-    slot: SlotAddress,
+    path: SlotPath,
 ): Modifier = this.onGloballyPositioned { coords: LayoutCoordinates ->
-    registry.registerSlot(slot, coords.boundsInWindow())
+    registry.registerSlot(path, coords.boundsInWindow())
 }
 
 fun Modifier.widgetBounds(
     registry: DropTargetRegistry,
-    slot: SlotAddress,
+    path: SlotPath,
     instanceId: String,
     index: Int,
 ): Modifier = this.onGloballyPositioned { coords: LayoutCoordinates ->
-    registry.registerWidget(slot, instanceId, index, coords.boundsInWindow())
+    registry.registerWidget(path, instanceId, index, coords.boundsInWindow())
 }
 
-// derivedStateOf import suppression -- present for future shape stability
+// SlotAddress-keyed compat for callers that have not migrated yet.
+// Internally promotes to a root-level SlotPath -- safe for flat
+// surfaces, lossy for nested ones.
+@Deprecated(
+    message     = "Use the SlotPath form; SlotAddress loses nested context",
+    replaceWith = ReplaceWith("slotBounds(registry, SlotPath(slot.surface, slot.slot))"),
+)
+fun Modifier.slotBounds(registry: DropTargetRegistry, slot: SlotAddress): Modifier =
+    slotBounds(registry, SlotPath(slot.surface, slot.slot))
+
 @Suppress("unused") private fun touchDerivedStateOf() = derivedStateOf { 0 }
 @Suppress("unused") private fun touchSnapshot() = Snapshot.current

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
@@ -84,7 +84,7 @@ fun PaletteItem(
                 onDragEnd             = { pointer ->
                     val targetPath = registry.slotForPoint(pointer) ?: return@dragSource
                     val index = registry.insertionIndexInSlot(targetPath, pointer)
-                    editController.addWidget(targetPath, descriptor.kind, index)
+                    editController.addWidget(targetPath, descriptor.kind, descriptor.slots, index)
                 },
             )
             .padding(horizontal = 10.dp, vertical = 8.dp),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/palette/PaletteItem.kt
@@ -82,9 +82,9 @@ fun PaletteItem(
                 widgetBoundsProvider  = { rowBounds },
                 ghost                 = { PaletteGhost(displayName = descriptor.displayName) },
                 onDragEnd             = { pointer ->
-                    val slot = registry.slotForPoint(pointer) ?: return@dragSource
-                    val index = registry.insertionIndexInSlot(slot, pointer)
-                    editController.addWidget(slot.surface, slot.slot, descriptor.kind, index)
+                    val targetPath = registry.slotForPoint(pointer) ?: return@dragSource
+                    val index = registry.insertionIndexInSlot(targetPath, pointer)
+                    editController.addWidget(targetPath, descriptor.kind, index)
                 },
             )
             .padding(horizontal = 10.dp, vertical = 8.dp),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/NewHomeScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -41,8 +43,16 @@ fun NewHomeScreen(
         )
     }
     CompositionLocalProvider(LocalHomeNewContext provides ctx) {
+        // verticalScroll so a tall widget (or a stack of widgets that
+        // overflows the viewport) does not push subsequent widgets
+        // off-screen with no way to reach them. The surface owns its
+        // own scroll state; SlotRenderer stays layout-neutral.
+        val scrollState = rememberScrollState()
         Column(
-            modifier            = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp),
+            modifier            = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             SlotRenderer(SurfaceId(SURFACE), SlotId("main"))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -43,8 +45,15 @@ fun LibraryScreen(
             ) {
                 SlotRenderer(SurfaceId(SURFACE), SlotId("header"))
             }
+            // Body slot scrolls so a tall pack list or a stack of
+            // additional library widgets does not push content past
+            // the viewport with no way to reach it.
+            val bodyScroll = rememberScrollState()
             Column(
-                modifier            = Modifier.weight(1f).fillMaxWidth(),
+                modifier            = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(bodyScroll),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 SlotRenderer(SurfaceId(SURFACE), SlotId("body"))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/GroupContainerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/GroupContainerWidget.kt
@@ -1,0 +1,48 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.widget.api.SlotRenderer
+import hivens.widget.model.SlotId
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+
+// First-class container widget: holds nested sub-widgets in its "body"
+// slot. The simplest possible composition primitive -- pick this from
+// the palette, drop other widgets inside it. Phase A's smoke surface
+// for nested drag&drop, schema_version=2's children field, and the
+// editor's smallest-area-first hit-test all converge here.
+//
+// Visually a tinted glass card with 12dp interior padding; the body
+// slot stacks its children vertically. Nesting depth is communicated
+// only through EditableWidgetChrome's depth-aware border alpha;
+// containers themselves stay visually quiet so the user's own widgets
+// remain the figure.
+@Widget(
+    id          = "container.group",
+    displayName = "Группа",
+    slots       = ["body"],
+)
+@Composable
+fun GroupContainerWidget(instance: WidgetInstance) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.55f))
+            .padding(12.dp),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            SlotRenderer(parent = instance, slot = SlotId("body"))
+        }
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
@@ -2,8 +2,9 @@ package hivens.ui.editor.dnd
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import hivens.widget.model.SlotAddress
+import hivens.widget.model.NestedSegment
 import hivens.widget.model.SlotId
+import hivens.widget.model.SlotPath
 import hivens.widget.model.SurfaceId
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,10 +14,10 @@ class DropTargetRegistryTest {
 
     private val homeNew = SurfaceId("home.new")
     private val main    = SlotId("main")
-    private val slot    = SlotAddress(homeNew, main)
+    private val slot    = SlotPath(homeNew, main)
     private val library = SurfaceId("library")
     private val body    = SlotId("body")
-    private val otherSlot = SlotAddress(library, body)
+    private val otherSlot = SlotPath(library, body)
 
     private fun rect(top: Float, height: Float = 50f, left: Float = 0f, width: Float = 300f): Rect =
         Rect(left = left, top = top, right = left + width, bottom = top + height)
@@ -83,4 +84,66 @@ class DropTargetRegistryTest {
         // because there are no widget rects to span.
         assertNull(r.slotForPoint(Offset(50f, 25f)))
     }
+
+    // ── Nested slot hit-testing (smallest-area-first) ─────────────────
+
+    private val containerPath: SlotPath = slot.child("container1", body)
+
+    @Test
+    fun `slotForPoint prefers the innermost (smallest-area) match when rects overlap`() {
+        val r = DropTargetRegistry()
+        // Root container occupies a large outer rect.
+        r.registerWidget(slot, "container1", index = 0, rect = rect(top = 0f, height = 300f))
+        // Inside it, a nested child sits in a tighter rect.
+        r.registerWidget(containerPath, "inner", index = 0, rect = rect(top = 50f, height = 50f, left = 20f, width = 200f))
+
+        // Pointer inside the inner child -- innermost (containerPath) wins.
+        assertEquals(containerPath, r.slotForPoint(Offset(100f, 75f)))
+        // Pointer inside the outer container only -- outer (slot) wins.
+        assertEquals(slot, r.slotForPoint(Offset(280f, 200f)))
+    }
+
+    @Test
+    fun `empty nested slot bounds resolve to the nested SlotPath, not the parent`() {
+        val r = DropTargetRegistry()
+        // Outer container has its own widget rect (the container chrome).
+        r.registerWidget(slot, "container1", index = 0, rect = rect(top = 0f, height = 300f))
+        // Empty body slot inside the container registers its placeholder bounds.
+        r.registerSlot(containerPath, rect(top = 80f, height = 80f, left = 20f, width = 200f))
+
+        // The placeholder bounds are strictly smaller than the container's
+        // own widget rect -- nested path wins.
+        assertEquals(containerPath, r.slotForPoint(Offset(100f, 120f)))
+    }
+
+    @Test
+    fun `slotForPoint at depth 2 still picks innermost`() {
+        val r = DropTargetRegistry()
+        val deeper = containerPath.child("container2", SlotId("inner"))
+
+        r.registerWidget(slot, "container1", index = 0, rect = rect(top = 0f, height = 400f))
+        r.registerWidget(containerPath, "container2", index = 0, rect = rect(top = 50f, height = 300f, left = 10f, width = 280f))
+        r.registerWidget(deeper, "leaf", index = 0, rect = rect(top = 100f, height = 50f, left = 30f, width = 220f))
+
+        assertEquals(deeper, r.slotForPoint(Offset(140f, 120f)))
+    }
+
+    @Test
+    fun `SlotPath equality distinguishes same-leaf-coords across containers`() {
+        val r = DropTargetRegistry()
+        val a = slot.child("c1", body)
+        val b = slot.child("c2", body)
+
+        r.registerWidget(a, "wA", index = 0, rect = rect(top = 0f))
+        r.registerWidget(b, "wB", index = 0, rect = rect(top = 200f))
+
+        assertEquals(a, r.slotForPoint(Offset(50f, 25f)))
+        assertEquals(b, r.slotForPoint(Offset(50f, 225f)))
+    }
+
+    // Compile-time touch: NestedSegment is part of widget-model and we
+    // expect tests to be able to build SlotPaths via either child()
+    // chains or direct construction.
+    @Suppress("unused")
+    private fun touchNestedSegment(): NestedSegment = NestedSegment("x", body)
 }

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -58,6 +58,8 @@ class WidgetRegistryConsistencyTest {
             "nav.profile",
             "nav.settings",
             "nav.about",
+            // Phase A.3 container sample
+            "container.group",
         )
         val actual = GeneratedWidgetRegistry.all().keys.map { it.value }.toSet()
         assertEquals(expected, actual, "registry drift -- expected exactly these widgets")

--- a/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import hivens.widget.model.LayoutGraph
 import hivens.widget.model.SlotAddress
+import hivens.widget.model.SlotPath
 import hivens.widget.model.WidgetInstance
 
 // Locals provided once near the application root. Static because the
@@ -47,3 +48,14 @@ typealias EmptySlotDecorator = @Composable (address: SlotAddress) -> Unit
 
 val LocalEmptySlotDecorator: ProvidableCompositionLocal<EmptySlotDecorator> =
     staticCompositionLocalOf { {} }
+
+// Current path the surrounding SlotRenderer is rendering. Container
+// widgets read this implicitly through the nested SlotRenderer
+// overload; chrome / empty-placeholder use it to register drop-target
+// bounds against the canonical path rather than just the leaf
+// (SurfaceId, SlotId) pair, so nested containers do not collide on the
+// registry. Must be inside a SlotRenderer to read.
+val LocalSlotPath: ProvidableCompositionLocal<SlotPath> =
+    staticCompositionLocalOf {
+        error("LocalSlotPath not provided -- read inside a SlotRenderer body")
+    }

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -1,36 +1,63 @@
 package hivens.widget.api
 
 import androidx.compose.runtime.Composable
-import hivens.widget.model.SlotAddress
+import androidx.compose.runtime.CompositionLocalProvider
+import hivens.widget.model.SlotContent
 import hivens.widget.model.SlotId
+import hivens.widget.model.SlotPath
 import hivens.widget.model.SurfaceId
+import hivens.widget.model.WidgetInstance
+import hivens.widget.model.traverse
 
-// Looks up the slot in the active LayoutGraph and emits its widgets in
-// order. The active graph is provided via LocalLayoutGraph from the
-// hosting application; the registry is provided via LocalWidgetRegistry.
-// Both locals are wired in the launcher's Koin bootstrap.
+// Renders every widget at the addressed slot. Two entry forms:
+//
+//   * Top-level: SlotRenderer(surface, slot) -- used by surface
+//     composables (NewHomeScreen, LibraryScreen, AppLayout rails, ...).
+//     Initialises LocalSlotPath at the surface root.
+//
+//   * Nested: SlotRenderer(parent, slot) -- used by container widgets
+//     inside their @Composable body. Extends LocalSlotPath with the
+//     container's instanceId so the editor's drop-target registry
+//     distinguishes "slot 'body' on container X" from "slot 'body' on
+//     container Y".
 //
 // Each widget renders through LocalWidgetDecorator. Default decorator
-// is identity -- zero decoration cost. The editor in :client-ui swaps
-// in a chrome wrapper that adds drag handles, remove buttons, and
-// pointer listeners. SlotRenderer itself stays editor-agnostic.
-//
-// An unknown WidgetKind (e.g. layout file refers to a plugin widget the
-// registry no longer ships) renders nothing -- the slot stays valid;
-// the diagnostic shows up in the --audit-widgets dev tool (kernel-4).
+// is identity -- zero cost when no editor is mounted. Unknown widget
+// kinds (layout file references a kind the registry no longer ships)
+// render nothing; the slot stays valid and the diagnostic surfaces in
+// the editor's --audit-widgets dev tool.
 @Composable
 fun SlotRenderer(surface: SurfaceId, slot: SlotId) {
+    val path = SlotPath(surface, slot)
+    CompositionLocalProvider(LocalSlotPath provides path) {
+        RenderSlotContent(path)
+    }
+}
+
+@Composable
+fun SlotRenderer(parent: WidgetInstance, slot: SlotId) {
+    val parentPath = LocalSlotPath.current
+    val childPath = parentPath.child(parent.instanceId, slot)
+    CompositionLocalProvider(LocalSlotPath provides childPath) {
+        RenderSlotContent(childPath)
+    }
+}
+
+@Composable
+private fun RenderSlotContent(path: SlotPath) {
     val graph = LocalLayoutGraph.current
     val registry = LocalWidgetRegistry.current
     val decorator = LocalWidgetDecorator.current
     val emptyDecorator = LocalEmptySlotDecorator.current
-    val widgets = graph.surfaces[surface]?.slots?.get(slot)?.widgets.orEmpty()
-    val address = SlotAddress(surface, slot)
-    if (widgets.isEmpty()) {
+
+    val content: SlotContent = graph.traverse(path) ?: SlotContent()
+    val address = path.leafAddress
+
+    if (content.widgets.isEmpty()) {
         emptyDecorator(address)
         return
     }
-    widgets.forEachIndexed { index, instance ->
+    content.widgets.forEachIndexed { index, instance ->
         val descriptor = registry[instance.kind] ?: return@forEachIndexed
         decorator(address, index, descriptor, instance) {
             descriptor.Render(instance)

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -181,10 +181,19 @@ private fun mutateNested(
 }
 
 // ── Compat overloads ──────────────────────────────────────────────────
-// These delegate to the SlotPath form; callers that still hand flat
-// (surface, slot) pairs keep working. New code should construct
-// SlotPath directly.
+// Transitional flat-coords forms. Deprecated to nudge callers onto the
+// SlotPath canonical form -- nested containers in Phase A.3 onward
+// cannot be expressed as (SurfaceId, SlotId) alone. Compat lives until
+// every in-tree caller migrates (tracked in the LayoutGraphMutations
+// test suite, which exercises the SlotPath path directly).
 
+@Deprecated(
+    message     = "Use SlotPath -- (SurfaceId, SlotId) cannot address nested container slots.",
+    replaceWith = ReplaceWith(
+        "insertWidget(SlotPath(surface, slot), widget, index)",
+        "hivens.widget.model.SlotPath",
+    ),
+)
 fun LayoutGraph.insertWidget(
     surface: SurfaceId,
     slot: SlotId,
@@ -192,12 +201,26 @@ fun LayoutGraph.insertWidget(
     index: Int,
 ): LayoutGraph = insertWidget(SlotPath(surface, slot), widget, index)
 
+@Deprecated(
+    message     = "Use SlotPath -- (SurfaceId, SlotId) cannot address nested container slots.",
+    replaceWith = ReplaceWith(
+        "removeWidget(SlotPath(surface, slot), instanceId)",
+        "hivens.widget.model.SlotPath",
+    ),
+)
 fun LayoutGraph.removeWidget(
     surface: SurfaceId,
     slot: SlotId,
     instanceId: String,
 ): LayoutGraph = removeWidget(SlotPath(surface, slot), instanceId)
 
+@Deprecated(
+    message     = "Use SlotPath -- (SurfaceId, SlotId) cannot address nested container slots.",
+    replaceWith = ReplaceWith(
+        "reorderInSlot(SlotPath(surface, slot), fromIndex, toIndex)",
+        "hivens.widget.model.SlotPath",
+    ),
+)
 fun LayoutGraph.reorderInSlot(
     surface: SurfaceId,
     slot: SlotId,
@@ -205,6 +228,13 @@ fun LayoutGraph.reorderInSlot(
     toIndex: Int,
 ): LayoutGraph = reorderInSlot(SlotPath(surface, slot), fromIndex, toIndex)
 
+@Deprecated(
+    message     = "Use SlotPath -- SlotAddress cannot address nested container slots.",
+    replaceWith = ReplaceWith(
+        "moveWidget(from.toPath(), to.toPath(), instanceId, toIndex)",
+        "hivens.widget.model.toPath",
+    ),
+)
 fun LayoutGraph.moveWidget(
     from: SlotAddress,
     to: SlotAddress,

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -264,4 +264,33 @@ class LayoutGraphMutationsTest {
         val ids = seedNested().walkInstances().map { it.instanceId }.toList()
         assertEquals(listOf("container1", "i1", "i2"), ids)
     }
+
+    @Test
+    fun `insertWidget into a nested slot the container did not declare is identity`() {
+        // Pin the contract: the LayoutGraph mutator does NOT auto-create
+        // missing child slot entries. The editor (EditModeController)
+        // is responsible for pre-seeding container children from the
+        // descriptor's declared slots when a container lands fresh from
+        // the palette. Without that pre-seed, dropping a widget INTO
+        // the freshly-added container would silently no-op here.
+        val bareContainer = WidgetInstance(
+            kind       = WidgetKind("container.group"),
+            instanceId = "ctr-without-body",
+            // children intentionally empty -- mimics a buggy editor
+            // path that forgot to pre-seed.
+        )
+        val graph = LayoutGraph(
+            surfaces = mapOf(
+                home to SurfaceLayout(slots = mapOf(
+                    main to SlotContent(listOf(bareContainer)),
+                )),
+            ),
+        )
+        val nestedPath = SlotPath(
+            surface  = home,
+            rootSlot = main,
+            nested   = listOf(NestedSegment("ctr-without-body", SlotId("body"))),
+        )
+        assertSame(graph, graph.insertWidget(nestedPath, w1, 0))
+    }
 }

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
@@ -80,21 +80,43 @@ internal object WidgetValidator {
         val id = (args["id"] as? String).orEmpty()
         val displayName = (args["displayName"] as? String).orEmpty()
         val removable = (args["removable"] as? Boolean) ?: true
-        // KSP reports Array<String> annotation values as List<*>. Filter
-        // defensively; an empty list is the leaf default.
-        val rawSlots = args["slots"] as? List<*>
-        val slots = rawSlots?.filterIsInstance<String>()?.filter { it.isNotBlank() }.orEmpty()
+        // KSP reports Array<String> annotation values as List<*>.
+        val rawSlots = (args["slots"] as? List<*>).orEmpty().filterIsInstance<String>()
 
         if (id.isBlank()) {
             env.logger.error("@Widget id must be non-blank", symbol)
             return null
         }
 
+        // Slot ids must be non-blank, free of whitespace (the editor
+        // uses them as JSON keys and CompositionLocal-resolved drop
+        // target keys; a slot id with a space deserializes fine but
+        // breaks any author who tries to write it back in source), and
+        // unique within a single descriptor. Reject loudly so a typo
+        // surfaces at build time, not as silent UI breakage.
+        val sanitized = mutableListOf<String>()
+        val seen = HashSet<String>()
+        for (raw in rawSlots) {
+            if (raw.isBlank()) {
+                env.logger.error("@Widget slot id must be non-blank", symbol)
+                return null
+            }
+            if (raw.any { it.isWhitespace() }) {
+                env.logger.error("@Widget slot id '$raw' must not contain whitespace", symbol)
+                return null
+            }
+            if (!seen.add(raw)) {
+                env.logger.error("@Widget slots contain duplicate id '$raw'", symbol)
+                return null
+            }
+            sanitized.add(raw)
+        }
+
         return Extracted(
             id = id,
             displayName = displayName,
             removable = removable,
-            slots = slots,
+            slots = sanitized,
         )
     }
 }


### PR DESCRIPTION
Closes Phase A of the Modular UI initiative. Stacks on top of #268 (A.1 data + KSP) and #269 (A.2 repository + debounce), both already on stable.

## Summary

- **SlotRenderer recursion.** Two entry forms: top-level `SlotRenderer(surface, slot)` initialises `LocalSlotPath`; nested `SlotRenderer(parent, slot)` (called by container widgets) extends it with the parent's instanceId. Traverses `WidgetInstance.children` at each hop.
- **DropTargetRegistry rewrite.** Keys drop targets by `SlotPath`. Two-pass hit-test collapses to one area-sorted pass (widget rects + empty-slot bounds compete together so a nested empty slot wins over its enclosing container's rect) plus the existing vertical-span fallback.
- **EditableWidgetChrome + EmptySlotPlaceholder** take `SlotPath`. Chrome's border alpha scales with `path.nested.size` -- subtle depth cue without shouting.
- **EditorSurfaceHost decorator** reads `LocalSlotPath` inside its `@Composable` lambda and threads the canonical path into chrome's drop / reorder / move handlers.
- **EditModeController** switches its public API to `SlotPath`. Compat overloads on `LayoutGraph` now carry `@Deprecated` with `ReplaceWith` hints so any out-of-tree caller migrates loudly.
- **GroupContainerWidget** (id `container.group`, slots `["body"]`) is the first-class container sample. Drop widgets in, drag them around, nest containers in containers.
- **WidgetValidator** rejects `@Widget(slots = ...)` ids that are blank, contain whitespace, or duplicate inside one descriptor. Build-time error rather than silent runtime breakage.
- **AutoMirrored fix** for `Icons.Filled.ViewSidebar` / `Icons.Filled.ViewQuilt` -- silences the IDE deprecation warning.
- **Tests** expanded: `DropTargetRegistryTest` adds depth-1 + depth-2 nested smallest-area cases plus same-leaf-coords-across-containers; `WidgetRegistryConsistencyTest` adds `container.group` to its expected set.

## Test plan

- [ ] `./gradlew check -x :client-ui:createReleaseDistributable` green (verified locally).
- [ ] Edit mode smoke: pick GroupContainerWidget from palette, drop into home.new main slot. Drop another widget INTO its body slot -- nested empty-slot placeholder wins the hit-test over the container's outer rect.
- [ ] Nest a second GroupContainer inside the first. Drop widgets at depth 2. Chrome border alpha visibly thickens with depth.
- [ ] Drag a widget OUT of a container back to home.new top level. Drag back in. State round-trips through disk (LayoutGraphRepository's debounced write + flush).
- [ ] Drag a container into its own body slot -- cycle guard in `moveWidget` returns identity, no graph corruption.
- [ ] `@Widget(slots = ["body", "body"])` or `@Widget(slots = ["odd slot"])` on a test sample triggers a KSP build error (manual verification, no test harness for KSP failures yet).