### PR TITLE
feat(widgets): Ctrl+E toggles editor edit mode

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -523,11 +523,16 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 // scope (preview = before focus dispatch) so it fires no
                 // matter which composable holds focus -- the side rails
                 // own focus, so a host Box-level handler misses the chord.
-                // The active EditorSurfaceHost observes the controller
-                // signal and gates on whether its surface is editable.
-                // KeyUp so a held chord toggles once, not on repeat.
-                if (ev.type == KeyEventType.KeyUp && ev.isCtrlPressed && ev.key == Key.E) {
-                    editModeController.requestEditToggle()
+                // The EditorSurfaceHost observes the controller signal and
+                // gates on whether its surface is editable.
+                if (ev.isCtrlPressed && ev.key == Key.E) {
+                    // Consume both edges so the chord never reaches a
+                    // focused control (e.g. the palette search field); act
+                    // on release only, so holding the key toggles once
+                    // instead of repeating on auto-repeat KeyDowns.
+                    if (ev.type == KeyEventType.KeyUp) {
+                        editModeController.requestEditToggle()
+                    }
                     true
                 } else {
                     false

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -5,6 +5,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -47,6 +52,7 @@ import hivens.ui.customization.LocalCustomization
 import hivens.ui.easter.AprilFools
 import hivens.ui.easter.AprilFoolsLoader
 import hivens.ui.easter.LocalAprilFools
+import hivens.ui.editor.EditModeController
 import hivens.ui.generated.resources.Res
 import hivens.ui.generated.resources.icon
 import hivens.ui.i18n.AppLocale
@@ -171,6 +177,7 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
     val layoutGraphRepo: LayoutGraphRepository = koinInject()
     val widgetRegistry: WidgetRegistry         = koinInject()
     val widgetServiceRegistry: WidgetServiceRegistry = koinInject()
+    val editModeController: EditModeController  = koinInject()
     // Shared process-lifetime scope (createdAtStart in appModule; canceled
     // by AppCoroutineScopeHook on JVM shutdown). Same instance backs
     // LauncherController.appScope and any other fire-and-forget work.
@@ -510,7 +517,22 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
             visible   = isWindowVisible,
             title     = Branding.TITLE,
             resizable = true,
-            icon      = windowIcon
+            icon      = windowIcon,
+            onPreviewKeyEvent = { ev ->
+                // Ctrl+E toggles widget edit mode. Handled at Window
+                // scope (preview = before focus dispatch) so it fires no
+                // matter which composable holds focus -- the side rails
+                // own focus, so a host Box-level handler misses the chord.
+                // The active EditorSurfaceHost observes the controller
+                // signal and gates on whether its surface is editable.
+                // KeyUp so a held chord toggles once, not on repeat.
+                if (ev.type == KeyEventType.KeyUp && ev.isCtrlPressed && ev.key == Key.E) {
+                    editModeController.requestEditToggle()
+                    true
+                } else {
+                    false
+                }
+            },
         ) {
             // Pulled-forward: triggered by the .show watcher above when a
             // second instance fires its signal. Skip on raiseTick == 0 so

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -1,6 +1,6 @@
 package hivens.ui.editor
 
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import hivens.launcher.LayoutGraphRepository
 import hivens.widget.model.SlotContent
@@ -31,18 +31,19 @@ class EditModeController(
     private val repo: LayoutGraphRepository,
     private val scope: CoroutineScope,
 ) {
-    // Window-level Ctrl+E increments this tick. The active
-    // EditorSurfaceHost observes it via snapshotFlow and flips its
-    // own edit state. The signal lives on the singleton controller
-    // because the keybind is handled at Window scope (focus-
-    // independent -- Modifier.onKeyEvent on the host Box only fires
-    // when a descendant holds focus, which the side rails steal),
-    // while the edit boolean is per-surface-host remember-state. The
-    // tick bridges the two.
-    val editToggleSignal: MutableState<Int> = mutableStateOf(0)
+    // Window-level Ctrl+E increments this tick. The EditorSurfaceHost
+    // observes it via snapshotFlow and flips its own edit state. The
+    // signal lives on the singleton controller because the keybind is
+    // handled at Window scope (focus-independent -- Modifier.onKeyEvent
+    // on the host Box only fires when a descendant holds focus, which
+    // the side rails steal), while the edit boolean is per-surface-host
+    // remember-state. The tick bridges the two. Read-only outward: only
+    // requestEditToggle mutates it.
+    private val _editToggleSignal = mutableStateOf(0)
+    val editToggleSignal: State<Int> = _editToggleSignal
 
     fun requestEditToggle() {
-        editToggleSignal.value++
+        _editToggleSignal.value++
     }
 
     // `slots` comes from the widget's descriptor and pre-seeds the

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -1,5 +1,7 @@
 package hivens.ui.editor
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import hivens.launcher.LayoutGraphRepository
 import hivens.widget.model.SlotContent
 import hivens.widget.model.SlotId
@@ -29,6 +31,20 @@ class EditModeController(
     private val repo: LayoutGraphRepository,
     private val scope: CoroutineScope,
 ) {
+    // Window-level Ctrl+E increments this tick. The active
+    // EditorSurfaceHost observes it via snapshotFlow and flips its
+    // own edit state. The signal lives on the singleton controller
+    // because the keybind is handled at Window scope (focus-
+    // independent -- Modifier.onKeyEvent on the host Box only fires
+    // when a descendant holds focus, which the side rails steal),
+    // while the edit boolean is per-surface-host remember-state. The
+    // tick bridges the two.
+    val editToggleSignal: MutableState<Int> = mutableStateOf(0)
+
+    fun requestEditToggle() {
+        editToggleSignal.value++
+    }
+
     // `slots` comes from the widget's descriptor and pre-seeds the
     // WidgetInstance.children map with empty SlotContent for every
     // declared slot. Without this, a freshly palette-added container

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -50,10 +50,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -177,6 +179,26 @@ fun EditorSurfaceHost(
         }
     }
 
+    // Window-level Ctrl+E (AppShell onPreviewKeyEvent) bumps
+    // controller.editToggleSignal; this observer flips local edit
+    // state. `seen` initialises to the current tick before collecting
+    // so navigating into a fresh host (new remember, but the singleton
+    // tick may already be > 0) does not spuriously toggle on mount.
+    // Only editable surfaces react; leaving edit mode drops preview,
+    // matching the FAB + Escape paths.
+    LaunchedEffect(availableSurfaces) {
+        var seen = controller.editToggleSignal.value
+        snapshotFlow { controller.editToggleSignal.value }.collect { tick ->
+            if (tick != seen) {
+                seen = tick
+                if (availableSurfaces.isNotEmpty()) {
+                    editing = !editing
+                    if (!editing) previewing = false
+                }
+            }
+        }
+    }
+
     val dragController = remember { DragController() }
     val registry       = remember { DropTargetRegistry() }
     val focusManager   = LocalFocusManager.current
@@ -292,6 +314,11 @@ fun EditorSurfaceHost(
             modifier = Modifier
                 .fillMaxSize()
                 .onKeyEvent { ev ->
+                    // Escape exits edit mode. Ctrl+E entry/toggle is
+                    // handled at Window scope (see AppShell) so it works
+                    // regardless of which descendant holds focus -- a
+                    // Box-level handler misses the chord when the side
+                    // rails own focus.
                     if (editing && ev.type == KeyEventType.KeyUp && ev.key == Key.Escape) {
                         editing = false
                         true

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -186,6 +186,12 @@ fun EditorSurfaceHost(
     // tick may already be > 0) does not spuriously toggle on mount.
     // Only editable surfaces react; leaving edit mode drops preview,
     // matching the FAB + Escape paths.
+    //
+    // The signal sits on the singleton controller, so every mounted
+    // host observes it. Safe because AppLayout mounts exactly one host
+    // (its Crossfade swaps screen content *inside* the host, not the
+    // host itself) -- there is never a second, hidden host to flip into
+    // edit mode behind the user's back.
     LaunchedEffect(availableSurfaces) {
         var seen = controller.editToggleSignal.value
         snapshotFlow { controller.editToggleSignal.value }.collect { tick ->

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/EditModeControllerTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/EditModeControllerTest.kt
@@ -1,0 +1,56 @@
+package hivens.ui.editor
+
+import hivens.launcher.LayoutGraphRepository
+import hivens.widget.model.LayoutGraph
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Pins the keybind bridge contract: requestEditToggle() is the only
+// mutator of the observable signal the active EditorSurfaceHost watches,
+// and each call advances it by one. The host's seen-init / toggle logic
+// needs a Compose snapshot harness and stays covered by live smoke.
+class EditModeControllerTest {
+
+    private lateinit var tmpDir: Path
+    private lateinit var scope: CoroutineScope
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = Files.createTempDirectory("edit-mode-controller-test")
+        scope  = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+        tmpDir.toFile().deleteRecursively()
+    }
+
+    private fun controller(): EditModeController {
+        val repo = LayoutGraphRepository(
+            tmpDir.resolve("layout-graph.json"),
+            Json { ignoreUnknownKeys = true; encodeDefaults = true },
+            scope,
+        ) { LayoutGraph.EMPTY }
+        return EditModeController(repo, scope)
+    }
+
+    @Test
+    fun `requestEditToggle increments the signal on each call`() {
+        val controller = controller()
+        assertEquals(0, controller.editToggleSignal.value)
+        controller.requestEditToggle()
+        assertEquals(1, controller.editToggleSignal.value)
+        controller.requestEditToggle()
+        assertEquals(2, controller.editToggleSignal.value)
+    }
+}


### PR DESCRIPTION
Adds a Ctrl+E hotkey to enter/exit the widget editor on any widget-composed surface. Complements the existing edit FAB; Escape still exits.

## Why window-scope

A `Modifier.onKeyEvent` on the `EditorSurfaceHost` Box only fires when a descendant holds focus, and the side rails own focus on the composed screens -- so a Box-level chord never fired. The handler lives on the `Window` instead (`onPreviewKeyEvent`, before focus dispatch), which is focus-independent.

## Wiring

- `EditModeController` gains an `editToggleSignal` tick + `requestEditToggle()`. The keybind is Window-scoped (singleton controller) while the edit boolean is per-host remember-state; the tick bridges the two.
- `EditorSurfaceHost` observes the tick via `snapshotFlow` and flips its local `editing` state. Only editable surfaces react; leaving edit mode drops preview, matching the FAB + Escape paths. Box-level Escape-to-exit unchanged.
- `AppShell` injects the controller and adds `onPreviewKeyEvent` on the main `Window`; Ctrl+E (KeyUp) calls `requestEditToggle()`.

## Verified

- Home: Ctrl+E enters edit mode (palette + chrome), Ctrl+E again exits to baseline.
- Fires while the palette search field holds focus, confirming focus-independence.
- No new widgets or surfaces, so the registry/layout consistency tests are unaffected; `:client-ui:compileKotlinDesktop` green.