### PR TITLE
feat(widgets): Phase G4-G5 -- weight drag-dividers + Grid

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/EditorSurfaceHost.kt
@@ -120,11 +120,13 @@ import hivens.ui.widgets.themepicker.STUB_THEME_PICKER
 import hivens.widget.api.EmptySlotDecorator
 import hivens.widget.api.LocalEmptySlotDecorator
 import hivens.widget.api.LocalSlotControlDecorator
+import hivens.widget.api.LocalSlotDividerDecorator
 import hivens.widget.api.LocalSlotPath
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import hivens.widget.api.LocalWidgetDecorator
 import hivens.widget.api.SlotControlDecorator
+import hivens.widget.api.SlotDividerDecorator
 import hivens.widget.api.WidgetDecorator
 import hivens.widget.model.SlotOrientation
 import hivens.widget.model.SlotPath
@@ -336,6 +338,28 @@ fun EditorSurfaceHost(
         }
     }
 
+    // Slot divider decorator: a draggable handle between adjacent widgets
+    // in a Row/Column slot on the selected surface, redistributing their
+    // weight. Identity off / previewing / foreign surface.
+    val slotDividerDecorator: SlotDividerDecorator = remember(state, previewing) {
+        if (state is EditModeState.On && !previewing) {
+            val selected = state.surface
+            { path, content, leftIndex ->
+                if (path.surface == selected) {
+                    SlotDivider(
+                        path       = path,
+                        content    = content,
+                        leftIndex  = leftIndex,
+                        controller = controller,
+                        registry   = registry,
+                    )
+                }
+            }
+        } else {
+            { _, _, _ -> }
+        }
+    }
+
     CompositionLocalProvider(
         LocalEditMode           provides state,
         LocalDragController     provides dragController,
@@ -343,6 +367,7 @@ fun EditorSurfaceHost(
         LocalWidgetDecorator    provides chromeDecorator,
         LocalEmptySlotDecorator provides emptyDecorator,
         LocalSlotControlDecorator provides slotControlDecorator,
+        LocalSlotDividerDecorator provides slotDividerDecorator,
         // Stub surface contexts. Surface composables that mount under
         // content() override with the real values; widgets dropped on
         // a foreign surface fall through to the stubs and render

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotControl.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotControl.kt
@@ -41,9 +41,7 @@ internal fun SlotControl(path: SlotPath, content: SlotContent, controller: EditM
         OrientChip("Ряд", content.orientation == SlotOrientation.Row) {
             controller.setSlotOrientation(path, SlotOrientation.Row)
         }
-        // Grid is selectable only once it renders as a real grid (Phase G5).
-        // In G1-G3 it would render as a Column, so the chip stays disabled.
-        OrientChip("Сетка", content.orientation == SlotOrientation.Grid, enabled = false) {
+        OrientChip("Сетка", content.orientation == SlotOrientation.Grid) {
             controller.setSlotOrientation(path, SlotOrientation.Grid)
         }
         if (content.orientation == SlotOrientation.Grid) {
@@ -60,26 +58,16 @@ internal fun SlotControl(path: SlotPath, content: SlotContent, controller: EditM
 }
 
 @Composable
-private fun OrientChip(label: String, active: Boolean, enabled: Boolean = true, onClick: () -> Unit) {
+private fun OrientChip(label: String, active: Boolean, onClick: () -> Unit) {
     Text(
         text       = label,
         style      = MaterialTheme.typography.labelSmall,
-        // A disabled-but-active chip still reads as the current orientation
-        // (dimmed primary), rather than collapsing to plain "greyed out".
-        color      = when {
-            active && !enabled -> CelestiaTheme.colors.primary.copy(alpha = 0.5f)
-            !enabled           -> CelestiaTheme.colors.textSecondary.copy(alpha = 0.4f)
-            active             -> CelestiaTheme.colors.primary
-            else               -> CelestiaTheme.colors.textSecondary
-        },
+        color      = if (active) CelestiaTheme.colors.primary else CelestiaTheme.colors.textSecondary,
         fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
         modifier   = Modifier
             .clip(RoundedCornerShape(6.dp))
-            .background(
-                if (active) CelestiaTheme.colors.primary.copy(alpha = if (enabled) 0.22f else 0.12f)
-                else Color.Transparent,
-            )
-            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier)
+            .background(if (active) CelestiaTheme.colors.primary.copy(alpha = 0.22f) else Color.Transparent)
+            .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 3.dp),
     )
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotDivider.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotDivider.kt
@@ -76,8 +76,7 @@ internal fun SlotDivider(
                 change.consume()
                 if (sumPx > 0f) {
                     accum += if (isRow) dragAmount.x else dragAmount.y
-                    val upper   = (sumPx - minPx).coerceAtLeast(minPx)
-                    val newLeft = (startLeftPx + accum).coerceIn(minPx.coerceAtMost(upper), upper)
+                    val newLeft = dividerLeftWeight(startLeftPx, sumPx, accum, minPx)
                     controller.setWidgetWeight(path, left.instanceId, newLeft)
                     controller.setWidgetWeight(path, right.instanceId, sumPx - newLeft)
                 }
@@ -101,4 +100,13 @@ internal fun SlotDivider(
             Box(Modifier.fillMaxWidth().height(2.dp).background(bar))
         }
     }
+}
+
+// New left-neighbor weight (px units) for a divider drag: the start px plus
+// the accumulated delta, clamped so neither side drops below minPx. The
+// right neighbor takes sumPx - this. Pure so the resize math is testable
+// without driving a real pointer gesture.
+internal fun dividerLeftWeight(startLeftPx: Float, sumPx: Float, accum: Float, minPx: Float): Float {
+    val upper = (sumPx - minPx).coerceAtLeast(minPx)
+    return (startLeftPx + accum).coerceIn(minPx.coerceAtMost(upper), upper)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotDivider.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotDivider.kt
@@ -1,0 +1,104 @@
+package hivens.ui.editor
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import hivens.ui.editor.dnd.DropTargetRegistry
+import hivens.ui.theme.CelestiaTheme
+import hivens.widget.model.SlotContent
+import hivens.widget.model.SlotOrientation
+import hivens.widget.model.SlotPath
+import java.awt.Cursor
+
+// Phase G4 drag-divider. Sits between two adjacent widgets in a Row/Column
+// slot in edit mode; dragging redistributes weight between the two
+// neighbors while preserving their combined main-axis size.
+//
+// The math captures both neighbors' px at drag start as a FIXED reference,
+// then maps the accumulated drag delta onto that reference -- so the live
+// setWidgetWeight writes (which change the layout mid-drag) never feed back
+// into the calculation and run away. Weights become px-magnitude values and
+// stay mutually consistent as the user drags the slot's other dividers.
+//
+// Grid slots size by column count, not dividers -> no-op there.
+@Composable
+internal fun SlotDivider(
+    path: SlotPath,
+    content: SlotContent,
+    leftIndex: Int,
+    controller: EditModeController,
+    registry: DropTargetRegistry,
+) {
+    if (content.orientation == SlotOrientation.Grid) return
+    val widgets = content.widgets
+    if (leftIndex < 0 || leftIndex >= widgets.lastIndex) return
+    val left  = widgets[leftIndex]
+    val right = widgets[leftIndex + 1]
+    val isRow = content.orientation == SlotOrientation.Row
+
+    val minPx = with(LocalDensity.current) { 40.dp.toPx() }
+    var startLeftPx by remember(left.instanceId, right.instanceId) { mutableStateOf(0f) }
+    var sumPx       by remember(left.instanceId, right.instanceId) { mutableStateOf(0f) }
+    var accum       by remember(left.instanceId, right.instanceId) { mutableStateOf(0f) }
+
+    val cursor = remember(isRow) {
+        PointerIcon(Cursor(if (isRow) Cursor.E_RESIZE_CURSOR else Cursor.N_RESIZE_CURSOR))
+    }
+
+    val drag = Modifier.pointerInput(left.instanceId, right.instanceId, isRow) {
+        detectDragGestures(
+            onDragStart = {
+                val lr = registry.widgetRect(path, left.instanceId)
+                val rr = registry.widgetRect(path, right.instanceId)
+                val lLen = if (isRow) (lr?.width ?: 0f) else (lr?.height ?: 0f)
+                val rLen = if (isRow) (rr?.width ?: 0f) else (rr?.height ?: 0f)
+                startLeftPx = lLen
+                sumPx       = lLen + rLen
+                accum       = 0f
+            },
+            onDrag = { change, dragAmount ->
+                change.consume()
+                if (sumPx > 0f) {
+                    accum += if (isRow) dragAmount.x else dragAmount.y
+                    val upper   = (sumPx - minPx).coerceAtLeast(minPx)
+                    val newLeft = (startLeftPx + accum).coerceIn(minPx.coerceAtMost(upper), upper)
+                    controller.setWidgetWeight(path, left.instanceId, newLeft)
+                    controller.setWidgetWeight(path, right.instanceId, sumPx - newLeft)
+                }
+            },
+        )
+    }
+
+    val bar = CelestiaTheme.colors.primary.copy(alpha = 0.55f)
+    if (isRow) {
+        Box(
+            modifier         = Modifier.fillMaxHeight().width(10.dp).pointerHoverIcon(cursor).then(drag),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(Modifier.fillMaxHeight().width(2.dp).background(bar))
+        }
+    } else {
+        Box(
+            modifier         = Modifier.fillMaxWidth().height(10.dp).pointerHoverIcon(cursor).then(drag),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(Modifier.fillMaxWidth().height(2.dp).background(bar))
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -118,6 +118,11 @@ class DropTargetRegistry {
         widgets[path]?.remove(instanceId)
     }
 
+    // Window-coord rect of one registered widget. Used by the Phase G
+    // slot dividers to read the two neighbors' main-axis px at drag start.
+    fun widgetRect(path: SlotPath, instanceId: String): Rect? =
+        widgets[path]?.get(instanceId)?.rect
+
     // Two passes:
     //   1) exact rect hit across all registered sources (widget rects +
     //      empty-slot placeholder bounds), innermost (smallest area)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/dnd/DragAndDrop.kt
@@ -192,6 +192,16 @@ class DropTargetRegistry {
     ): Int {
         val items = widgets[path]?.values?.sortedBy { it.index } ?: return 0
         if (items.isEmpty()) return 0
+        if (orientation == SlotOrientation.Grid) {
+            // Row-major: insert before the first cell the pointer sits above
+            // (an earlier row) or, within the same row band, left of center.
+            items.forEach { wb ->
+                val r = wb.rect
+                if (pointInWindow.y < r.top) return wb.index
+                if (pointInWindow.y <= r.bottom && pointInWindow.x < r.left + r.width / 2f) return wb.index
+            }
+            return items.size
+        }
         val horizontal = orientation == SlotOrientation.Row
         items.forEach { wb ->
             val mid = if (horizontal) wb.rect.left + wb.rect.width / 2f

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/SlotDividerMathTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/SlotDividerMathTest.kt
@@ -1,0 +1,32 @@
+package hivens.ui.editor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SlotDividerMathTest {
+
+    @Test
+    fun `drag toward the right grows the left widget`() {
+        // pair 200px, left starts at 100, drag +30 -> left 130
+        assertEquals(130f, dividerLeftWeight(startLeftPx = 100f, sumPx = 200f, accum = 30f, minPx = 40f))
+    }
+
+    @Test
+    fun `drag toward the left shrinks the left widget`() {
+        assertEquals(70f, dividerLeftWeight(startLeftPx = 100f, sumPx = 200f, accum = -30f, minPx = 40f))
+    }
+
+    @Test
+    fun `clamps so neither side drops below min`() {
+        // sum 200, min 40 -> left clamped to [40, 160]
+        assertEquals(160f, dividerLeftWeight(100f, 200f, 999f, 40f))
+        assertEquals(40f, dividerLeftWeight(100f, 200f, -999f, 40f))
+    }
+
+    @Test
+    fun `degenerate pair smaller than two mins pins to min without crashing`() {
+        // sum 60, min 40 -> upper = max(20,40) = 40, lower = min(40,40) = 40
+        assertEquals(40f, dividerLeftWeight(30f, 60f, 10f, 40f))
+        assertEquals(40f, dividerLeftWeight(30f, 60f, -10f, 40f))
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/editor/dnd/DropTargetRegistryTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import hivens.widget.model.NestedSegment
 import hivens.widget.model.SlotId
+import hivens.widget.model.SlotOrientation
 import hivens.widget.model.SlotPath
 import hivens.widget.model.SurfaceId
 import kotlin.test.Test
@@ -35,6 +36,38 @@ class DropTargetRegistryTest {
         assertEquals(1, r.insertionIndexInSlot(slot, Offset(50f, 70f)))
         // Below all -> append at 3
         assertEquals(3, r.insertionIndexInSlot(slot, Offset(50f, 200f)))
+    }
+
+    @Test
+    fun `insertionIndexInSlot uses the X axis for a Row slot`() {
+        val r = DropTargetRegistry()
+        // three cells side by side, 100 wide each
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f, height = 80f, left = 0f,   width = 100f)) // x [0,100], mid 50
+        r.registerWidget(slot, "b", index = 1, rect = rect(top = 0f, height = 80f, left = 110f, width = 100f)) // x [110,210], mid 160
+        r.registerWidget(slot, "c", index = 2, rect = rect(top = 0f, height = 80f, left = 220f, width = 100f)) // x [220,320]
+
+        val row = SlotOrientation.Row
+        assertEquals(0, r.insertionIndexInSlot(slot, Offset(10f, 40f), row))   // left of a's mid
+        assertEquals(1, r.insertionIndexInSlot(slot, Offset(120f, 40f), row))  // past a's mid, before b's mid
+        assertEquals(3, r.insertionIndexInSlot(slot, Offset(400f, 40f), row))  // past all -> append
+        assertEquals(1, r.insertionIndexInSlot(slot, Offset(120f, 999f), row)) // Y ignored for Row
+    }
+
+    @Test
+    fun `insertionIndexInSlot is row-major for a Grid slot`() {
+        val r = DropTargetRegistry()
+        // 2x2 grid: row 0 = [a,b] at y[0,80]; row 1 = [c,d] at y[100,180]
+        r.registerWidget(slot, "a", index = 0, rect = rect(top = 0f,   height = 80f, left = 0f,   width = 100f)) // r0c0, mid x50
+        r.registerWidget(slot, "b", index = 1, rect = rect(top = 0f,   height = 80f, left = 110f, width = 100f)) // r0c1, mid x160
+        r.registerWidget(slot, "c", index = 2, rect = rect(top = 100f, height = 80f, left = 0f,   width = 100f)) // r1c0
+        r.registerWidget(slot, "d", index = 3, rect = rect(top = 100f, height = 80f, left = 110f, width = 100f)) // r1c1
+
+        val grid = SlotOrientation.Grid
+        assertEquals(0, r.insertionIndexInSlot(slot, Offset(50f, -10f), grid)) // above everything
+        assertEquals(0, r.insertionIndexInSlot(slot, Offset(10f, 40f), grid))  // row 0, left of a's center
+        assertEquals(1, r.insertionIndexInSlot(slot, Offset(120f, 40f), grid)) // row 0, between a and b centers
+        assertEquals(2, r.insertionIndexInSlot(slot, Offset(10f, 140f), grid)) // row 1, left of c's center
+        assertEquals(4, r.insertionIndexInSlot(slot, Offset(400f, 400f), grid))// past all -> append
     }
 
     @Test

--- a/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/Locals.kt
@@ -61,6 +61,15 @@ typealias SlotControlDecorator = @Composable (path: SlotPath, content: SlotConte
 val LocalSlotControlDecorator: ProvidableCompositionLocal<SlotControlDecorator> =
     staticCompositionLocalOf { { _, _ -> } }
 
+// Phase G: rendered by SlotRenderer between two adjacent widgets in a
+// Row/Column slot in edit mode. Default = nothing. The editor swaps in a
+// draggable divider that redistributes weight between the widget at
+// `leftIndex` and the one after it. Kept editor-agnostic here.
+typealias SlotDividerDecorator = @Composable (path: SlotPath, content: SlotContent, leftIndex: Int) -> Unit
+
+val LocalSlotDividerDecorator: ProvidableCompositionLocal<SlotDividerDecorator> =
+    staticCompositionLocalOf { { _, _, _ -> } }
+
 // Current path the surrounding SlotRenderer is rendering. Container
 // widgets read this implicitly through the nested SlotRenderer
 // overload; chrome / empty-placeholder use it to register drop-target

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -106,7 +107,29 @@ private fun RenderSlotContent(path: SlotPath, modifier: Modifier, spacing: Dp) {
                 if (index < content.widgets.lastIndex) slotDivider(path, content, index)
             }
         }
-        // Column + Grid (Grid renders as a Column until G5).
+        SlotOrientation.Grid -> Column(modifier, verticalArrangement = Arrangement.spacedBy(spacing)) {
+            slotControl(path, content)
+            // Non-lazy chunked grid: a Column of equal-width Rows. Reuses the
+            // decorator path so chrome + DnD stay consistent; cells are uniform
+            // (per-widget weight is ignored in Grid) and the last row is padded
+            // with weighted spacers so the columns stay aligned. No dividers.
+            val cols = content.gridColumns.coerceAtLeast(1)
+            content.widgets.chunked(cols).forEachIndexed { rowIndex, rowWidgets ->
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    rowWidgets.forEachIndexed { colIndex, instance ->
+                        val index = rowIndex * cols + colIndex
+                        val descriptor = registry[instance.kind]
+                        Box(Modifier.weight(1f)) {
+                            if (descriptor != null) {
+                                decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
+                            }
+                        }
+                    }
+                    repeat(cols - rowWidgets.size) { Spacer(Modifier.weight(1f)) }
+                }
+            }
+        }
+        // Column.
         else -> Column(modifier, verticalArrangement = Arrangement.spacedBy(spacing)) {
             slotControl(path, content)
             content.widgets.forEachIndexed { index, instance ->

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -76,6 +76,7 @@ private fun RenderSlotContent(path: SlotPath, modifier: Modifier, spacing: Dp) {
     val decorator = LocalWidgetDecorator.current
     val emptyDecorator = LocalEmptySlotDecorator.current
     val slotControl = LocalSlotControlDecorator.current
+    val slotDivider = LocalSlotDividerDecorator.current
 
     val content: SlotContent = graph.traverse(path) ?: SlotContent()
     val address = path.leafAddress
@@ -92,28 +93,34 @@ private fun RenderSlotContent(path: SlotPath, modifier: Modifier, spacing: Dp) {
         SlotOrientation.Row -> Row(modifier, horizontalArrangement = Arrangement.spacedBy(spacing)) {
             slotControl(path, content)
             content.widgets.forEachIndexed { index, instance ->
-                val descriptor = registry[instance.kind] ?: return@forEachIndexed
-                if (instance.weight > 0f) {
-                    Box(Modifier.weight(instance.weight)) {
+                val descriptor = registry[instance.kind]
+                if (descriptor != null) {
+                    if (instance.weight > 0f) {
+                        Box(Modifier.weight(instance.weight)) {
+                            decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
+                        }
+                    } else {
                         decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
                     }
-                } else {
-                    decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
                 }
+                if (index < content.widgets.lastIndex) slotDivider(path, content, index)
             }
         }
         // Column + Grid (Grid renders as a Column until G5).
         else -> Column(modifier, verticalArrangement = Arrangement.spacedBy(spacing)) {
             slotControl(path, content)
             content.widgets.forEachIndexed { index, instance ->
-                val descriptor = registry[instance.kind] ?: return@forEachIndexed
-                if (instance.weight > 0f) {
-                    Box(Modifier.weight(instance.weight)) {
+                val descriptor = registry[instance.kind]
+                if (descriptor != null) {
+                    if (instance.weight > 0f) {
+                        Box(Modifier.weight(instance.weight)) {
+                            decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
+                        }
+                    } else {
                         decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
                     }
-                } else {
-                    decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
                 }
+                if (index < content.widgets.lastIndex) slotDivider(path, content, index)
             }
         }
     }


### PR DESCRIPTION
## Summary

Phase G4-G5, the follow-up to #276: weight resize via drag-dividers, plus the
real Grid orientation render.

- G4 -- drag-dividers. A draggable divider between adjacent widgets in a
  Row/Column slot (edit mode) redistributes their `weight`. New
  `LocalSlotDividerDecorator` (widget-api, no-op default) invoked by
  `SlotRenderer` between widgets; the divider captures the pair's main-axis px
  at drag start as a fixed reference and maps the accumulated delta onto it,
  preserving their px-sum so the live weight writes never feed back into the
  math. The registry gains `widgetRect()` for reading the neighbors' bounds.
- G5 -- Grid. Grid renders as a non-lazy chunked grid: a Column of equal-width
  Rows of `gridColumns` cells (last row padded with weighted spacers; uniform
  cells, no dividers). The G3 column-count stepper drives it, and the Grid
  orientation chip is re-enabled (it was a WIP-disabled stub while #276
  rendered Grid as a Column). `insertionIndexInSlot` gains a row-major Grid
  hit-test.

Builds on #276 (merged).

## Test plan

- [x] `./gradlew :widget-model:test :widget-api:test :client-ui:desktopTest` -- green
- [x] Unit: orientation-aware hit-test (Row X-axis, Grid row-major) + divider resize math (`dividerLeftWeight`)
- [x] Drag a divider between two Row widgets -> weights shift live and persist
- [x] Switch a slot to Grid, change the column count -> grid reflows
- [x] Drop a widget into a Grid slot -> lands row-major; switch back to Row/Column intact