### PR TITLE
fix(widgets): center the left-rail bottom icons

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailConsoleToggle.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailConsoleToggle.kt
@@ -1,11 +1,14 @@
 package hivens.ui.widgets.shell
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import hivens.ui.theme.CelestiaTheme
@@ -18,21 +21,25 @@ import org.koin.compose.koinInject
 @Composable
 fun LeftRailConsoleToggle(instance: WidgetInstance) {
     val gameConsole: GameConsoleService = koinInject()
-    IconButton(
-        onClick  = {
-            if (gameConsole.shouldShowConsole) gameConsole.hide()
-            else gameConsole.show()
-        },
-        modifier = Modifier.size(48.dp),
-    ) {
-        Icon(
-            imageVector        = Icons.Default.Build,
-            contentDescription = null,
-            tint               = if (gameConsole.shouldShowConsole)
-                CelestiaTheme.colors.primary
-            else
-                CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
-            modifier           = Modifier.size(22.dp),
-        )
+    // The slot's Column is start-aligned (Phase G), so a fixed-width button
+    // packs left; fill + center to sit under the nav items like the rest.
+    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        IconButton(
+            onClick  = {
+                if (gameConsole.shouldShowConsole) gameConsole.hide()
+                else gameConsole.show()
+            },
+            modifier = Modifier.size(48.dp),
+        ) {
+            Icon(
+                imageVector        = Icons.Default.Build,
+                contentDescription = null,
+                tint               = if (gameConsole.shouldShowConsole)
+                    CelestiaTheme.colors.primary
+                else
+                    CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+                modifier           = Modifier.size(22.dp),
+            )
+        }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailLogout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/shell/LeftRailLogout.kt
@@ -1,11 +1,14 @@
 package hivens.ui.widgets.shell
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import hivens.ui.theme.CelestiaTheme
@@ -21,12 +24,15 @@ fun LeftRailLogout(instance: WidgetInstance) {
     val ctx = LocalLeftRailContext.current
     if (!ctx.isAuthenticated) return
 
-    IconButton(onClick = ctx.onLogout, modifier = Modifier.size(48.dp)) {
-        Icon(
-            imageVector        = Icons.AutoMirrored.Filled.ExitToApp,
-            contentDescription = null,
-            tint               = CelestiaTheme.colors.error.copy(alpha = 0.75f),
-            modifier           = Modifier.size(22.dp),
-        )
+    // Center in the rail (the slot's Column is start-aligned post-Phase G).
+    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        IconButton(onClick = ctx.onLogout, modifier = Modifier.size(48.dp)) {
+            Icon(
+                imageVector        = Icons.AutoMirrored.Filled.ExitToApp,
+                contentDescription = null,
+                tint               = CelestiaTheme.colors.error.copy(alpha = 0.75f),
+                modifier           = Modifier.size(22.dp),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

The two bottom left-rail icons (console toggle + logout) rendered left-packed
instead of centered under the nav column.

Root cause: they are fixed-size `IconButton(48.dp)`, and post-Phase-G the
slot's own Column is start-aligned -- so a fixed-width child sits at the left
edge, while the nav items above are `NavigationRailItem`s that fill the rail
and center their icon. Wrapping each bottom button in a
`Box(fillMaxWidth, Center)` lines them up.

Independent of #277 / #278 -- branched off stable, touches only the two rail
widget files.

## Test plan

- [x] `./gradlew :client-ui:compileKotlinDesktop` -- green
- [x] Left rail: console-toggle + logout icons centered, matching the nav column above (verify live)