### PR TITLE
feat(widgets): Phase 5 -- typed per-widget props + prop editor

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditModeController.kt
@@ -13,8 +13,10 @@ import hivens.widget.model.insertWidget
 import hivens.widget.model.moveWidget
 import hivens.widget.model.removeWidget
 import hivens.widget.model.reorderInSlot
+import hivens.widget.model.updateWidgetProps
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
 import java.util.UUID
 
 // Single mutation entry point for the editor. Every operation resolves
@@ -76,6 +78,16 @@ class EditModeController(
     fun removeWidget(path: SlotPath, instanceId: String) {
         scope.launch {
             repo.update { it.removeWidget(path, instanceId) }
+        }
+    }
+
+    // Replaces the props of one widget. The editor's prop panel hands
+    // over the full JsonObject (default baseline overlaid with the
+    // user's edits); an empty object resets the widget to its declared
+    // defaults.
+    fun updateProps(path: SlotPath, instanceId: String, props: JsonObject) {
+        scope.launch {
+            repo.update { it.updateWidgetProps(path, instanceId, props) }
         }
     }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -173,10 +173,14 @@ fun EditorSurfaceHost(
     var selectedSurface by remember(availableSurfaces) {
         mutableStateOf(availableSurfaces.firstOrNull())
     }
-    // Prop editor target. Cleared on surface change (keyed remember) and
-    // on dismiss; while set, the palette hides so the two right-edge
-    // panels do not overlap.
+    // Prop editor target. Cleared on surface change (keyed remember), on
+    // dismiss, and on leaving edit mode; while set, the palette hides so
+    // the two right-edge panels do not overlap.
     var propTarget by remember(availableSurfaces) { mutableStateOf<PropTarget?>(null) }
+    // Any edit-mode exit (FAB / Escape / Ctrl+E) drops the prop target, so
+    // re-entering does not silently reopen the last panel with the palette
+    // still hidden.
+    LaunchedEffect(editing) { if (!editing) propTarget = null }
     val currentGraph = LocalLayoutGraph.current
     // Leaving a surface drops edit mode -- avoids a stale edit state
     // pointed at the wrong surface after navigation.

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -95,6 +95,7 @@ import hivens.ui.editor.dnd.DropTargetRegistry
 import hivens.ui.editor.dnd.LocalDragController
 import hivens.ui.editor.dnd.LocalDropTargetRegistry
 import hivens.ui.editor.palette.WidgetPalettePanel
+import hivens.ui.editor.props.WidgetPropPanel
 import hivens.ui.editor.presets.PresetEnvelope
 import hivens.ui.editor.presets.PresetManagerPanel
 import hivens.ui.editor.presets.PresetMeta
@@ -123,6 +124,7 @@ import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.widget.api.LocalWidgetDecorator
 import hivens.widget.api.WidgetDecorator
+import hivens.widget.model.SlotPath
 import hivens.widget.model.SurfaceId
 import kotlinx.coroutines.CoroutineScope
 import org.koin.compose.koinInject
@@ -141,6 +143,10 @@ import org.koin.compose.koinInject
 //
 // editor-3 will add palette panel + cross-slot drop. editor-2 keeps
 // drags within the source slot.
+
+// Which widget instance the prop panel is currently editing.
+private data class PropTarget(val path: SlotPath, val instanceId: String)
+
 @Composable
 fun EditorSurfaceHost(
     currentScreen: Screen,
@@ -167,6 +173,10 @@ fun EditorSurfaceHost(
     var selectedSurface by remember(availableSurfaces) {
         mutableStateOf(availableSurfaces.firstOrNull())
     }
+    // Prop editor target. Cleared on surface change (keyed remember) and
+    // on dismiss; while set, the palette hides so the two right-edge
+    // panels do not overlap.
+    var propTarget by remember(availableSurfaces) { mutableStateOf<PropTarget?>(null) }
     val currentGraph = LocalLayoutGraph.current
     // Leaving a surface drops edit mode -- avoids a stale edit state
     // pointed at the wrong surface after navigation.
@@ -241,6 +251,7 @@ fun EditorSurfaceHost(
                     onRemove     = {
                         controller.removeWidget(path, instance.instanceId)
                     },
+                    onEditProps  = { propTarget = PropTarget(path, instance.instanceId) },
                     onCommitDrop = { committedPointer ->
                         // Hit-test which slot received the drop. Null =
                         // pointer is off any slot; treat as cancel.
@@ -438,12 +449,21 @@ fun EditorSurfaceHost(
                 )
 
                 WidgetPalettePanel(
-                    visible        = editing && paletteOpen && !previewing,
+                    visible        = editing && paletteOpen && !previewing && propTarget == null,
                     onDismiss      = { paletteOpen = false },
                     controller     = dragController,
                     registry       = registry,
                     editController = controller,
                     modifier       = Modifier.align(Alignment.TopEnd),
+                )
+
+                WidgetPropPanel(
+                    visible    = editing && !previewing && propTarget != null,
+                    path       = propTarget?.path,
+                    instanceId = propTarget?.instanceId,
+                    controller = controller,
+                    onDismiss  = { propTarget = null },
+                    modifier   = Modifier.align(Alignment.TopEnd),
                 )
 
                 EditModeFab(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/decoration/EditableWidgetChrome.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -75,6 +76,7 @@ fun EditableWidgetChrome(
     controller: DragController,
     registry: DropTargetRegistry,
     onRemove: () -> Unit,
+    onEditProps: () -> Unit,
     onCommitDrop: (committedPointer: androidx.compose.ui.geometry.Offset) -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -211,6 +213,43 @@ fun EditableWidgetChrome(
                         contentDescription = "Удалить",
                         tint               = CelestiaTheme.colors.onPrimary,
                         modifier           = Modifier.size(14.dp).padding(0.dp).graphicsLayer { },
+                    )
+                }
+            }
+
+            // Prop editor affordance: hover-only "tune" gear, shown only
+            // when the widget declares props (propsSerializer != null).
+            // Sits left of the remove/force-remove button at the top-end.
+            // Same Release-consume pattern as remove so the tap does not
+            // start a drag.
+            this@Column.AnimatedVisibility(
+                visible  = isHovered && descriptor.propsSerializer != null,
+                enter    = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
+                exit     = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
+                modifier = Modifier.align(Alignment.TopEnd).padding(top = 4.dp, end = 30.dp),
+            ) {
+                Surface(
+                    color    = CelestiaTheme.colors.primary.copy(alpha = 0.85f),
+                    shape    = RoundedCornerShape(6.dp),
+                    modifier = Modifier
+                        .size(22.dp)
+                        .pointerInput(instance.instanceId) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    if (event.type == PointerEventType.Release) {
+                                        onEditProps()
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        },
+                ) {
+                    Icon(
+                        imageVector        = Icons.Default.Tune,
+                        contentDescription = "Настроить",
+                        tint               = CelestiaTheme.colors.onPrimary,
+                        modifier           = Modifier.size(14.dp).padding(0.dp),
                     )
                 }
             }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropControls.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropControls.kt
@@ -1,0 +1,213 @@
+package hivens.ui.editor.props
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.customization.HexField
+import hivens.ui.widgets.customization.LabeledSlider
+import hivens.widget.model.PropChoice
+import hivens.widget.model.PropColor
+import hivens.widget.model.PropRange
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.math.roundToInt
+
+// Renders one editor control for a single prop field, dispatching on the
+// serial kind + @SerialInfo annotations. `current` is the effective
+// value (default baseline overlaid with the instance's override), so it
+// is never null. onChange emits the new value as a JsonElement. INT/FLOAT
+// fields without a @PropRange fall through to a text field -- a slider
+// needs bounds.
+@Composable
+internal fun PropFieldRow(
+    label: String,
+    element: SerialDescriptor,
+    annotations: List<Annotation>,
+    current: JsonElement,
+    onChange: (JsonElement) -> Unit,
+) {
+    val isColor = annotations.any { it is PropColor }
+    val choice  = annotations.filterIsInstance<PropChoice>().firstOrNull()
+    val range   = annotations.filterIsInstance<PropRange>().firstOrNull()
+    val cur     = current.jsonPrimitive
+
+    when {
+        element.kind == SerialKind.ENUM -> {
+            val options = (0 until element.elementsCount).map { element.getElementName(it) }
+            ChoiceRow(label, options, cur.content) { onChange(JsonPrimitive(it)) }
+        }
+        choice != null ->
+            ChoiceRow(label, choice.options.toList(), cur.content) { onChange(JsonPrimitive(it)) }
+        isColor ->
+            ColorRow(label, cur.content) { onChange(JsonPrimitive(it)) }
+        element.kind == PrimitiveKind.BOOLEAN ->
+            BoolRow(label, cur.booleanOrNull ?: false) { onChange(JsonPrimitive(it)) }
+        element.kind == PrimitiveKind.INT && range != null ->
+            LabeledSlider(
+                label         = label,
+                value         = (cur.intOrNull ?: range.min.toInt()).toFloat(),
+                range         = range.min.toFloat()..range.max.toFloat(),
+                format        = "%.0f",
+                onValueChange = { onChange(JsonPrimitive(it.roundToInt())) },
+            )
+        (element.kind == PrimitiveKind.FLOAT || element.kind == PrimitiveKind.DOUBLE) && range != null ->
+            LabeledSlider(
+                label         = label,
+                value         = cur.floatOrNull ?: range.min.toFloat(),
+                range         = range.min.toFloat()..range.max.toFloat(),
+                format        = "%.2f",
+                onValueChange = { onChange(JsonPrimitive(it)) },
+            )
+        else ->
+            StringRow(label, cur.content) { onChange(JsonPrimitive(it)) }
+    }
+}
+
+@Composable
+private fun BoolRow(label: String, value: Boolean, onChange: (Boolean) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text     = label,
+            style    = MaterialTheme.typography.bodySmall,
+            color    = CelestiaTheme.colors.textSecondary,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(
+            checked         = value,
+            onCheckedChange = onChange,
+            colors          = SwitchDefaults.colors(checkedThumbColor = CelestiaTheme.colors.primary),
+        )
+    }
+}
+
+@Composable
+private fun ColorRow(label: String, hex: String, onChange: (String) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text     = label,
+            style    = MaterialTheme.typography.bodySmall,
+            color    = CelestiaTheme.colors.textSecondary,
+            modifier = Modifier.width(140.dp),
+        )
+        HexField(
+            initialHex   = hex,
+            invalidLabel = "hex",
+            onValidHex   = onChange,
+            modifier     = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun StringRow(label: String, value: String, onChange: (String) -> Unit) {
+    var text by remember(value) { mutableStateOf(value) }
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text     = label,
+            style    = MaterialTheme.typography.bodySmall,
+            color    = CelestiaTheme.colors.textSecondary,
+            modifier = Modifier.width(140.dp),
+        )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(36.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(glassSurfaceAlpha(0.4f))
+                .border(1.dp, CelestiaTheme.colors.outline.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+                .padding(horizontal = 10.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            BasicTextField(
+                value         = text,
+                onValueChange = { text = it; onChange(it) },
+                singleLine    = true,
+                textStyle     = TextStyle(color = CelestiaTheme.colors.textPrimary, fontSize = 13.sp),
+                cursorBrush   = SolidColor(CelestiaTheme.colors.primary),
+                modifier      = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChoiceRow(label: String, options: List<String>, selected: String, onChange: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text     = label,
+            style    = MaterialTheme.typography.bodySmall,
+            color    = CelestiaTheme.colors.textSecondary,
+            modifier = Modifier.width(140.dp),
+        )
+        Box(modifier = Modifier.weight(1f)) {
+            Text(
+                text     = selected,
+                style    = MaterialTheme.typography.bodySmall,
+                color    = CelestiaTheme.colors.textPrimary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(glassSurfaceAlpha(0.4f))
+                    .border(1.dp, CelestiaTheme.colors.outline.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+                    .clickable { expanded = true }
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
+            )
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                options.forEach { opt ->
+                    DropdownMenuItem(
+                        text    = { Text(opt, style = MaterialTheme.typography.bodySmall) },
+                        onClick = { onChange(opt); expanded = false },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropPanel.kt
@@ -1,0 +1,199 @@
+package hivens.ui.editor.props
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.editor.EditModeController
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.LocalLayoutGraph
+import hivens.widget.api.LocalWidgetRegistry
+import hivens.widget.api.WidgetDescriptor
+import hivens.widget.model.PropHidden
+import hivens.widget.model.PropLabel
+import hivens.widget.model.SlotPath
+import hivens.widget.model.WidgetInstance
+import hivens.widget.model.traverse
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonObject
+
+// Right-edge prop editor. Opened by a widget's "tune" chrome affordance,
+// which sets the host's prop target (path + instanceId). Resolves the
+// live instance from the layout graph each recomposition so external
+// edits (or a reset) reflect immediately. Mounted at the same edge as
+// the palette; the host hides the palette while this is open so they do
+// not overlap.
+@Composable
+fun WidgetPropPanel(
+    visible: Boolean,
+    path: SlotPath?,
+    instanceId: String?,
+    controller: EditModeController,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val graph = LocalLayoutGraph.current
+    val registry = LocalWidgetRegistry.current
+
+    val instance: WidgetInstance? = if (path != null && instanceId != null) {
+        graph.traverse(path)?.widgets?.firstOrNull { it.instanceId == instanceId }
+    } else {
+        null
+    }
+    val descriptor = instance?.let { registry[it.kind] }
+    val serializer = descriptor?.propsSerializer
+
+    AnimatedVisibility(
+        visible  = visible && serializer != null,
+        enter    = fadeIn(spring()) + slideInHorizontally(spring(stiffness = Spring.StiffnessMediumLow)) { it },
+        exit     = fadeOut(spring()) + slideOutHorizontally(spring(stiffness = Spring.StiffnessMediumLow)) { it },
+        modifier = modifier,
+    ) {
+        // All non-null inside the gate; an explicit check keeps smart-cast
+        // happy and survives the exit frame where the target may have just
+        // vanished (widget removed while editing).
+        if (descriptor != null && serializer != null && instance != null &&
+            path != null && instanceId != null
+        ) {
+            PropPanelBody(
+                descriptor = descriptor,
+                serializer = serializer,
+                instance   = instance,
+                path       = path,
+                instanceId = instanceId,
+                controller = controller,
+                onDismiss  = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PropPanelBody(
+    descriptor: WidgetDescriptor,
+    serializer: KSerializer<*>,
+    instance: WidgetInstance,
+    path: SlotPath,
+    instanceId: String,
+    controller: EditModeController,
+    onDismiss: () -> Unit,
+) {
+    val sd = serializer.descriptor
+    // Effective values: the encoded default baseline overlaid with the
+    // instance's stored overrides. Every key is present, so each field's
+    // current value is non-null.
+    val effective: JsonObject = remember(descriptor.defaultPropsJson, instance.props) {
+        JsonObject(descriptor.defaultPropsJson + instance.props)
+    }
+
+    Column(
+        modifier = Modifier
+            .width(320.dp)
+            .fillMaxHeight()
+            .padding(top = 64.dp, bottom = 96.dp, end = 16.dp)
+            .shadow(elevation = 18.dp, shape = RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(14.dp))
+            .background(glassSurfaceAlpha(0.86f)),
+    ) {
+        Row(
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier              = Modifier
+                .fillMaxWidth()
+                .padding(start = 14.dp, end = 6.dp, top = 12.dp, bottom = 6.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Default.Tune,
+                    contentDescription = null,
+                    tint               = CelestiaTheme.colors.primary,
+                    modifier           = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text       = descriptor.displayName,
+                    style      = MaterialTheme.typography.titleSmall,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            IconButton(onClick = onDismiss, modifier = Modifier.size(28.dp)) {
+                Icon(
+                    imageVector        = Icons.Default.Close,
+                    contentDescription = "Закрыть",
+                    tint               = CelestiaTheme.colors.textSecondary,
+                    modifier           = Modifier.size(16.dp),
+                )
+            }
+        }
+
+        Column(
+            modifier            = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 14.dp, vertical = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            for (i in 0 until sd.elementsCount) {
+                val anns = sd.getElementAnnotations(i)
+                if (anns.any { it is PropHidden }) continue
+                val name = sd.getElementName(i)
+                val cur = effective[name] ?: continue
+                val label = anns.filterIsInstance<PropLabel>().firstOrNull()?.value ?: name
+                PropFieldRow(
+                    label       = label,
+                    element     = sd.getElementDescriptor(i),
+                    annotations = anns,
+                    current     = cur,
+                    onChange    = { newValue ->
+                        controller.updateProps(path, instanceId, JsonObject(effective + (name to newValue)))
+                    },
+                )
+            }
+        }
+
+        TextButton(
+            onClick  = { controller.updateProps(path, instanceId, JsonObject(emptyMap())) },
+            modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+        ) {
+            Icon(Icons.Default.RestartAlt, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text("Сбросить к умолчанию", style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/props/WidgetPropPanel.kt
@@ -30,7 +30,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -69,8 +72,22 @@ fun WidgetPropPanel(
     val graph = LocalLayoutGraph.current
     val registry = LocalWidgetRegistry.current
 
-    val instance: WidgetInstance? = if (path != null && instanceId != null) {
-        graph.traverse(path)?.widgets?.firstOrNull { it.instanceId == instanceId }
+    // Latch the last real target so the slide-out animation still has
+    // content: on dismiss / edit-mode exit the host clears propTarget the
+    // same frame `visible` goes false, which would otherwise blank the
+    // panel mid-animation. The conditional write converges (same value on
+    // re-composition) and only updates while a target is set.
+    var lastPath by remember { mutableStateOf<SlotPath?>(null) }
+    var lastId   by remember { mutableStateOf<String?>(null) }
+    if (path != null && instanceId != null) {
+        lastPath = path
+        lastId   = instanceId
+    }
+    val resolvePath = path ?: lastPath
+    val resolveId   = instanceId ?: lastId
+
+    val instance: WidgetInstance? = if (resolvePath != null && resolveId != null) {
+        graph.traverse(resolvePath)?.widgets?.firstOrNull { it.instanceId == resolveId }
     } else {
         null
     }
@@ -85,16 +102,17 @@ fun WidgetPropPanel(
     ) {
         // All non-null inside the gate; an explicit check keeps smart-cast
         // happy and survives the exit frame where the target may have just
-        // vanished (widget removed while editing).
+        // vanished (dismiss / edit-mode exit / widget removed). Uses the
+        // latched resolve* so exit renders the last content.
         if (descriptor != null && serializer != null && instance != null &&
-            path != null && instanceId != null
+            resolvePath != null && resolveId != null
         ) {
             PropPanelBody(
                 descriptor = descriptor,
                 serializer = serializer,
                 instance   = instance,
-                path       = path,
-                instanceId = instanceId,
+                path       = resolvePath,
+                instanceId = resolveId,
                 controller = controller,
                 onDismiss  = onDismiss,
             )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/WidgetPropColor.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/WidgetPropColor.kt
@@ -1,0 +1,13 @@
+package hivens.ui.widgets
+
+import androidx.compose.ui.graphics.Color
+
+// Hex string -> Compose Color for @PropColor widget props. "" / blank /
+// malformed -> null so the caller falls back to a theme colour. Accepts
+// #RRGGBB and #AARRGGBB, with or without the leading '#'.
+fun String.toWidgetColorOrNull(): Color? {
+    val clean = trim().removePrefix("#")
+    if (clean.length != 6 && clean.length != 8) return null
+    val full = if (clean.length == 6) "FF$clean" else clean
+    return runCatching { Color(full.toLong(16)) }.getOrNull()
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutCreditsWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutCreditsWidget.kt
@@ -42,7 +42,9 @@ import kotlinx.serialization.Serializable
 // embraces the chaos.
 @Serializable
 data class AboutCreditsProps(
-    @PropLabel("Заголовок") val title: String = "",
+    // Overrides only the top "Авторы" section header; the Технологии and
+    // Лицензия sections stay localized.
+    @PropLabel("Заголовок (авторы)") val title: String = "",
 )
 
 @Widget(id = "about.credits", displayName = "Авторы и технологии", propsClass = AboutCreditsProps::class)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutCreditsWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutCreditsWidget.kt
@@ -29,17 +29,26 @@ import hivens.ui.easter.GibberishMode
 import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 
 // Credits + technology list + license. Self-scrolls because the
 // content is long; the surface does not impose a verticalScroll on
 // the slot. AprilFools occasionally corrupts these strings (role
 // scramble, tech-name zalgo, license-text lorem) -- the left column
 // embraces the chaos.
-@Widget(id = "about.credits", displayName = "Авторы и технологии")
+@Serializable
+data class AboutCreditsProps(
+    @PropLabel("Заголовок") val title: String = "",
+)
+
+@Widget(id = "about.credits", displayName = "Авторы и технологии", propsClass = AboutCreditsProps::class)
 @Composable
 fun AboutCreditsWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<AboutCreditsProps>()
     val af = LocalAprilFools.current
     val s = LocalStrings.current
 
@@ -49,7 +58,7 @@ fun AboutCreditsWidget(instance: WidgetInstance) {
                 .padding(20.dp)
                 .verticalScroll(rememberScrollState()),
         ) {
-            SectionLabel(s.aboutSectionCreator)
+            SectionLabel(p.title.ifBlank { s.aboutSectionCreator })
             Spacer(Modifier.height(12.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 AsyncImage(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutLinksCardWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutLinksCardWidget.kt
@@ -14,22 +14,31 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import hivens.ui.components.GlassCard
 import hivens.ui.i18n.LocalStrings
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AboutLinksProps(
+    @PropLabel("Заголовок") val title: String = "",
+)
 
 // External links: repo + issue tracker + releases. URLs are stable
 // upstream so they stay inline rather than threading through
 // configuration. Per-button atomization would be the same shape as
 // system rows -- one card per button or floating buttons. Single
 // card matches the legacy visual.
-@Widget(id = "about.links.card", displayName = "Ссылки")
+@Widget(id = "about.links.card", displayName = "Ссылки", propsClass = AboutLinksProps::class)
 @Composable
 fun AboutLinksCardWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<AboutLinksProps>()
     val s = LocalStrings.current
 
     GlassCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(20.dp)) {
-            SectionLabel(s.aboutSectionLinks)
+            SectionLabel(p.title.ifBlank { s.aboutSectionLinks })
             Spacer(Modifier.height(12.dp))
             LinkButton(s.aboutLinkGithub,    "https://github.com/Kitty-Hivens/Nexira",         Icons.Default.Code)
             Spacer(Modifier.height(8.dp))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutLogoWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutLogoWidget.kt
@@ -29,8 +29,11 @@ import hivens.ui.generated.resources.Res
 import hivens.ui.generated.resources.favicon
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.painterResource
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -40,9 +43,15 @@ import java.util.Locale
 // AprilFools wrapper occasionally corrupts these strings -- left
 // column embraces the chaos. Right column (system info, links)
 // stays readable on purpose.
-@Widget(id = "about.logo", displayName = "Логотип и версия")
+@Serializable
+data class AboutLogoProps(
+    @PropLabel("Заголовок") val title: String = "",
+)
+
+@Widget(id = "about.logo", displayName = "Логотип и версия", propsClass = AboutLogoProps::class)
 @Composable
 fun AboutLogoWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<AboutLogoProps>()
     val af = LocalAprilFools.current
     val s = LocalStrings.current
 
@@ -59,7 +68,7 @@ fun AboutLogoWidget(instance: WidgetInstance) {
             Spacer(Modifier.height(16.dp))
 
             Text(
-                text       = af.maybeGibberish(Branding.TITLE, probability = 0.15f),
+                text       = af.maybeGibberish(p.title.ifBlank { Branding.TITLE }, probability = 0.15f),
                 style      = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Black,
                 color      = CelestiaTheme.colors.textPrimary,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSystemCardWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSystemCardWidget.kt
@@ -16,23 +16,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import hivens.ui.components.GlassCard
 import hivens.ui.i18n.LocalStrings
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AboutSystemProps(
+    @PropLabel("Заголовок") val title: String = "",
+)
 
 // OS / CPU / RAM / Java / Display info rows in one card.
 // Per-row atomization would give the user editor freedom they would
 // not actually exercise (no one hides "RAM" but keeps "CPU"), and
 // would either explode into five mini-cards or leave bare rows
 // floating with no visual grouping.
-@Widget(id = "about.system.card", displayName = "Система")
+@Widget(id = "about.system.card", displayName = "Система", propsClass = AboutSystemProps::class)
 @Composable
 fun AboutSystemCardWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<AboutSystemProps>()
     val ctx = LocalAboutContext.current
     val s = LocalStrings.current
 
     GlassCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(20.dp)) {
-            SectionLabel(s.aboutSectionSystem)
+            SectionLabel(p.title.ifBlank { s.aboutSectionSystem })
             Spacer(Modifier.height(12.dp))
 
             val osName     = System.getProperty("os.name")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutUpdatePanelWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutUpdatePanelWidget.kt
@@ -37,8 +37,16 @@ import hivens.ui.components.GlassCard
 import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AboutUpdateProps(
+    @PropLabel("Заголовок") val title: String = "",
+)
 
 // Update check + state machine: Idle (check button) -> Checking
 // (spinner) -> UpToDate / Available / Error. Reads + writes
@@ -46,9 +54,10 @@ import hivens.widget.model.WidgetInstance
 // ctx.showUpdateDialog. Removing this widget loses the in-pane
 // update affordance but the puppet check / dialog routes still
 // work because the state lives in the surface composable.
-@Widget(id = "about.update.panel", displayName = "Обновления")
+@Widget(id = "about.update.panel", displayName = "Обновления", propsClass = AboutUpdateProps::class)
 @Composable
 fun AboutUpdatePanelWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<AboutUpdateProps>()
     val ctx = LocalAboutContext.current
     val af = LocalAprilFools.current
     val s = LocalStrings.current
@@ -56,7 +65,7 @@ fun AboutUpdatePanelWidget(instance: WidgetInstance) {
 
     GlassCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(20.dp)) {
-            SectionLabel(s.aboutSectionUpdates)
+            SectionLabel(p.title.ifBlank { s.aboutSectionUpdates })
             Spacer(Modifier.height(16.dp))
             InfoRow(Icons.Default.Info, s.aboutCurrentVersion, "v${Branding.VERSION.removePrefix("v")}")
             Spacer(Modifier.height(16.dp))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/customization/CustomizationHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/customization/CustomizationHelpers.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.toWidgetColorOrNull
 
 @Composable
 internal fun SectionTitle(text: String) {
@@ -128,7 +129,7 @@ internal fun HexField(
     modifier: Modifier = Modifier,
 ) {
     var text by remember(initialHex) { mutableStateOf(initialHex) }
-    val parsed = parseHexOrNull(text)
+    val parsed = text.toWidgetColorOrNull()
     val valid  = text.isBlank() || parsed != null
 
     Row(
@@ -163,7 +164,7 @@ internal fun HexField(
                     text = t
                     if (t.isNotBlank()) {
                         val normalized = t.trim()
-                        parseHexOrNull(normalized)?.let { onValidHex(normalized) }
+                        normalized.toWidgetColorOrNull()?.let { onValidHex(normalized) }
                     }
                 },
                 singleLine    = true,
@@ -181,10 +182,3 @@ internal fun HexField(
         }
     }
 }
-
-private fun parseHexOrNull(hex: String): Color? = runCatching {
-    val clean = hex.removePrefix("#").trim()
-    if (clean.length != 6 && clean.length != 8) return@runCatching null
-    val full = if (clean.length == 6) "FF$clean" else clean
-    Color(full.toLong(16))
-}.getOrNull()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewQuickLaunch.kt
@@ -36,17 +36,26 @@ import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.utils.GameConsoleService
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
+
+@Serializable
+data class QuickLaunchProps(
+    @PropLabel("Надпись кнопки") val buttonLabel: String = "Играть",
+)
 
 // Quick-launch target = most recently played, falling back to most
 // recently installed when nothing has been played. Empty repo elides
 // the widget entirely -- HomeNewRecent already shows the install CTA
 // in that state and two empty cards would be noisy.
-@Widget(id = "home.new.quicklaunch", displayName = "Quick launch")
+@Widget(id = "home.new.quicklaunch", displayName = "Quick launch", propsClass = QuickLaunchProps::class)
 @Composable
 fun HomeNewQuickLaunch(instance: WidgetInstance) {
+    val p = instance.rememberProps<QuickLaunchProps>()
     val ctx = LocalHomeNewContext.current
     val repo: IPackRepository = koinInject()
     val controller: LauncherController = koinInject()
@@ -116,7 +125,7 @@ fun HomeNewQuickLaunch(instance: WidgetInstance) {
             ) {
                 Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(6.dp))
-                Text("Играть", fontWeight = FontWeight.SemiBold)
+                Text(p.buttonLabel, fontWeight = FontWeight.SemiBold)
             }
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewRecent.kt
@@ -39,20 +39,29 @@ import hivens.core.data.PackInstance
 import hivens.ui.Screen
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
-private const val MAX_RECENT = 5
+@Serializable
+data class RecentProps(
+    @PropLabel("Заголовок") val title: String = "Твои сборки",
+    @PropLabel("Сколько плиток") @PropRange(1.0, 12.0) val maxTiles: Int = 5,
+)
 
 // Pack tiles row. Sort priority: played packs first by recency, then
 // unplayed packs by install order. A fresh install with packs but no
 // launches still shows the tiles (sorted by createdAt), so the new
 // home reads as populated rather than blank. Empty repo shows a CTA
 // pointing at Browse.
-@Widget(id = "home.new.recent", displayName = "Pack tiles")
+@Widget(id = "home.new.recent", displayName = "Pack tiles", propsClass = RecentProps::class)
 @Composable
 fun HomeNewRecent(instance: WidgetInstance) {
+    val p = instance.rememberProps<RecentProps>()
     val ctx = LocalHomeNewContext.current
     val repo: IPackRepository = koinInject()
     val all by remember { repo.observe() }.collectAsState(initial = emptyList())
@@ -62,16 +71,16 @@ fun HomeNewRecent(instance: WidgetInstance) {
         return
     }
 
-    val recent = remember(all) {
+    val recent = remember(all, p.maxTiles) {
         all.sortedWith(
             compareByDescending<PackInstance> { it.lastPlayedEpochOrZero }
                 .thenByDescending { it.createdAtEpoch },
-        ).take(MAX_RECENT)
+        ).take(p.maxTiles)
     }
 
     Column(Modifier.fillMaxWidth().padding(top = 12.dp)) {
         Text(
-            text       = "Твои сборки",
+            text       = p.title,
             style      = MaterialTheme.typography.titleSmall,
             color      = CelestiaTheme.colors.textPrimary,
             fontWeight = FontWeight.SemiBold,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewWelcome.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/new/HomeNewWelcome.kt
@@ -18,15 +18,27 @@ import hivens.ui.AppState
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WelcomeProps(
+    // Blank keeps the localized, name-personalized greeting; a non-blank
+    // value is the user's own banner text (single language, by choice).
+    @PropLabel("Свой текст приветствия") val customGreeting: String = "",
+    @PropLabel("Показывать подзаголовок") val showSubtitle: Boolean = true,
+)
 
 // Greeting banner. Personalizes with the authenticated player name;
 // in unauthenticated / loading states the welcome stays generic so the
 // banner does not flicker between greetings during login.
-@Widget(id = "home.new.welcome", displayName = "Welcome banner")
+@Widget(id = "home.new.welcome", displayName = "Welcome banner", propsClass = WelcomeProps::class)
 @Composable
 fun HomeNewWelcome(instance: WidgetInstance) {
+    val p = instance.rememberProps<WelcomeProps>()
     val ctx = LocalHomeNewContext.current
     val s = LocalStrings.current
     val playerName = (ctx.appState as? AppState.Authenticated)?.session?.playerName
@@ -39,16 +51,22 @@ fun HomeNewWelcome(instance: WidgetInstance) {
             .padding(horizontal = 20.dp, vertical = 18.dp),
     ) {
         Text(
-            text       = if (playerName != null) s.dashboardWelcome(playerName) else s.appName,
+            text       = when {
+                p.customGreeting.isNotBlank() -> p.customGreeting
+                playerName != null            -> s.dashboardWelcome(playerName)
+                else                          -> s.appName
+            },
             style      = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.SemiBold,
             color      = CelestiaTheme.colors.textPrimary,
         )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text  = s.settingsHomeViewSub,
-            style = MaterialTheme.typography.bodySmall,
-            color = CelestiaTheme.colors.textSecondary,
-        )
+        if (p.showSubtitle) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text  = s.settingsHomeViewSub,
+                style = MaterialTheme.typography.bodySmall,
+                color = CelestiaTheme.colors.textSecondary,
+            )
+        }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryBody.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryBody.kt
@@ -33,17 +33,28 @@ import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.screens.library.PackCard
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.utils.GameConsoleService
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
+
+@Serializable
+data class LibraryBodyProps(
+    @PropLabel("Заголовок пустого состояния") val emptyTitle: String = "Пока пусто",
+    @PropLabel("Текст пустого состояния")
+    val emptyText: String = "Установите сборку через Browse — она появится здесь.",
+)
 
 // Single widget covers both populated list and empty state. Slot-level
 // branching would force the layout graph to know about appState, which
 // belongs to navigation, not layout. Self-gating keeps the slot stable
 // across the empty -> populated transition.
-@Widget(id = "library.body", displayName = "Library Body")
+@Widget(id = "library.body", displayName = "Library Body", propsClass = LibraryBodyProps::class)
 @Composable
 fun LibraryBody(instance: WidgetInstance) {
+    val p = instance.rememberProps<LibraryBodyProps>()
     val ctx = LocalLibraryContext.current
     val repo: IPackRepository = koinInject()
     val controller: LauncherController = koinInject()
@@ -53,7 +64,11 @@ fun LibraryBody(instance: WidgetInstance) {
     val authedSession = (ctx.appState as? AppState.Authenticated)?.session
 
     if (instances.isEmpty()) {
-        LibraryEmpty(onBrowse = { ctx.onScreenChange(Screen.Browse) })
+        LibraryEmpty(
+            title    = p.emptyTitle,
+            body     = p.emptyText,
+            onBrowse = { ctx.onScreenChange(Screen.Browse) },
+        )
     } else {
         LibraryList(
             instances    = instances,
@@ -103,20 +118,20 @@ private fun LibraryList(
 }
 
 @Composable
-private fun LibraryEmpty(onBrowse: () -> Unit) {
+private fun LibraryEmpty(title: String, body: String, onBrowse: () -> Unit) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Text(
-                text       = "Пока пусто",
+                text       = title,
                 style      = MaterialTheme.typography.titleLarge,
                 color      = CelestiaTheme.colors.textPrimary,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                text      = "Установите сборку через Browse — она появится здесь.",
+                text      = body,
                 style     = MaterialTheme.typography.bodyMedium,
                 color     = CelestiaTheme.colors.textSecondary,
                 textAlign = TextAlign.Center,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
@@ -12,22 +12,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 
-@Widget(id = "library.header", displayName = "Library Header")
+@Serializable
+data class LibraryHeaderProps(
+    @PropLabel("Заголовок") val title: String = "БИБЛИОТЕКА",
+    @PropLabel("Подзаголовок") val subtitle: String = "Установленные сборки",
+)
+
+@Widget(id = "library.header", displayName = "Library Header", propsClass = LibraryHeaderProps::class)
 @Composable
 fun LibraryHeader(instance: WidgetInstance) {
+    val p = instance.rememberProps<LibraryHeaderProps>()
     Column(Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
         Text(
-            text       = "БИБЛИОТЕКА",
+            text       = p.title,
             style      = MaterialTheme.typography.headlineSmall,
             color      = CelestiaTheme.colors.textPrimary,
             fontWeight = FontWeight.Bold,
         )
         Spacer(Modifier.height(4.dp))
         Text(
-            text  = "Установленные сборки",
+            text  = p.subtitle,
             style = MaterialTheme.typography.bodyMedium,
             color = CelestiaTheme.colors.textSecondary,
         )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/library/LibraryHeader.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LibraryHeaderProps(
-    @PropLabel("Заголовок") val title: String = "БИБЛИОТЕКА",
+    @PropLabel("Заголовок") val title: String = "Библиотека",
     @PropLabel("Подзаголовок") val subtitle: String = "Установленные сборки",
 )
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/profile/ProfileSkinSectionWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/profile/ProfileSkinSectionWidget.kt
@@ -39,8 +39,12 @@ import hivens.ui.i18n.LocalStrings
 import hivens.ui.identity.SkinManager
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -55,9 +59,15 @@ import java.io.File
 // Skin preview + upload + refresh. Reads session from
 // LocalProfileContext; pulls SkinManager + SkinRepository from Koin
 // directly (services live per-widget, not in the surface context).
-@Widget(id = "profile.skin.section", displayName = "Скин")
+@Serializable
+data class ProfileSkinProps(
+    @PropLabel("Высота превью") @PropRange(200.0, 480.0) val previewHeight: Int = 360,
+)
+
+@Widget(id = "profile.skin.section", displayName = "Скин", propsClass = ProfileSkinProps::class)
 @Composable
 fun ProfileSkinSectionWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<ProfileSkinProps>()
     val ctx = LocalProfileContext.current
     val s = LocalStrings.current
     val af = LocalAprilFools.current
@@ -84,7 +94,7 @@ fun ProfileSkinSectionWidget(instance: WidgetInstance) {
         Box(
             Modifier
                 .fillMaxWidth()
-                .height(360.dp)
+                .height(p.previewHeight.dp)
                 .clip(RoundedCornerShape(style.cardCorner))
                 .background(CelestiaTheme.colors.background.copy(alpha = 0.4f)),
         ) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
@@ -2,10 +2,10 @@ package hivens.ui.widgets.sample
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -27,27 +27,60 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.toWidgetColorOrNull
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropColor
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
 import kotlinx.coroutines.delay
+import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
 
-// Analog clock with smooth-sweeping seconds. Theme-aware: dial reads
-// surface, hands read textPrimary, accent ring reads primary. Per-
-// second tick recomposes only the Canvas + the digital time line; the
-// surrounding card stays still.
-@Widget(id = "home.new.clock", displayName = "Clock")
+@Serializable
+enum class ClockMode { Analog, Digital, Both }
+
+@Serializable
+data class ClockProps(
+    @PropLabel("Режим") val mode: ClockMode = ClockMode.Both,
+    @PropLabel("24-часовой формат") val format24h: Boolean = true,
+    @PropLabel("Секунды") val showSeconds: Boolean = true,
+    @PropLabel("Заголовок") val title: String = "Часы",
+    @PropLabel("Размер циферблата") @PropRange(80.0, 200.0) val faceSize: Int = 140,
+    @PropLabel("Цвет акцента") @PropColor val accent: String = "",
+)
+
+// Analog + digital clock with smooth-sweeping seconds. Theme-aware: dial
+// reads surface, hands read textPrimary, accent (second hand / hub) reads
+// the accent prop or falls back to primary. Per-second tick recomposes
+// only the Canvas + the digital time line; the surrounding card stays
+// still.
+@Widget(id = "home.new.clock", displayName = "Clock", propsClass = ClockProps::class)
 @Composable
 fun ClockWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<ClockProps>()
+    val accent = p.accent.toWidgetColorOrNull()
+    val timeFormatter = remember(p.format24h, p.showSeconds) {
+        DateTimeFormatter.ofPattern(
+            buildString {
+                append(if (p.format24h) "HH:mm" else "hh:mm")
+                if (p.showSeconds) append(":ss")
+                if (!p.format24h) append(" a")
+            },
+        )
+    }
+
     var now by remember { mutableStateOf(LocalDateTime.now()) }
     LaunchedEffect(Unit) {
         while (true) {
@@ -68,44 +101,56 @@ fun ClockWidget(instance: WidgetInstance) {
             .padding(horizontal = 16.dp, vertical = 14.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
-            text       = "Часы",
-            style      = MaterialTheme.typography.labelLarge,
-            color      = CelestiaTheme.colors.textSecondary,
-            fontWeight = FontWeight.Medium,
-            modifier   = Modifier.align(Alignment.Start),
-        )
-        Spacer(Modifier.height(10.dp))
+        if (p.title.isNotBlank()) {
+            Text(
+                text       = p.title,
+                style      = MaterialTheme.typography.labelLarge,
+                color      = CelestiaTheme.colors.textSecondary,
+                fontWeight = FontWeight.Medium,
+                modifier   = Modifier.align(Alignment.Start),
+            )
+            Spacer(Modifier.height(10.dp))
+        }
 
-        ClockFace(
-            time     = now,
-            modifier = Modifier.size(140.dp),
-        )
+        if (p.mode != ClockMode.Digital) {
+            ClockFace(
+                time           = now,
+                showSeconds    = p.showSeconds,
+                accentOverride = accent,
+                modifier       = Modifier.size(p.faceSize.dp),
+            )
+            Spacer(Modifier.height(10.dp))
+        }
 
-        Spacer(Modifier.height(10.dp))
-
-        Text(
-            text       = TIME_FORMATTER.format(now),
-            style      = MaterialTheme.typography.titleLarge,
-            color      = CelestiaTheme.colors.textPrimary,
-            fontWeight = FontWeight.Light,
-        )
-        Text(
-            text  = DATE_FORMATTER.format(now),
-            style = MaterialTheme.typography.bodySmall,
-            color = CelestiaTheme.colors.textSecondary,
-        )
+        if (p.mode != ClockMode.Analog) {
+            Text(
+                text       = timeFormatter.format(now),
+                style      = MaterialTheme.typography.titleLarge,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.Light,
+            )
+            Text(
+                text  = DATE_FORMATTER.format(now),
+                style = MaterialTheme.typography.bodySmall,
+                color = CelestiaTheme.colors.textSecondary,
+            )
+        }
     }
 }
 
 @Composable
-private fun ClockFace(time: LocalDateTime, modifier: Modifier = Modifier) {
+private fun ClockFace(
+    time: LocalDateTime,
+    showSeconds: Boolean,
+    accentOverride: Color?,
+    modifier: Modifier = Modifier,
+) {
     val dialColor   = CelestiaTheme.colors.surface
     val rimColor    = CelestiaTheme.colors.outline.copy(alpha = 0.50f)
     val markerColor = CelestiaTheme.colors.textSecondary.copy(alpha = 0.75f)
     val hourColor   = CelestiaTheme.colors.textPrimary
     val minuteColor = CelestiaTheme.colors.textPrimary
-    val secondColor = CelestiaTheme.colors.primary
+    val secondColor = accentOverride ?: CelestiaTheme.colors.primary
 
     Box(
         modifier = modifier
@@ -116,12 +161,12 @@ private fun ClockFace(time: LocalDateTime, modifier: Modifier = Modifier) {
                 ),
             ),
     ) {
-        Canvas(modifier = Modifier.fillMaxWidth().padding(0.dp).align(Alignment.Center).size(140.dp)) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
             val radius = min(size.width, size.height) / 2f
             val center = Offset(size.width / 2f, size.height / 2f)
 
             // Rim
-            drawCircle(color = rimColor, radius = radius - 1f, center = center, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2f))
+            drawCircle(color = rimColor, radius = radius - 1f, center = center, style = Stroke(width = 2f))
 
             // Hour markers: long at 12/3/6/9, short elsewhere
             for (i in 0 until 12) {
@@ -167,15 +212,18 @@ private fun ClockFace(time: LocalDateTime, modifier: Modifier = Modifier) {
                     cap         = StrokeCap.Round,
                 )
             }
-            // Second hand (counter-weighted)
-            rotate(degrees = second * 6f - 90f, pivot = center) {
-                drawLine(
-                    color       = secondColor,
-                    start       = Offset(center.x - radius * 0.12f, center.y),
-                    end         = Offset(center.x + radius * 0.82f, center.y),
-                    strokeWidth = 1.5f,
-                    cap         = StrokeCap.Round,
-                )
+            // Second hand (counter-weighted) -- only when the showSeconds
+            // prop is on.
+            if (showSeconds) {
+                rotate(degrees = second * 6f - 90f, pivot = center) {
+                    drawLine(
+                        color       = secondColor,
+                        start       = Offset(center.x - radius * 0.12f, center.y),
+                        end         = Offset(center.x + radius * 0.82f, center.y),
+                        strokeWidth = 1.5f,
+                        cap         = StrokeCap.Round,
+                    )
+                }
             }
 
             // Hub
@@ -185,5 +233,4 @@ private fun ClockFace(time: LocalDateTime, modifier: Modifier = Modifier) {
     }
 }
 
-private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
 private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, d MMM")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/LaunchButtonWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/LaunchButtonWidget.kt
@@ -38,17 +38,27 @@ import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.utils.GameConsoleService
 import hivens.ui.widgets.home.new.LocalHomeNewContext
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
+
+@Serializable
+data class LaunchButtonProps(
+    // Blank falls back to the default "Запустить" label.
+    @PropLabel("Надпись") val label: String = "",
+)
 
 // Big "Continue last" launch tile. Decoupled from the QuickLaunch
 // card -- this one is a single full-width tap target with a gradient
 // background, no surrounding labels or metadata. Designed to feel
 // like a console "press to play" affordance.
-@Widget(id = "home.new.launchbutton", displayName = "Launch button")
+@Widget(id = "home.new.launchbutton", displayName = "Launch button", propsClass = LaunchButtonProps::class)
 @Composable
 fun LaunchButtonWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<LaunchButtonProps>()
     val ctx = LocalHomeNewContext.current
     val repo: IPackRepository = koinInject()
     val controller: LauncherController = koinInject()
@@ -111,7 +121,7 @@ fun LaunchButtonWidget(instance: WidgetInstance) {
             Spacer(Modifier.width(14.dp))
             Column(Modifier.weight(1f)) {
                 Text(
-                    text       = if (ready) "Запустить" else "Играть нельзя",
+                    text       = if (ready) p.label.ifBlank { "Запустить" } else "Играть нельзя",
                     style      = MaterialTheme.typography.titleLarge,
                     color      = if (ready) Color.White else CelestiaTheme.colors.textSecondary,
                     fontWeight = FontWeight.SemiBold,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/MusicPlayerWidget.kt
@@ -67,9 +67,12 @@ import hivens.ui.theme.CelestiaTheme
 import hivens.ui.widgets.services.MusicPlayerService
 import hivens.ui.widgets.services.MusicPlayerServiceImpl
 import hivens.widget.api.provideService
+import hivens.widget.api.rememberProps
 import hivens.widget.model.ProvidesService
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -88,10 +91,16 @@ import kotlin.io.path.name
 // removing every game widget and keeping this + a clock + the right
 // rail (or nothing). MP3 support arrives with Skinema (FFmpeg
 // via Panama).
-@Widget(id = "home.new.music", displayName = "Music player")
+@Serializable
+data class MusicProps(
+    @PropLabel("Заголовок") val title: String = "Музыкальный плеер",
+)
+
+@Widget(id = "home.new.music", displayName = "Music player", propsClass = MusicProps::class)
 @ProvidesService(MusicPlayerService::class)
 @Composable
 fun MusicPlayerWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<MusicProps>()
     val player: AudioPlayer = koinInject()
     val state by player.state.collectAsState()
     val volume by player.volume.collectAsState()
@@ -143,7 +152,7 @@ fun MusicPlayerWidget(instance: WidgetInstance) {
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
                 Text(
-                    text       = "Музыкальный плеер",
+                    text       = p.title,
                     style      = MaterialTheme.typography.labelLarge,
                     color      = CelestiaTheme.colors.textSecondary,
                     fontWeight = FontWeight.Medium,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ProgressWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ProgressWidget.kt
@@ -24,17 +24,27 @@ import androidx.compose.ui.unit.dp
 import hivens.launcher.AutoSyncService
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
+
+@Serializable
+data class ProgressProps(
+    @PropLabel("Заголовок") val title: String = "Фоновая активность",
+    @PropLabel("Текст простоя") val idleText: String = "Сейчас ничего не качается.",
+)
 
 // Compact background-activity card. Shows AutoSyncService state when
 // a sync is in flight; collapses to a calm "idle" message otherwise.
 // Polished version of the dashboard's autosync strip, broken out so
 // the new home can host it independently.
-@Widget(id = "home.new.progress", displayName = "Background activity")
+@Widget(id = "home.new.progress", displayName = "Background activity", propsClass = ProgressProps::class)
 @Composable
 fun ProgressWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<ProgressProps>()
     val autoSyncService: AutoSyncService = koinInject()
     val snapshot by autoSyncService.snapshot.collectAsState()
     val overall  = snapshot.overall
@@ -48,7 +58,7 @@ fun ProgressWidget(instance: WidgetInstance) {
             .padding(horizontal = 16.dp, vertical = 14.dp),
     ) {
         Text(
-            text       = "Фоновая активность",
+            text       = p.title,
             style      = MaterialTheme.typography.labelLarge,
             color      = CelestiaTheme.colors.textSecondary,
             fontWeight = FontWeight.Medium,
@@ -57,7 +67,7 @@ fun ProgressWidget(instance: WidgetInstance) {
 
         when (val s = overall) {
             is AutoSyncService.OverallState.InProgress -> InProgressBody(s)
-            else                                       -> IdleBody()
+            else                                       -> IdleBody(p.idleText)
         }
     }
 }
@@ -102,14 +112,14 @@ private fun InProgressBody(state: AutoSyncService.OverallState.InProgress) {
 }
 
 @Composable
-private fun IdleBody() {
+private fun IdleBody(text: String) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 6.dp),
     ) {
         Text(
-            text  = "Сейчас ничего не качается.",
+            text  = text,
             style = MaterialTheme.typography.bodyMedium,
             color = CelestiaTheme.colors.textSecondary,
         )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/SpacerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/SpacerWidget.kt
@@ -13,27 +13,35 @@ import androidx.compose.ui.unit.dp
 import hivens.ui.editor.EditModeState
 import hivens.ui.editor.LocalEditMode
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
 
-// Layout primitive. Renders 32dp of empty vertical space; in edit
-// mode a faint dashed center line shows the widget is there and
-// grabbable. Props in Phase 5 will let the user pick the height; for
-// now it is fixed so the editor can demonstrate reorder without prop
-// UI.
-@Widget(id = "home.new.spacer", displayName = "Spacer")
+@Serializable
+data class SpacerProps(
+    @PropLabel("Высота") @PropRange(8.0, 160.0) val height: Int = 32,
+)
+
+// Layout primitive. Renders empty vertical space (height is a prop); in
+// edit mode a faint dashed center line shows the widget is there and
+// grabbable.
+@Widget(id = "home.new.spacer", displayName = "Spacer", propsClass = SpacerProps::class)
 @Composable
 fun SpacerWidget(instance: WidgetInstance) {
+    val h = instance.rememberProps<SpacerProps>().height.dp
     val edit = LocalEditMode.current is EditModeState.On
     if (!edit) {
-        Spacer(Modifier.fillMaxWidth().height(32.dp))
+        Spacer(Modifier.fillMaxWidth().height(h))
         return
     }
     val lineColor = CelestiaTheme.colors.outline.copy(alpha = 0.35f)
     Canvas(
         modifier = Modifier
             .fillMaxWidth()
-            .height(32.dp),
+            .height(h),
     ) {
         val y = size.height / 2f
         drawLine(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/serverdetails/ServerDetailsBannerWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/serverdetails/ServerDetailsBannerWidget.kt
@@ -22,15 +22,25 @@ import androidx.compose.ui.unit.dp
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
+import hivens.widget.api.rememberProps
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
 import hivens.widget.model.Widget
 import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServerBannerProps(
+    @PropLabel("Скругление углов") @PropRange(0.0, 32.0) val cornerRadius: Int = 16,
+)
 
 // Banner image (banner.png from the pack assets dir) or a missing
 // hint when the file is absent. Fills its slot box, image scaled
 // to crop so framing is consistent across asset sizes.
-@Widget(id = "server.details.banner", displayName = "Баннер сервера")
+@Widget(id = "server.details.banner", displayName = "Баннер сервера", propsClass = ServerBannerProps::class)
 @Composable
 fun ServerDetailsBannerWidget(instance: WidgetInstance) {
+    val p = instance.rememberProps<ServerBannerProps>()
     val ctx = LocalServerDetailsContext.current
     val s = LocalStrings.current
     val banner by ctx.bannerImage
@@ -38,12 +48,12 @@ fun ServerDetailsBannerWidget(instance: WidgetInstance) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(p.cornerRadius.dp))
             .background(glassSurfaceAlpha(0.5f))
             .border(
                 width = 1.dp,
                 color = CelestiaTheme.colors.outline.copy(alpha = 0.2f),
-                shape = RoundedCornerShape(16.dp),
+                shape = RoundedCornerShape(p.cornerRadius.dp),
             ),
         contentAlignment = Alignment.Center,
     ) {

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/props/PropDescriptorTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/props/PropDescriptorTest.kt
@@ -1,0 +1,78 @@
+package hivens.ui.editor.props
+
+import hivens.widget.model.PropChoice
+import hivens.widget.model.PropColor
+import hivens.widget.model.PropHidden
+import hivens.widget.model.PropLabel
+import hivens.widget.model.PropRange
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Serializable
+private enum class Flavor { A, B, C }
+
+@Serializable
+private data class SampleProps(
+    @PropLabel("Флаг") val flag: Boolean = true,
+    @PropRange(80.0, 200.0) val size: Int = 140,
+    @PropColor val accent: String = "",
+    @PropChoice(["x", "y"]) val pick: String = "x",
+    @PropHidden val secret: Int = 0,
+    val flavor: Flavor = Flavor.B,
+)
+
+// Validates the contract the prop editor's form builder relies on: the
+// @SerialInfo prop annotations must survive into the SerialDescriptor and
+// be readable via getElementAnnotations, and enum fields must report the
+// ENUM kind with their entry names. If @SerialInfo retention or targeting
+// were wrong, the editor would silently render every field as a plain
+// text box -- this catches that at build time.
+class PropDescriptorTest {
+
+    private val d = serializer<SampleProps>().descriptor
+
+    private fun annsOf(name: String): List<Annotation> {
+        val idx = (0 until d.elementsCount).first { d.getElementName(it) == name }
+        return d.getElementAnnotations(idx)
+    }
+
+    @Test
+    fun `PropLabel surfaces with its value`() {
+        assertEquals("Флаг", annsOf("flag").filterIsInstance<PropLabel>().firstOrNull()?.value)
+    }
+
+    @Test
+    fun `PropRange surfaces with bounds`() {
+        val r = annsOf("size").filterIsInstance<PropRange>().firstOrNull()
+        assertEquals(80.0, r?.min)
+        assertEquals(200.0, r?.max)
+    }
+
+    @Test
+    fun `PropColor surfaces`() {
+        assertTrue(annsOf("accent").any { it is PropColor })
+    }
+
+    @Test
+    fun `PropChoice surfaces with options`() {
+        val c = annsOf("pick").filterIsInstance<PropChoice>().firstOrNull()
+        assertEquals(listOf("x", "y"), c?.options?.toList())
+    }
+
+    @Test
+    fun `PropHidden surfaces`() {
+        assertTrue(annsOf("secret").any { it is PropHidden })
+    }
+
+    @Test
+    fun `enum field reports ENUM kind with entry names`() {
+        val idx = (0 until d.elementsCount).first { d.getElementName(it) == "flavor" }
+        val ed = d.getElementDescriptor(idx)
+        assertEquals(SerialKind.ENUM, ed.kind)
+        assertEquals(listOf("A", "B", "C"), (0 until ed.elementsCount).map { ed.getElementName(it) })
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/widget/WidgetRegistryConsistencyTest.kt
@@ -137,4 +137,40 @@ class WidgetRegistryConsistencyTest {
             "non-removable set protects the launcher from being navigation-locked",
         )
     }
+
+    @Test
+    fun `widgets exposing props match the Phase 5 audited set`() {
+        val propful = GeneratedWidgetRegistry.all().values
+            .filter { it.propsSerializer != null }
+            .map { it.kind.value }
+            .toSet()
+        val expected = setOf(
+            // display widgets
+            "home.new.clock",
+            "home.new.spacer",
+            "home.new.progress",
+            "home.new.welcome",
+            "home.new.launchbutton",
+            "home.new.music",
+            "home.new.recent",
+            "home.new.quicklaunch",
+            // About surface (title overrides)
+            "about.logo",
+            "about.system.card",
+            "about.credits",
+            "about.links.card",
+            "about.update.panel",
+            // Library
+            "library.header",
+            "library.body",
+            // expressive knobs on otherwise data-driven sections
+            "server.details.banner",
+            "profile.skin.section",
+        )
+        assertEquals(
+            expected,
+            propful,
+            "prop-exposing widget set drifted -- a @Widget(propsClass=...) was added or dropped",
+        )
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ proguard          = "7.8.2"
 # repositories chain) until libtray cuts its first Maven Central release;
 # pinned to a commit sha rather than a branch so upstream main-branch
 # changes don't silently land in our build.
-libtray           = "e5e6b5f"
+libtray           = "e86f497"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"

--- a/widget-api/build.gradle.kts
+++ b/widget-api/build.gradle.kts
@@ -1,6 +1,10 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.compose.compiler)
+    // widget-api is serialization-aware: WidgetDescriptor exposes a
+    // KSerializer, WidgetProps decodes instance props, and prop classes
+    // declared here (or in tests) need generated serializers.
+    alias(libs.plugins.kotlin.serialization)
 }
 
 // Compose-bound surface for the widget kernel. Data shapes (ids,

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetProps.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetProps.kt
@@ -1,0 +1,34 @@
+package hivens.widget.api
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import hivens.widget.model.WidgetInstance
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.serializer
+
+// Shared Json for prop decode. ignoreUnknownKeys: a layout written by a
+// newer build (extra prop keys) still decodes on an older one.
+// encodeDefaults: the editor + registry round-trip explicit values.
+val widgetPropsJson: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+// Decode this instance's stored props into the typed prop class T. An
+// empty props object decodes to all-defaults (every prop field has a
+// default), so an un-tuned widget still gets a valid T. A malformed
+// props object (corrupt / cross-version layout file) falls back to
+// defaults rather than crashing the surface -- the layout file is
+// user-editable, so this is a real boundary.
+inline fun <reified T> WidgetInstance.decodeProps(): T =
+    runCatching {
+        widgetPropsJson.decodeFromJsonElement(serializer<T>(), props)
+    }.getOrElse {
+        widgetPropsJson.decodeFromJsonElement(serializer<T>(), JsonObject(emptyMap()))
+    }
+
+// Composable accessor: memoized on props so the decode runs only when
+// stored props change. The returned data class is stable (all-stable
+// fields), so Compose can skip recomposition when nothing changed --
+// the stability win typed props buy over a raw JsonObject.
+@Composable
+inline fun <reified T> WidgetInstance.rememberProps(): T =
+    remember(props) { decodeProps<T>() }

--- a/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/WidgetRegistry.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import hivens.widget.model.SlotId
 import hivens.widget.model.WidgetInstance
 import hivens.widget.model.WidgetKind
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonObject
 
 interface WidgetDescriptor {
     val kind: WidgetKind
@@ -20,6 +22,20 @@ interface WidgetDescriptor {
     // structural keys in WidgetInstance.children) to validate moves.
     val slots: List<SlotId>
         get() = emptyList()
+
+    // Typed-props support, populated by the KSP processor from
+    // @Widget(propsClass = ...). A null serializer means the widget is
+    // propless (the default) -- the editor shows no prop affordance.
+    // When non-null, the editor builds its form from
+    // propsSerializer.descriptor (element names / kinds / @SerialInfo
+    // annotations) and reads current values from defaultPropsJson
+    // overlaid with the instance's stored props. Widgets read typed
+    // values via WidgetInstance.rememberProps.
+    val propsSerializer: KSerializer<*>?
+        get() = null
+
+    val defaultPropsJson: JsonObject
+        get() = JsonObject(emptyMap())
 
     @Composable
     fun Render(instance: WidgetInstance)

--- a/widget-api/src/test/kotlin/hivens/widget/api/WidgetPropsTest.kt
+++ b/widget-api/src/test/kotlin/hivens/widget/api/WidgetPropsTest.kt
@@ -1,0 +1,47 @@
+package hivens.widget.api
+
+import hivens.widget.model.WidgetInstance
+import hivens.widget.model.WidgetKind
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Serializable
+private data class SampleProps(
+    val flag: Boolean = true,
+    val count: Int = 7,
+    val label: String = "hi",
+)
+
+class WidgetPropsTest {
+
+    private fun inst(props: JsonObject) = WidgetInstance(WidgetKind("x"), "i", props)
+
+    @Test
+    fun `empty props decodes to all defaults`() {
+        assertEquals(SampleProps(), inst(JsonObject(emptyMap())).decodeProps<SampleProps>())
+    }
+
+    @Test
+    fun `partial props overrides only the set keys`() {
+        val p = inst(buildJsonObject { put("count", 42) }).decodeProps<SampleProps>()
+        assertEquals(SampleProps(count = 42), p)
+    }
+
+    @Test
+    fun `unknown keys are ignored`() {
+        val p = inst(buildJsonObject { put("count", 3); put("ghost", "x") }).decodeProps<SampleProps>()
+        assertEquals(SampleProps(count = 3), p)
+    }
+
+    @Test
+    fun `malformed value falls back to defaults`() {
+        // count is an Int field; a non-numeric string fails the decode,
+        // and the accessor must fall back to defaults rather than throw.
+        val p = inst(buildJsonObject { put("count", "not-a-number") }).decodeProps<SampleProps>()
+        assertEquals(SampleProps(), p)
+    }
+}

--- a/widget-model/build.gradle.kts
+++ b/widget-model/build.gradle.kts
@@ -8,7 +8,11 @@ plugins {
 // TUI surfaces that never touch Compose) depend on this module;
 // Compose-tainted bits live in :widget-api one layer up.
 dependencies {
-    implementation(libs.kotlinx.serialization.json)
+    // api (not implementation): WidgetInstance.props is a JsonObject and
+    // WidgetDescriptor in :widget-api now exposes KSerializer +
+    // JsonObject for typed props, so the serialization types must be on
+    // the compile classpath of modules that depend on :widget-model.
+    api(libs.kotlinx.serialization.json)
 
     testImplementation(kotlin("test"))
 }

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -92,6 +92,24 @@ fun LayoutGraph.moveWidget(
     return removeWidget(from, instanceId).insertWidget(to, widget, toIndex)
 }
 
+// Replaces the props JsonObject on a single widget addressed by
+// (path, instanceId). No-op if the slot or the instance is gone --
+// editor prop edits race with disk reloads, same contract as the other
+// transforms.
+fun LayoutGraph.updateWidgetProps(
+    path: SlotPath,
+    instanceId: String,
+    props: JsonObject,
+): LayoutGraph =
+    mutate(path) { content ->
+        if (content.widgets.none { it.instanceId == instanceId }) content
+        else content.copy(
+            widgets = content.widgets.map {
+                if (it.instanceId == instanceId) it.copy(props = props) else it
+            },
+        )
+    }
+
 // Walks the path and returns the SlotContent at the leaf, or null if
 // any intermediate surface / slot / parent widget is missing.
 fun LayoutGraph.traverse(path: SlotPath): SlotContent? {

--- a/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/Widget.kt
@@ -1,5 +1,7 @@
 package hivens.widget.model
 
+import kotlin.reflect.KClass
+
 // Marker annotation scanned by the KSP processor in :widget-processor.
 // Apply to top-level @Composable functions with signature
 //   fun Name(instance: WidgetInstance)
@@ -27,4 +29,13 @@ annotation class Widget(
     // the editor's drop hit-test and by the KSP processor to validate
     // that container.children references only declared slots.
     val slots: Array<String> = [],
+    // The @Serializable data class holding this widget's tunable props,
+    // or Unit::class (the default) for a propless widget. Every field
+    // must have a default so the KSP-generated registry can construct
+    // an instance for the default-props baseline. The processor checks
+    // the class carries @kotlinx.serialization.Serializable and emits
+    // its serializer into the descriptor; the widget body reads typed
+    // values via instance.rememberProps<T>(), the editor builds its
+    // form from the serializer's descriptor.
+    val propsClass: KClass<*> = Unit::class,
 )

--- a/widget-model/src/main/kotlin/hivens/widget/model/WidgetProps.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/WidgetProps.kt
@@ -1,0 +1,47 @@
+package hivens.widget.model
+
+import kotlinx.serialization.SerialInfo
+
+// Field-level metadata for widget prop classes. These are @SerialInfo
+// annotations: the serialization compiler plugin copies them into the
+// SerialDescriptor, so the prop editor reads them off
+// descriptor.getElementAnnotations(i) at runtime with no reflection.
+//
+// A field's serial kind (Boolean/Int/Float/String/enum) picks the base
+// editor control; these annotations refine it. They live in widget-model
+// so prop classes stay Compose-free and serializable.
+//
+// Retention is left at the Kotlin default (RUNTIME) on purpose --
+// @SerialInfo annotations must be RUNTIME to survive into the descriptor.
+
+// Human-facing label shown in the editor. Without it the editor falls
+// back to the serial element name.
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropLabel(val value: String)
+
+// Numeric bounds for an Int/Float field -- renders a slider instead of a
+// free-entry field. step == 0.0 means continuous (the control rounds
+// Int fields to whole steps itself).
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropRange(val min: Double, val max: Double, val step: Double = 0.0)
+
+// Marks a String field as a hex colour ("#RRGGBB" / "#AARRGGBB"; ""
+// means "fall back to the theme"). Renders the swatch + hex control.
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropColor
+
+// Fixed option set for a String field -- renders a dropdown. (enum
+// fields already render a dropdown from their serial kind; this is for
+// String-typed choices that are not a Kotlin enum.)
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropChoice(val options: Array<String>)
+
+// Excludes a field from the editor form. Still serialized and readable
+// by the widget -- for computed or internal props the user must not tune.
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropHidden

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -1,6 +1,8 @@
 package hivens.widget.model
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -57,6 +59,29 @@ class LayoutGraphMutationsTest {
     fun `removeWidget of unknown id is identity`() {
         val graph = seed(w1)
         assertSame(graph, graph.removeWidget(rootPath, "ghost"))
+    }
+
+    @Test
+    fun `updateWidgetProps replaces props on the matching widget only`() {
+        val props = buildJsonObject { put("title", "Hi") }
+        val out = seed(w1, w2).updateWidgetProps(rootPath, "i2", props)
+        assertEquals(props, out.mainWidgets().first { it.instanceId == "i2" }.props)
+        assertEquals(JsonObject(emptyMap()), out.mainWidgets().first { it.instanceId == "i1" }.props)
+    }
+
+    @Test
+    fun `updateWidgetProps on unknown instance is identity`() {
+        val graph = seed(w1)
+        assertSame(graph, graph.updateWidgetProps(rootPath, "ghost", buildJsonObject { put("x", 1) }))
+    }
+
+    @Test
+    fun `updateWidgetProps on unknown slot is identity`() {
+        val graph = seed(w1)
+        assertSame(
+            graph,
+            graph.updateWidgetProps(SlotPath(home, SlotId("nope")), "i1", buildJsonObject { put("x", 1) }),
+        )
     }
 
     @Test

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetRegistryProcessor.kt
@@ -43,6 +43,7 @@ class WidgetRegistryProcessor(
                 displayName = extracted.displayName.ifBlank { funcName },
                 removable = extracted.removable,
                 slots = extracted.slots,
+                propsClassFqn = extracted.propsClassFqn,
                 functionFqn = if (packageName.isEmpty()) funcName else "$packageName.$funcName",
                 containingFile = symbol.containingFile,
             )
@@ -89,8 +90,23 @@ class WidgetRegistryProcessor(
         appendLine("import hivens.widget.model.SlotId")
         appendLine("import hivens.widget.model.WidgetInstance")
         appendLine("import hivens.widget.model.WidgetKind")
+        // Serialization imports + the shared Json only when at least one
+        // widget declares props -- otherwise they would be unused and
+        // warn on a props-free build.
+        val hasProps = widgets.any { it.propsClassFqn != null }
+        if (hasProps) {
+            appendLine("import kotlinx.serialization.KSerializer")
+            appendLine("import kotlinx.serialization.json.Json")
+            appendLine("import kotlinx.serialization.json.JsonObject")
+            appendLine("import kotlinx.serialization.json.jsonObject")
+        }
         appendLine()
         appendLine("object $GENERATED_FILE_NAME : WidgetRegistry {")
+        if (hasProps) {
+            // encodeDefaults so the default-props baseline carries every
+            // field; the editor overlays the instance's stored overrides.
+            appendLine("    private val propsJson: Json = Json { encodeDefaults = true; ignoreUnknownKeys = true }")
+        }
         appendLine("    private val map: Map<WidgetKind, WidgetDescriptor> = buildMap {")
         widgets.forEach { entry ->
             val kindLiteral = "WidgetKind(\"${entry.id.kotlinEscape()}\")"
@@ -99,6 +115,12 @@ class WidgetRegistryProcessor(
             appendLine("            override val displayName: String = \"${entry.displayName.kotlinEscape()}\"")
             appendLine("            override val removable: Boolean = ${entry.removable}")
             appendLine("            override val slots: List<SlotId> = ${entry.slots.toSlotIdListLiteral()}")
+            if (entry.propsClassFqn != null) {
+                val fqn = entry.propsClassFqn
+                appendLine("            override val propsSerializer: KSerializer<*>? = $fqn.serializer()")
+                appendLine("            override val defaultPropsJson: JsonObject =")
+                appendLine("                propsJson.encodeToJsonElement($fqn.serializer(), $fqn()).jsonObject")
+            }
             appendLine("            @Composable override fun Render(instance: WidgetInstance) {")
             appendLine("                ${entry.functionFqn}(instance)")
             appendLine("            }")
@@ -124,6 +146,7 @@ private data class WidgetEntry(
     val displayName: String,
     val removable: Boolean,
     val slots: List<String>,
+    val propsClassFqn: String?,
     val functionFqn: String,
     val containingFile: com.google.devtools.ksp.symbol.KSFile?,
 )

--- a/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
+++ b/widget-processor/src/main/kotlin/hivens/widget/processor/WidgetValidator.kt
@@ -1,7 +1,9 @@
 package hivens.widget.processor
 
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Modifier
 
 // Shared rule-set for what a @Widget composable must look like. The KSP
@@ -16,12 +18,17 @@ internal object WidgetValidator {
     private const val COMPOSABLE_ANNOTATION_FQN = "androidx.compose.runtime.Composable"
     private const val WIDGET_INSTANCE_FQN = "hivens.widget.model.WidgetInstance"
 
+    private const val SERIALIZABLE_ANNOTATION_FQN = "kotlinx.serialization.Serializable"
+
     // Annotation args extracted from a valid @Widget declaration.
     data class Extracted(
         val id: String,
         val displayName: String,
         val removable: Boolean,
         val slots: List<String>,
+        // FQN of the @Serializable props class, or null for Unit::class
+        // (a propless widget).
+        val propsClassFqn: String?,
     )
 
     // KSP entry point. Returns the extracted annotation args, or null
@@ -112,11 +119,44 @@ internal object WidgetValidator {
             sanitized.add(raw)
         }
 
+        // propsClass: a KClass<*> annotation arg arrives as a KSType.
+        // Unit::class (the default) means "no props". Anything else must
+        // be @Serializable with an all-default primary constructor, so
+        // the generated registry can build the zero-arg default-props
+        // baseline and the editor can read its serializer descriptor.
+        val propsType = args["propsClass"] as? KSType
+        val propsDecl = propsType?.declaration
+        val propsClassFqn = propsDecl?.qualifiedName?.asString()?.takeIf { it != "kotlin.Unit" }
+        if (propsClassFqn != null) {
+            val isSerializable = propsDecl!!.annotations.any {
+                it.shortName.asString() == "Serializable" &&
+                    it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+                        SERIALIZABLE_ANNOTATION_FQN
+            }
+            if (!isSerializable) {
+                env.logger.error(
+                    "@Widget propsClass '$propsClassFqn' must be annotated @$SERIALIZABLE_ANNOTATION_FQN",
+                    symbol,
+                )
+                return null
+            }
+            val primaryCtor = (propsDecl as? KSClassDeclaration)?.primaryConstructor
+            if (primaryCtor != null && primaryCtor.parameters.any { !it.hasDefault }) {
+                env.logger.error(
+                    "@Widget propsClass '$propsClassFqn' must give every property a default " +
+                        "-- the registry needs a zero-arg baseline",
+                    symbol,
+                )
+                return null
+            }
+        }
+
         return Extracted(
             id = id,
             displayName = displayName,
             removable = removable,
             slots = sanitized,
+            propsClassFqn = propsClassFqn,
         )
     }
 }


### PR DESCRIPTION
## Phase 5 -- typed per-widget props + prop editor

Per-widget props are declared as `@Serializable` classes via
`@Widget(propsClass = FooProps::class)`. KSP emits the serializer + a
default-props baseline into the descriptor; widgets read typed values
through `instance.rememberProps<FooProps>()` (memoized, Compose-stable).
`@SerialInfo` field annotations (`PropLabel` / `PropRange` / `PropColor` /
`PropChoice` / `PropHidden`) drive the editor form. Storage stays in the
existing `WidgetInstance.props` JsonObject -- the typed-props end-state
the `LayoutGraph` comment foreshadowed.

### Editor
A "tune" gear on each prop-bearing widget opens `WidgetPropPanel`, which
builds a form from the serializer descriptor (switch / slider / hex /
dropdown / text) and writes back via `EditModeController.updateProps` ->
`LayoutGraph.updateWidgetProps`. Reset restores declared defaults. The
palette hides while the prop panel is open so the two right-edge panels
do not overlap.

### Widgets (17)
Clock, Spacer, Progress, Welcome, Launch, Music, Pack tiles, Quick
launch; the five About sections; Library header/body; ServerDetails
banner; Profile skin. Settings-mirror, structural-nav and pure-data
widgets stay propless by design (build-pinned in the consistency test).

### Tests
`decodeProps` (empty / partial / unknown / malformed), `updateWidgetProps`
transform, `SerialDescriptor` introspection (the `@SerialInfo` -> form
contract), and a registry pin of the 17 prop-exposing widgets.

## Also in this branch
- `fix(tray)`: bump libtray to `e86f497` (Windows upside-down tray-icon
  fix). Independent of Phase 5 -- its own commit.

## Test plan
- [x] `:client-ui:compileKotlinDesktop` green (with the new libtray)
- [x] widget-model / widget-api / prop + consistency / EditModeController tests green
- [ ] live: gear -> prop panel -> change a prop -> widget updates + persists across restart