### PR TITLE
fix(launcher): resetSurface always succeeds despite leaked ids

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
@@ -2,8 +2,7 @@ package hivens.launcher
 
 import hivens.widget.model.LayoutGraph
 import hivens.widget.model.SurfaceId
-import hivens.widget.model.instanceIds
-import hivens.widget.model.removeInstanceIds
+import hivens.widget.model.resetSurface
 import hivens.widget.model.walkInstances
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -127,21 +126,7 @@ class LayoutGraphRepository(
      */
     suspend fun resetSurface(surface: SurfaceId) {
         val def = defaultGraph()
-        update { graph ->
-            val defaultLayout = def.surfaces[surface]
-                ?: return@update graph.copy(surfaces = graph.surfaces - surface)
-            // Ids the restored default reintroduces. If any leaked onto
-            // OTHER surfaces via a cross-surface move, strip them there
-            // first -- otherwise the restored default id collides with the
-            // leaked copy and the tree-wide uniqueness check in update()
-            // rejects the whole reset, trapping the user. Reset is the
-            // escape hatch; it must always succeed.
-            val restoredIds = defaultLayout.instanceIds()
-            val cleaned = graph.surfaces.mapValues { (sid, layout) ->
-                if (sid == surface) layout else layout.removeInstanceIds(restoredIds)
-            }
-            graph.copy(surfaces = cleaned + (surface to defaultLayout))
-        }
+        update { it.resetSurface(surface, def.surfaces[surface]) }
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
@@ -2,6 +2,8 @@ package hivens.launcher
 
 import hivens.widget.model.LayoutGraph
 import hivens.widget.model.SurfaceId
+import hivens.widget.model.instanceIds
+import hivens.widget.model.removeInstanceIds
 import hivens.widget.model.walkInstances
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -127,11 +129,18 @@ class LayoutGraphRepository(
         val def = defaultGraph()
         update { graph ->
             val defaultLayout = def.surfaces[surface]
-            if (defaultLayout != null) {
-                graph.copy(surfaces = graph.surfaces + (surface to defaultLayout))
-            } else {
-                graph.copy(surfaces = graph.surfaces - surface)
+                ?: return@update graph.copy(surfaces = graph.surfaces - surface)
+            // Ids the restored default reintroduces. If any leaked onto
+            // OTHER surfaces via a cross-surface move, strip them there
+            // first -- otherwise the restored default id collides with the
+            // leaked copy and the tree-wide uniqueness check in update()
+            // rejects the whole reset, trapping the user. Reset is the
+            // escape hatch; it must always succeed.
+            val restoredIds = defaultLayout.instanceIds()
+            val cleaned = graph.surfaces.mapValues { (sid, layout) ->
+                if (sid == surface) layout else layout.removeInstanceIds(restoredIds)
             }
+            graph.copy(surfaces = cleaned + (surface to defaultLayout))
         }
     }
 

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -185,6 +185,25 @@ private fun SlotContent.walkInstances(): Sequence<WidgetInstance> = sequence {
     }
 }
 
+// All instanceIds under one surface, tree-wide (including nested children).
+fun SurfaceLayout.instanceIds(): Set<String> =
+    slots.values.flatMap { content -> content.walkInstances().map { it.instanceId } }.toSet()
+
+// Removes every widget whose instanceId is in `ids`, tree-wide. resetSurface
+// uses this to clear ids that leaked onto OTHER surfaces (via a cross-surface
+// move) before restoring a default surface -- otherwise the restored default
+// ids collide with the leaked copies and the tree-wide uniqueness check
+// rejects the whole reset, trapping the user.
+fun SurfaceLayout.removeInstanceIds(ids: Set<String>): SurfaceLayout =
+    copy(slots = slots.mapValues { (_, content) -> content.removeInstanceIds(ids) })
+
+private fun SlotContent.removeInstanceIds(ids: Set<String>): SlotContent =
+    copy(
+        widgets = widgets
+            .filter { it.instanceId !in ids }
+            .map { w -> w.copy(children = w.children.mapValues { (_, c) -> c.removeInstanceIds(ids) }) },
+    )
+
 // ── Internal traversal + rebuild ──────────────────────────────────────
 
 // Applies `mutator` to the SlotContent at `path`. If the mutator

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -204,6 +204,22 @@ private fun SlotContent.removeInstanceIds(ids: Set<String>): SlotContent =
             .map { w -> w.copy(children = w.children.mapValues { (_, c) -> c.removeInstanceIds(ids) }) },
     )
 
+// Restores `surface` to `defaultLayout` (its bundled default), first stripping
+// any of the restored instanceIds that leaked onto OTHER surfaces (via a
+// cross-surface move) so the tree-wide uniqueness invariant holds and the reset
+// always succeeds -- otherwise the restored id collides with the leaked copy.
+// A null defaultLayout (surface absent from the bundled default) removes the
+// surface entirely. Pure so the escape-hatch path is unit-testable alongside
+// the other LayoutGraph transforms.
+fun LayoutGraph.resetSurface(surface: SurfaceId, defaultLayout: SurfaceLayout?): LayoutGraph {
+    if (defaultLayout == null) return copy(surfaces = surfaces - surface)
+    val restoredIds = defaultLayout.instanceIds()
+    val cleaned = surfaces.mapValues { (sid, layout) ->
+        if (sid == surface) layout else layout.removeInstanceIds(restoredIds)
+    }
+    return copy(surfaces = cleaned + (surface to defaultLayout))
+}
+
 // ── Internal traversal + rebuild ──────────────────────────────────────
 
 // Applies `mutator` to the SlotContent at `path`. If the mutator

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -337,6 +337,27 @@ class LayoutGraphMutationsTest {
     }
 
     @Test
+    fun `instanceIds collects ids tree-wide for a surface`() {
+        val layout = SurfaceLayout(slots = mapOf(main to SlotContent(listOf(container))))
+        assertEquals(setOf("container1", "i1", "i2"), layout.instanceIds())
+    }
+
+    @Test
+    fun `removeInstanceIds strips matching widgets tree-wide`() {
+        val layout = SurfaceLayout(
+            slots = mapOf(
+                SlotId("top") to SlotContent(listOf(w1, w2)),
+                SlotId("bot") to SlotContent(listOf(container)),
+            ),
+        )
+        val out = layout.removeInstanceIds(setOf("i1"))
+        assertEquals(listOf("i2"), out.slots[SlotId("top")]!!.widgets.map { it.instanceId })
+        // i1 nested inside the container's body slot is stripped too.
+        val body = out.slots[SlotId("bot")]!!.widgets[0].children[SlotId("body")]!!.widgets
+        assertEquals(listOf("i2"), body.map { it.instanceId })
+    }
+
+    @Test
     fun `insertWidget into a nested slot the container did not declare is identity`() {
         // Pin the contract: the LayoutGraph mutator does NOT auto-create
         // missing child slot entries. The editor (EditModeController)

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -358,6 +358,32 @@ class LayoutGraphMutationsTest {
     }
 
     @Test
+    fun `resetSurface restores default and strips ids leaked to other surfaces`() {
+        // The bug scenario: home's default widget (i1) was moved onto another
+        // surface; resetting home re-adds i1, which must not collide.
+        val defaultHome = SurfaceLayout(slots = mapOf(main to SlotContent(listOf(w1))))
+        val graph = LayoutGraph(
+            surfaces = mapOf(
+                home to SurfaceLayout(slots = mapOf(main to SlotContent(listOf(w2)))),       // home edited away from default
+                SurfaceId("library") to SurfaceLayout(slots = mapOf(                          // i1 leaked here
+                    SlotId("body") to SlotContent(listOf(w1)),
+                )),
+            ),
+        )
+        val out = graph.resetSurface(home, defaultHome)
+        assertEquals(listOf("i1"), out.surfaces[home]!!.slots[main]!!.widgets.map { it.instanceId })
+        assertEquals(emptyList<String>(), out.surfaces[SurfaceId("library")]!!.slots[SlotId("body")]!!.widgets.map { it.instanceId })
+        // The pre-fix bug would have produced two "i1" tree-wide -> uniqueness must hold.
+        val ids = out.walkInstances().map { it.instanceId }.toList()
+        assertEquals(ids.toSet().size, ids.size, "no duplicate instanceIds after reset")
+    }
+
+    @Test
+    fun `resetSurface with a null default removes the surface entirely`() {
+        assertNull(seed(w1).resetSurface(home, null).surfaces[home])
+    }
+
+    @Test
     fun `insertWidget into a nested slot the container did not declare is identity`() {
         // Pin the contract: the LayoutGraph mutator does NOT auto-create
         // missing child slot entries. The editor (EditModeController)


### PR DESCRIPTION
## Summary

The "Сбросить" (reset surface) escape hatch could silently fail. `resetSurface`
restores a surface's bundled default, but if a default-id widget had earlier
been **moved onto another surface**, restoring re-introduces that id while the
leaked copy still exists -> `update()`'s tree-wide duplicate-instanceId check
rejects the whole reset and keeps the broken graph -- trapping the user.

Fix: reset now strips the restored surface's instanceIds from every OTHER
surface before applying, so the restore can never collide. The logic is a pure
`LayoutGraph.resetSurface(surface, defaultLayout)` transform in widget-model
(consistent with the other transforms and unit-testable); the repository just
threads it through `update()`. New tree-wide `instanceIds()` /
`removeInstanceIds()` helpers.

Found while testing the canvas editor (dragging home widgets onto the profile
surface, then reset failing), but the bug is general to any cross-surface move.

## Test plan

- [x] `./gradlew :widget-model:test :client-ui:desktopTest` -- green
- [x] Unit: `instanceIds` / `removeInstanceIds` (incl. nested children)
- [x] Unit: `resetSurface` bug scenario -- a default-id moved cross-surface -> reset succeeds, leaked copy stripped, no duplicate ids tree-wide
- [x] Live (sanity): move a home widget onto another surface, then Сбросить -> no "duplicate instanceId" rejection