### PR TITLE
build(deps): resolve libtray from Maven Central, drop JitPack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,12 +38,11 @@ logback           = "1.5.32"
 commonsCompress   = "1.28.0"
 proguard          = "7.8.2"
 
-# Pure-Panama tray library (Kitty-Hivens/libtray) — replaces dorkbox/SystemTray
-# for the native tray icon. Pulled via JitPack (root build.gradle.kts
-# repositories chain) until libtray cuts its first Maven Central release;
-# pinned to a commit sha rather than a branch so upstream main-branch
-# changes don't silently land in our build.
-libtray           = "e86f497"
+# Pure-Panama tray library (Kitty-Hivens/libtray) -- replaces dorkbox/SystemTray
+# for the native tray icon. Now on Maven Central as dev.hivens:libtray
+# (resolved from mavenCentral; the jitpack repo is no longer needed for it).
+# Pinned to a released semver so upstream changes don't silently land here.
+libtray           = "0.1.0"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"
@@ -93,7 +92,7 @@ filekit-dialogs-compose         = { group = "io.github.vinceglb", name = "fileki
 
 # Misc
 commons-compress                = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
-libtray                          = { group = "com.github.Kitty-Hivens", name = "libtray",      version.ref = "libtray" }
+libtray                          = { group = "dev.hivens", name = "libtray", version.ref = "libtray" }
 
 # JNA dropped — was only present for dorkbox/SystemTray. libtray is
 # pure java.lang.foreign (Project Panama) and pulls no JNA transitively.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,10 +37,8 @@ plugins {
 //     single-source-of-truth rule -- a new repo only enters the project
 //     by being added here, not by drifting into one subproject and
 //     surprising another.
-//   * mavenCentral covers the bulk of dependencies.
-//   * JitPack hosts libtray (Kitty-Hivens/libtray) until it ships a real
-//     Maven Central release; commit-sha-pinned in libs.versions.toml so
-//     an upstream main-branch break does not silently drift the build.
+//   * mavenCentral covers the bulk of dependencies (incl. libtray, now
+//     published as dev.hivens:libtray).
 //
 // JetBrains compose-dev maven was previously listed for Compose Multiplatform
 // alpha artifacts. Removed alongside the bump to 1.11.0 GA (commit d214466) --
@@ -59,7 +57,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
-        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
## Summary
- libtray published its first Maven Central release (`dev.hivens:libtray:0.1.0`); replaces the JitPack commit-sha pin (`com.github.Kitty-Hivens:libtray`) with the released semver.
- Removes the now-orphaned `jitpack.io` repository from `settings.gradle.kts`. libtray was its only consumer; the `com.github.*` entries in the catalog are Gradle plugin ids resolved via the plugin portal, not JitPack.

## Test plan
- [x] `:client-ui:compileKotlinDesktop` resolves and compiles against the release with `mavenCentral()` alone, JitPack removed.