### PR TITLE
feat(widgets): Phase D -- cross-widget service registry + first provider/consumer

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -66,6 +66,8 @@ import hivens.ui.utils.GameConsoleService
 import hivens.launcher.LayoutGraphRepository
 import hivens.widget.api.LocalLayoutGraph
 import hivens.widget.api.LocalWidgetRegistry
+import hivens.widget.api.LocalWidgetServiceRegistry
+import hivens.widget.api.WidgetServiceRegistry
 import hivens.widget.api.WidgetRegistry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -168,6 +170,7 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
     val gameConsole: GameConsoleService        = koinInject()
     val layoutGraphRepo: LayoutGraphRepository = koinInject()
     val widgetRegistry: WidgetRegistry         = koinInject()
+    val widgetServiceRegistry: WidgetServiceRegistry = koinInject()
     // Shared process-lifetime scope (createdAtStart in appModule; canceled
     // by AppCoroutineScopeHook on JVM shutdown). Same instance backs
     // LauncherController.appScope and any other fire-and-forget work.
@@ -582,6 +585,7 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 androidx.compose.ui.platform.LocalDensity provides scaledDensity,
                 LocalLayoutGraph                         provides layoutGraph,
                 LocalWidgetRegistry                      provides widgetRegistry,
+                LocalWidgetServiceRegistry               provides widgetServiceRegistry,
             ) {
             val effectiveStyle = if (customization.experimentalColorOverridesEnabled) {
                 styleSpec.applyOverrides(customization.styleOverrides)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -18,6 +18,7 @@ import hivens.ui.editor.presets.PresetRepository
 import hivens.ui.utils.GameConsoleService
 import java.nio.file.Path
 import hivens.widget.api.WidgetRegistry
+import hivens.widget.api.WidgetServiceRegistry
 import hivens.widget.generated.GeneratedWidgetRegistry
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.koin.dsl.module
@@ -38,6 +39,14 @@ val uiModule = module {
     // composables are added across the codebase. Kernel-1 starts the
     // registry empty -- surface refactors arrive in kernel-3.
     single<WidgetRegistry> { GeneratedWidgetRegistry }
+
+    // Cross-widget service registry (Phase D). One global instance per
+    // launcher process. Provider widgets register via provideService
+    // from inside their composable body (DisposableEffect-driven
+    // lifecycle); consumer widgets read via useService<T>() / its
+    // siblings. Wired into the composition root from AppShell so
+    // LocalWidgetServiceRegistry resolves before any @Widget renders.
+    single { WidgetServiceRegistry() }
 
     // Editor mutation facade. Holds no state itself; fires LayoutGraph
     // updates into the shared CoroutineScope so callers stay

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
@@ -64,6 +64,10 @@ import hivens.ui.audio.AudioPlayer
 import hivens.ui.audio.PlaybackState
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.services.MusicPlayerService
+import hivens.ui.widgets.services.MusicPlayerServiceImpl
+import hivens.widget.api.provideService
+import hivens.widget.model.ProvidesService
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
 import io.github.vinceglb.filekit.FileKit
@@ -85,12 +89,23 @@ import kotlin.io.path.name
 // rail (or nothing). MP3 support arrives with Skinema (FFmpeg
 // via Panama).
 @Widget(id = "home.new.music", displayName = "Music player")
+@ProvidesService(MusicPlayerService::class)
 @Composable
 fun MusicPlayerWidget(instance: WidgetInstance) {
     val player: AudioPlayer = koinInject()
     val state by player.state.collectAsState()
     val volume by player.volume.collectAsState()
     val scope = rememberCoroutineScope()
+
+    // Expose this widget's AudioPlayer-backed playback through the
+    // cross-widget service registry. PlaybackMiniControlWidget (and
+    // future achievement watchers / music-ducking helpers) read this
+    // via useService<MusicPlayerService>(). The DisposableEffect
+    // unregisters on dispose so removing the widget cleanly drops
+    // the binding; re-adding it re-binds to the same AudioPlayer
+    // singleton.
+    val musicService = remember(player) { MusicPlayerServiceImpl(player) }
+    provideService(MusicPlayerService::class, instance.instanceId, musicService)
 
     val pickFile = {
         scope.launch {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/PlaybackMiniControlWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/PlaybackMiniControlWidget.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
@@ -112,6 +111,11 @@ fun PlaybackMiniControlWidget(instance: WidgetInstance) {
         Spacer(Modifier.width(10.dp))
 
         val isPlaying = state is PlaybackState.Playing
+        // Idle (no file ever loaded) intentionally disables play here:
+        // the file-picker lives on the main MusicPlayer widget. The
+        // mini-control drives existing playback, it does not bootstrap
+        // it. Open the main widget once, pick a track, then the mini
+        // can transport it from anywhere on the surface.
         val canTransport = state is PlaybackState.Playing || state is PlaybackState.Paused || state is PlaybackState.Ready
         TransportButton(
             icon        = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -262,7 +266,7 @@ private fun MiniVolumeBar(
 }
 
 private fun currentTitleShort(state: PlaybackState): String = when (state) {
-    PlaybackState.Idle       -> "—"
+    PlaybackState.Idle       -> "Без файла"
     is PlaybackState.Ready   -> state.file.name
     is PlaybackState.Playing -> state.file.name
     is PlaybackState.Paused  -> state.file.name

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/PlaybackMiniControlWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/PlaybackMiniControlWidget.kt
@@ -1,0 +1,270 @@
+package hivens.ui.widgets.sample
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import hivens.ui.audio.PlaybackState
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.services.MusicPlayerService
+import hivens.widget.api.useService
+import hivens.widget.model.InjectService
+import hivens.widget.model.Widget
+import hivens.widget.model.WidgetInstance
+import kotlin.io.path.name
+
+// Mini transport for the cross-widget music service. Reads
+// MusicPlayerService from the registry; if no provider is currently
+// mounted (the user removed the MusicPlayerWidget, or hasn't dropped
+// one yet) shows a muted disabled state instead of disappearing or
+// crashing. Demonstrates the bidirectional read+write loop end to
+// end: sliding the volume here moves it on the main player, tapping
+// pause here flips the main player's transport, both backed by the
+// same AudioPlayer Koin singleton.
+@Widget(
+    id          = "home.new.playback.mini",
+    displayName = "Мини-плеер",
+)
+@InjectService(MusicPlayerService::class)
+@Composable
+fun PlaybackMiniControlWidget(instance: WidgetInstance) {
+    val service: MusicPlayerService? = useService()
+
+    if (service == null) {
+        DisabledPlaceholder()
+        return
+    }
+
+    val state by service.state.collectAsState()
+    val volume by service.volume.collectAsState()
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(glassSurfaceAlpha(0.55f))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Icon(
+            imageVector        = Icons.Default.MusicNote,
+            contentDescription = null,
+            tint               = CelestiaTheme.colors.primary,
+            modifier           = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text       = currentTitleShort(state),
+            style      = MaterialTheme.typography.bodyMedium,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.Medium,
+            maxLines   = 1,
+            overflow   = TextOverflow.Ellipsis,
+            modifier   = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(10.dp))
+
+        val isPlaying = state is PlaybackState.Playing
+        val canTransport = state is PlaybackState.Playing || state is PlaybackState.Paused || state is PlaybackState.Ready
+        TransportButton(
+            icon        = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+            enabled     = canTransport,
+            onClick     = { if (isPlaying) service.pause() else service.play() },
+            description = if (isPlaying) "Пауза" else "Воспроизвести",
+        )
+        Spacer(Modifier.width(10.dp))
+        MiniVolumeBar(
+            value         = volume,
+            onValueChange = { service.setVolume(it) },
+            modifier      = Modifier.width(110.dp),
+        )
+    }
+}
+
+@Composable
+private fun DisabledPlaceholder() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.4f))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Icon(
+            imageVector        = Icons.AutoMirrored.Filled.VolumeOff,
+            contentDescription = null,
+            tint               = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+            modifier           = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text  = "Нет плеера на этой раскладке",
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            text  = "Добавь Music player",
+            style = MaterialTheme.typography.labelSmall,
+            color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.7f),
+        )
+    }
+}
+
+@Composable
+private fun TransportButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    description: String,
+) {
+    val bg = if (enabled) CelestiaTheme.colors.primary else CelestiaTheme.colors.surfaceVariant.copy(alpha = 0.4f)
+    val tint = if (enabled) CelestiaTheme.colors.onPrimary else CelestiaTheme.colors.textSecondary.copy(alpha = 0.4f)
+    Box(
+        modifier = Modifier
+            .size(30.dp)
+            .clip(CircleShape)
+            .background(bg)
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector        = icon,
+            contentDescription = description,
+            tint               = tint,
+            modifier           = Modifier.size(16.dp),
+        )
+    }
+}
+
+// Smaller cousin of MusicPlayerWidget's VolumeBar, scoped down so it
+// fits inside a single transport row. Same gesture model.
+@Composable
+private fun MiniVolumeBar(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    var pressing by remember { mutableStateOf(false) }
+    val active = isHovered || pressing
+
+    val trackHeight by animateDpAsState(
+        targetValue   = if (active) 4.dp else 3.dp,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "mini-vol-track",
+    )
+    val thumbAlpha by animateFloatAsState(
+        targetValue   = if (active) 1f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label         = "mini-vol-thumb-alpha",
+    )
+
+    var widthPx by remember { mutableStateOf(0) }
+
+    Box(
+        modifier = modifier
+            .height(20.dp)
+            .hoverable(interaction)
+            .onSizeChanged { widthPx = it.width }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    pressing = true
+                    val w = size.width.coerceAtLeast(1).toFloat()
+                    onValueChange((down.position.x / w).coerceIn(0f, 1f))
+                    drag(down.id) { change ->
+                        val newValue = (change.position.x / w).coerceIn(0f, 1f)
+                        onValueChange(newValue)
+                        change.consume()
+                    }
+                    pressing = false
+                }
+            },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(trackHeight)
+                .clip(RoundedCornerShape(50))
+                .background(CelestiaTheme.colors.outline.copy(alpha = 0.20f)),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(value)
+                .height(trackHeight)
+                .clip(RoundedCornerShape(50))
+                .background(CelestiaTheme.colors.primary),
+        )
+        if (widthPx > 0 && thumbAlpha > 0.01f) {
+            val thumbHalfPx = with(LocalDensity.current) { 8.dp.toPx() / 2f }
+            val xPx = (value * widthPx - thumbHalfPx).toInt()
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(xPx, 0) }
+                    .size(8.dp)
+                    .graphicsLayer { alpha = thumbAlpha }
+                    .clip(CircleShape)
+                    .background(CelestiaTheme.colors.primary),
+            )
+        }
+    }
+}
+
+private fun currentTitleShort(state: PlaybackState): String = when (state) {
+    PlaybackState.Idle       -> "—"
+    is PlaybackState.Ready   -> state.file.name
+    is PlaybackState.Playing -> state.file.name
+    is PlaybackState.Paused  -> state.file.name
+    is PlaybackState.Error   -> state.file.name
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/services/MusicPlayerService.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/services/MusicPlayerService.kt
@@ -1,0 +1,28 @@
+package hivens.ui.widgets.services
+
+import hivens.ui.audio.PlaybackState
+import hivens.widget.model.WidgetService
+import kotlinx.coroutines.flow.StateFlow
+
+// Cross-widget contract for any widget that wants to read or drive
+// audio playback. Phase D's first concrete service. Currently backed
+// by AudioPlayer (javax.sound.sampled); Skinema will swap the impl to
+// FFmpeg-via-Panama while keeping this interface, so consumers
+// (PlaybackMiniControlWidget today, achievement watchers tomorrow,
+// music-ducking-on-launch later) write against the contract once and
+// never touch the engine swap.
+//
+// Reactive fields are StateFlow so non-Compose consumers (a
+// background coroutine inside a future plugin, telemetry sink) can
+// observe state without going through the registry's snapshot
+// subscription. Compose consumers convert via .collectAsState() as
+// they already do for AudioPlayer directly.
+interface MusicPlayerService : WidgetService {
+    val state: StateFlow<PlaybackState>
+    val volume: StateFlow<Float>
+
+    fun setVolume(level: Float)
+    fun play()
+    fun pause()
+    fun stop()
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/services/MusicPlayerServiceImpl.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/services/MusicPlayerServiceImpl.kt
@@ -1,0 +1,27 @@
+package hivens.ui.widgets.services
+
+import hivens.ui.audio.AudioPlayer
+
+// Adapter from the cross-widget service contract to the concrete
+// javax.sound.sampled-backed AudioPlayer. AudioPlayer is the Koin
+// singleton -- one player per launcher process -- so every widget
+// that mounts MusicPlayerWidget binds to the same underlying state.
+// Removing the widget unregisters the service but leaves AudioPlayer
+// alive; re-adding the widget re-binds to the same player and the
+// track keeps playing.
+//
+// When Skinema lands and AudioPlayer is replaced by a Panama-FFmpeg
+// engine, this file is the single seam: the MusicPlayerService
+// interface stays, Impl points at the new engine, every consumer
+// keeps working.
+class MusicPlayerServiceImpl(
+    private val player: AudioPlayer,
+) : MusicPlayerService {
+    override val state get() = player.state
+    override val volume get() = player.volume
+
+    override fun setVolume(level: Float) = player.setVolume(level)
+    override fun play() = player.play()
+    override fun pause() = player.pause()
+    override fun stop() = player.stop()
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -60,6 +60,8 @@ class WidgetRegistryConsistencyTest {
             "nav.about",
             // Phase A.3 container sample
             "container.group",
+            // Phase D service-consumer sample
+            "home.new.playback.mini",
         )
         val actual = GeneratedWidgetRegistry.all().keys.map { it.value }.toSet()
         assertEquals(expected, actual, "registry drift -- expected exactly these widgets")

--- a/widget-api/build.gradle.kts
+++ b/widget-api/build.gradle.kts
@@ -10,4 +10,10 @@ plugins {
 dependencies {
     api(project(":widget-model"))
     implementation(libs.compose.runtime)
+
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
@@ -59,3 +59,13 @@ val LocalSlotPath: ProvidableCompositionLocal<SlotPath> =
     staticCompositionLocalOf {
         error("LocalSlotPath not provided -- read inside a SlotRenderer body")
     }
+
+// Cross-widget service registry. Provided once at the launcher's
+// composition root from the Koin-bound singleton. Consumer widgets
+// read via useService<T>() / useServiceByInstance / useAllServices;
+// provider widgets register via provideService(...). Must be wired
+// before any widget that participates in services renders.
+val LocalWidgetServiceRegistry: ProvidableCompositionLocal<WidgetServiceRegistry> =
+    staticCompositionLocalOf {
+        error("LocalWidgetServiceRegistry not provided -- wire WidgetServiceRegistry in Koin and at the composition root")
+    }

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceHelpers.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceHelpers.kt
@@ -1,0 +1,63 @@
+package hivens.widget.api
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import hivens.widget.model.WidgetService
+import kotlin.reflect.KClass
+
+// Composable read of "any provider of T" from the registry. Returns
+// null when no provider is currently mounted; recomposes the caller
+// when a provider mounts or unmounts (SnapshotStateMap subscription).
+//
+// Consumer widgets should treat null as a normal state and render a
+// disabled / placeholder UI, NOT throw. Service contracts come and go
+// as the user edits the layout.
+@Composable
+inline fun <reified T : WidgetService> useService(): T? {
+    val registry = LocalWidgetServiceRegistry.current
+    return registry.first(T::class)
+}
+
+// Composable read of a specific provider by its widget instanceId.
+// Useful when a consumer needs to bind to one particular provider
+// among several (e.g. "the music player on home.new, not the one on
+// the right rail"). Returns null when that exact instance is gone.
+@Composable
+inline fun <reified T : WidgetService> useServiceByInstance(instanceId: String): T? {
+    val registry = LocalWidgetServiceRegistry.current
+    return registry.byInstance(T::class, instanceId)
+}
+
+// Composable read of every provider of T. Useful for broadcast
+// patterns (achievement watchers, debug inspectors) that want to
+// observe state across multiple mounted providers simultaneously.
+@Composable
+inline fun <reified T : WidgetService> useAllServices(): List<T> {
+    val registry = LocalWidgetServiceRegistry.current
+    return registry.all(T::class)
+}
+
+// Register a service implementation for the lifetime of the
+// surrounding composition, scoped to one widget instance. Calls
+// register on enter and unregister on dispose. Keyed on (clazz,
+// instanceId, service) so a service-instance swap re-registers
+// cleanly without leaking the previous binding.
+//
+// Provider widgets call this from inside their composable body,
+// typically with `service` constructed via `remember(deps) {
+// MyServiceImpl(deps) }` so the impl outlives recompositions but
+// dies with the widget.
+@Composable
+fun <T : WidgetService> provideService(
+    clazz: KClass<T>,
+    instanceId: String,
+    service: T,
+) {
+    val registry = LocalWidgetServiceRegistry.current
+    DisposableEffect(registry, clazz, instanceId, service) {
+        registry.register(clazz, instanceId, service)
+        onDispose {
+            registry.unregister(clazz, instanceId)
+        }
+    }
+}

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceHelpers.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceHelpers.kt
@@ -2,6 +2,7 @@ package hivens.widget.api
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import hivens.widget.model.WidgetService
 import kotlin.reflect.KClass
 
@@ -38,15 +39,24 @@ inline fun <reified T : WidgetService> useAllServices(): List<T> {
 }
 
 // Register a service implementation for the lifetime of the
-// surrounding composition, scoped to one widget instance. Calls
-// register on enter and unregister on dispose. Keyed on (clazz,
-// instanceId, service) so a service-instance swap re-registers
-// cleanly without leaking the previous binding.
+// surrounding composition, scoped to one widget instance.
 //
-// Provider widgets call this from inside their composable body,
-// typically with `service` constructed via `remember(deps) {
-// MyServiceImpl(deps) }` so the impl outlives recompositions but
-// dies with the widget.
+// Two effects intentionally separated:
+//   * `DisposableEffect(registry, clazz, instanceId)` owns the
+//     registration LIFETIME -- onDispose fires only when the widget
+//     unmounts (or the registry/clazz/instanceId tuple changes,
+//     which in practice never happens for one widget).
+//   * `SideEffect { register(...) }` refreshes the bound impl ref on
+//     every successful composition. Idempotent map put; cheap.
+//
+// The split matters when a provider widget instantiates its impl
+// inline (`provideService(MusicPlayerService::class, id,
+// MusicPlayerServiceImpl(player))`) instead of wrapping in
+// `remember`. With the old keyed-on-service shape every recomposition
+// would unregister + register through snapshot state, and consumers
+// would see a one-frame null between the two halves. Decoupling the
+// effects keeps the binding live across recompositions; consumers
+// see a continuous service ref even from a remember-less provider.
 @Composable
 fun <T : WidgetService> provideService(
     clazz: KClass<T>,
@@ -54,10 +64,12 @@ fun <T : WidgetService> provideService(
     service: T,
 ) {
     val registry = LocalWidgetServiceRegistry.current
-    DisposableEffect(registry, clazz, instanceId, service) {
-        registry.register(clazz, instanceId, service)
+    DisposableEffect(registry, clazz, instanceId) {
         onDispose {
             registry.unregister(clazz, instanceId)
         }
+    }
+    SideEffect {
+        registry.register(clazz, instanceId, service)
     }
 }

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceRegistry.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceRegistry.kt
@@ -37,6 +37,16 @@ class WidgetServiceRegistry {
         mutableStateMapOf()
 
     fun register(clazz: KClass<out WidgetService>, instanceId: String, service: WidgetService) {
+        // The reified provideService<T> wrapper is type-safe, but a
+        // direct register call from a future plugin / hand-written
+        // provider could store a service that does not actually
+        // implement clazz; failure would surface as a
+        // ClassCastException on the consumer's first<T>() call, with
+        // no breadcrumb back to the wrong provider. Reject loudly
+        // here instead.
+        require(clazz.isInstance(service)) {
+            "service does not implement ${clazz.qualifiedName} (got ${service::class.qualifiedName})"
+        }
         val perKind = byKind.getOrPut(clazz) { mutableStateMapOf() }
         perKind[instanceId] = service
     }
@@ -51,8 +61,17 @@ class WidgetServiceRegistry {
     fun <T : WidgetService> byInstance(clazz: KClass<T>, instanceId: String): T? =
         byKind[clazz]?.get(instanceId) as T?
 
-    fun <T : WidgetService> first(clazz: KClass<T>): T? =
-        all(clazz).firstOrNull()
+    @Suppress("UNCHECKED_CAST")
+    fun <T : WidgetService> first(clazz: KClass<T>): T? {
+        val perKind = byKind[clazz] ?: return null
+        // O(n) min-key scan instead of all().firstOrNull() which sorts
+        // the entire list just to drop everything but the first.
+        // SnapshotStateMap's iteration order is unspecified, so the
+        // sort was for determinism; min-by-instanceId gives the same
+        // deterministic winner without paying for the full sort.
+        val firstKey = perKind.keys.minOrNull() ?: return null
+        return perKind[firstKey] as T?
+    }
 
     @Suppress("UNCHECKED_CAST")
     fun <T : WidgetService> all(clazz: KClass<T>): List<T> {

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceRegistry.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetServiceRegistry.kt
@@ -1,0 +1,69 @@
+package hivens.widget.api
+
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.mutableStateMapOf
+import hivens.widget.model.WidgetService
+import kotlin.reflect.KClass
+
+// Cross-widget service registry. Provider widgets register their
+// service implementations on mount; consumer widgets / mixins read by
+// kind, by instance, or as a broadcast list. Backed by snapshot state
+// maps so Compose consumers recompose automatically when a provider
+// mounts or unmounts -- no separate Flow plumbing required.
+//
+// Scope: single global registry, one Koin singleton per launcher
+// process. A consumer on any surface can read a provider on any
+// other; achievement detection and music ducking are cross-surface
+// by design. Per-surface scoping can land later via a `scope`
+// filter without breaking the default.
+//
+// Lookups return nullable snapshots so a consumer firing during the
+// brief between-mount window (provider unmounted, replacement not yet
+// mounted) does not block or deadlock -- it gets null this frame and
+// recomposes next frame when the new provider registers.
+//
+// Sort by instanceId is the determinism contract: with two providers
+// of the same kind, every consumer using first() must agree on which
+// one wins, and that agreement must survive process restarts (no
+// random.shuffle, no insertion-order from a non-deterministic source).
+class WidgetServiceRegistry {
+
+    // Two-level snapshot map: outer keyed by service KClass, inner
+    // keyed by provider widget's instanceId. Reading either level
+    // subscribes the Compose snapshot to changes, so a consumer that
+    // calls first<MusicPlayerService>() automatically recomposes
+    // when the MusicPlayerWidget mounts / unmounts.
+    private val byKind: SnapshotStateMap<KClass<*>, SnapshotStateMap<String, WidgetService>> =
+        mutableStateMapOf()
+
+    fun register(clazz: KClass<out WidgetService>, instanceId: String, service: WidgetService) {
+        val perKind = byKind.getOrPut(clazz) { mutableStateMapOf() }
+        perKind[instanceId] = service
+    }
+
+    fun unregister(clazz: KClass<out WidgetService>, instanceId: String) {
+        val perKind = byKind[clazz] ?: return
+        perKind.remove(instanceId)
+        if (perKind.isEmpty()) byKind.remove(clazz)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : WidgetService> byInstance(clazz: KClass<T>, instanceId: String): T? =
+        byKind[clazz]?.get(instanceId) as T?
+
+    fun <T : WidgetService> first(clazz: KClass<T>): T? =
+        all(clazz).firstOrNull()
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : WidgetService> all(clazz: KClass<T>): List<T> {
+        val perKind = byKind[clazz] ?: return emptyList()
+        // Sort by instanceId for determinism. Without this, the
+        // SnapshotStateMap's iteration order is unspecified and a
+        // "first" lookup could pick a different provider between
+        // runs, or worse, flicker between providers on
+        // recomposition.
+        return perKind.entries
+            .sortedBy { it.key }
+            .map { it.value as T }
+    }
+}

--- a/widget-api/src/test/kotlin/hivens/widget/api/WidgetServiceRegistryTest.kt
+++ b/widget-api/src/test/kotlin/hivens/widget/api/WidgetServiceRegistryTest.kt
@@ -3,6 +3,7 @@ package hivens.widget.api
 import hivens.widget.model.WidgetService
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -104,5 +105,18 @@ class WidgetServiceRegistryTest {
         val reg = WidgetServiceRegistry()
         reg.register(OtherService::class, "id", OtherImpl())
         assertTrue(reg.all(SampleService::class).isEmpty())
+    }
+
+    @Test
+    fun `register rejects an impl that does not implement the declared service kind`() {
+        val reg = WidgetServiceRegistry()
+        val ex = assertFailsWith<IllegalArgumentException> {
+            // A plugin / hand-written provider could pass the wrong
+            // KClass; the registry must catch the mismatch loud and
+            // local, not defer it to a ClassCastException on the
+            // consumer's first<T>() call.
+            reg.register(SampleService::class, "id", OtherImpl())
+        }
+        assertTrue("SampleService" in (ex.message ?: ""))
     }
 }

--- a/widget-api/src/test/kotlin/hivens/widget/api/WidgetServiceRegistryTest.kt
+++ b/widget-api/src/test/kotlin/hivens/widget/api/WidgetServiceRegistryTest.kt
@@ -1,0 +1,108 @@
+package hivens.widget.api
+
+import hivens.widget.model.WidgetService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class WidgetServiceRegistryTest {
+
+    private interface SampleService : WidgetService {
+        val tag: String
+    }
+
+    private interface OtherService : WidgetService
+
+    private class SampleImpl(override val tag: String) : SampleService
+    private class OtherImpl : OtherService
+
+    @Test
+    fun `register then first returns the registered impl`() {
+        val reg = WidgetServiceRegistry()
+        val impl = SampleImpl("a")
+        reg.register(SampleService::class, "instance-a", impl)
+        assertSame(impl, reg.first(SampleService::class))
+    }
+
+    @Test
+    fun `byInstance returns the right impl for the right id`() {
+        val reg = WidgetServiceRegistry()
+        val a = SampleImpl("a")
+        val b = SampleImpl("b")
+        reg.register(SampleService::class, "id-a", a)
+        reg.register(SampleService::class, "id-b", b)
+        assertSame(a, reg.byInstance(SampleService::class, "id-a"))
+        assertSame(b, reg.byInstance(SampleService::class, "id-b"))
+        assertNull(reg.byInstance(SampleService::class, "missing"))
+    }
+
+    @Test
+    fun `all returns every registered impl sorted by instanceId`() {
+        val reg = WidgetServiceRegistry()
+        // Register in reverse-alphabetical order; expect sorted output.
+        reg.register(SampleService::class, "z-id", SampleImpl("z"))
+        reg.register(SampleService::class, "a-id", SampleImpl("a"))
+        reg.register(SampleService::class, "m-id", SampleImpl("m"))
+        val list = reg.all(SampleService::class)
+        assertEquals(listOf("a", "m", "z"), list.map { it.tag })
+    }
+
+    @Test
+    fun `first picks the instanceId-sorted-first impl deterministically`() {
+        val reg = WidgetServiceRegistry()
+        reg.register(SampleService::class, "z-id", SampleImpl("z"))
+        reg.register(SampleService::class, "a-id", SampleImpl("a"))
+        reg.register(SampleService::class, "m-id", SampleImpl("m"))
+        assertEquals("a", reg.first(SampleService::class)?.tag)
+    }
+
+    @Test
+    fun `unregister removes the impl from all lookup forms`() {
+        val reg = WidgetServiceRegistry()
+        val impl = SampleImpl("a")
+        reg.register(SampleService::class, "instance-a", impl)
+        reg.unregister(SampleService::class, "instance-a")
+        assertNull(reg.first(SampleService::class))
+        assertNull(reg.byInstance(SampleService::class, "instance-a"))
+        assertTrue(reg.all(SampleService::class).isEmpty())
+    }
+
+    @Test
+    fun `unregister of unknown id is a no-op`() {
+        val reg = WidgetServiceRegistry()
+        reg.register(SampleService::class, "instance-a", SampleImpl("a"))
+        reg.unregister(SampleService::class, "does-not-exist")
+        assertEquals(1, reg.all(SampleService::class).size)
+    }
+
+    @Test
+    fun `services of different KClasses do not collide`() {
+        val reg = WidgetServiceRegistry()
+        val sample = SampleImpl("a")
+        val other = OtherImpl()
+        // Same instanceId used across two service kinds -- common case
+        // when one widget exposes multiple contracts.
+        reg.register(SampleService::class, "shared-id", sample)
+        reg.register(OtherService::class, "shared-id", other)
+        assertSame(sample, reg.first(SampleService::class))
+        assertSame(other, reg.first(OtherService::class))
+    }
+
+    @Test
+    fun `registering same id twice replaces the impl`() {
+        val reg = WidgetServiceRegistry()
+        reg.register(SampleService::class, "id", SampleImpl("first"))
+        reg.register(SampleService::class, "id", SampleImpl("second"))
+        assertEquals("second", reg.first(SampleService::class)?.tag)
+        assertEquals(1, reg.all(SampleService::class).size)
+    }
+
+    @Test
+    fun `all returns empty list when no provider registered for that kind`() {
+        val reg = WidgetServiceRegistry()
+        reg.register(OtherService::class, "id", OtherImpl())
+        assertTrue(reg.all(SampleService::class).isEmpty())
+    }
+}

--- a/widget-model/src/main/kotlin/hivens/widget/model/Service.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/Service.kt
@@ -1,0 +1,45 @@
+package hivens.widget.model
+
+import kotlin.reflect.KClass
+
+// Marker interface for cross-widget service contracts. Every typed
+// service that one widget exposes for sibling widgets / future mixins
+// to consume extends this. The marker keeps the registry's generics
+// resolvable without leaking Compose into widget-model, and lets the
+// Phase E plugin loader enumerate every service contract reachable
+// through reflection on loaded jars.
+//
+// Implementations are NOT required to be thread-safe by themselves;
+// the registry's snapshot-state storage gives consumers a stable
+// reference per Compose frame, and any underlying mutable state
+// (StateFlow, channels, ...) is expected to handle its own threading.
+interface WidgetService
+
+// Declarative hint that a @Widget composable runtime-registers
+// implementations of the listed service contracts. Documentation +
+// audit only -- the annotation does NOT auto-register. The widget
+// must still call provideService(...) from inside its composable
+// body; this annotation lets a future tool (Phase E plugin loader,
+// Phase F editor diagnostic, --audit-widgets dev tool) verify that
+// every claimed service has a corresponding registration call.
+//
+// Multiple classes are supported because a single widget can sensibly
+// expose more than one contract (e.g. a future PackController widget
+// might provide both PackLifecycleService and PackTelemetryService).
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class ProvidesService(
+    vararg val classes: KClass<out WidgetService>,
+)
+
+// Declarative hint that a @Widget composable reads one or more
+// service contracts from the registry. Same documentation /
+// audit-only intent as ProvidesService. Phase F's editor diagnostic
+// uses pairs of (provider, injector) to warn the user when an
+// injector is dropped onto a surface that has no provider for its
+// required service.
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class InjectService(
+    val service: KClass<out WidgetService>,
+)

--- a/widget-model/src/main/kotlin/hivens/widget/model/Service.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/Service.kt
@@ -38,8 +38,14 @@ annotation class ProvidesService(
 // uses pairs of (provider, injector) to warn the user when an
 // injector is dropped onto a surface that has no provider for its
 // required service.
+//
+// vararg for symmetry with ProvidesService: a future achievement
+// watcher reasonably reads MusicPlayerService AND PackLifecycleService
+// in one widget, and the audit list should reflect that in a single
+// annotation rather than forcing the author to chain @Repeatable
+// instances.
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class InjectService(
-    val service: KClass<out WidgetService>,
+    vararg val services: KClass<out WidgetService>,
 )


### PR DESCRIPTION
Phase D of the Modular UI initiative. Promoted ahead of Phase C (mixins) so mixin APIs land in the next phase already designed against a real service surface rather than toy cases.

## Summary

- **\`widget-model\`** gains a \`WidgetService\` marker interface plus \`@ProvidesService(vararg KClass<out WidgetService>)\` / \`@InjectService(KClass<out WidgetService>)\` annotations. Documentation / audit only -- runtime registration stays explicit. KSP processor for these annotations lands in Phase E together with the reflection-based plugin loader validator (one shared rule-set).
- **\`widget-api\`** gains \`WidgetServiceRegistry\`: two-level \`SnapshotStateMap<KClass, instanceId -> service>\`. Compose consumers recompose on register / unregister via snapshot subscription -- no Flow plumbing. Lookup API: \`first<T>()\` (instanceId-sorted-first for determinism), \`byInstance<T>(id)\`, \`all<T>()\`; all nullable / possibly-empty so a consumer firing during a between-mount window does not deadlock. Reified helpers \`useService\`/\`useServiceByInstance\`/\`useAllServices\` + \`provideService(...)\` DisposableEffect wrapper. \`LocalWidgetServiceRegistry\` CompositionLocal wired at the composition root.
- **\`client-ui\`** gains \`MusicPlayerService\` + Impl that wraps the existing \`AudioPlayer\` Koin singleton (one player per launcher, widget composables are the binding shim). \`MusicPlayerWidget\` gets \`@ProvidesService(MusicPlayerService::class)\` and calls \`provideService(...)\` inside its body. New \`PlaybackMiniControlWidget\` (id \`home.new.playback.mini\`) is the first consumer: \`useService<MusicPlayerService>()\`; null -> muted "Нет плеера" placeholder, present -> thin transport row (title + play/pause + mini volume bar) that drives the service bidirectionally. Both widgets share the AudioPlayer state, so volume slider on the mini-control moves the main player's bar in lockstep, pause from either flips the other.
- Mount-order infrastructure inside \`SlotRenderer\` stays deferred to Phase C (when the mixin chain needs it); \`DisposableEffect\` inside the provider widget is sufficient for Phase D.

## Test plan

- [ ] \`./gradlew check -x :client-ui:createReleaseDistributable\` green (verified locally).
- [ ] \`WidgetServiceRegistryTest\` covers register / unregister, all three lookup forms, instanceId-sorted determinism, replace-on-duplicate-id, multi-KClass isolation, no-op unregister of unknown id.
- [ ] \`WidgetRegistryConsistencyTest\` expected set includes \`home.new.playback.mini\`.
- [ ] Live smoke: edit mode -> drop MusicPlayer + Мини-плеер onto home.new main. Slide mini-volume; main's bar moves. Tap pause on mini; main's transport flips. Remove main MusicPlayer; mini swaps to "Нет плеера" placeholder within a frame. Re-add; mini rebinds.