### PR TITLE
feat(launcher): declare javaMajor on the resolved runtime

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/IJavaManager.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/IJavaManager.kt
@@ -14,16 +14,27 @@ import java.nio.file.Path
 interface IJavaManager {
 
     /**
-     * Returns the absolute path to the `java` executable suitable for the
-     * given Minecraft version. Triggers a download into the runtimes
-     * directory if the required Liberica build is not already on disk.
+     * Version-keyed shortcut: derives the Java major via [detectJavaVersion] and
+     * provisions the JDK for it. Suitable for the SC server path which has no
+     * concept of a loader-declared Java. Pack-centric callers should use
+     * [getJavaPathForMajor] instead, with the major from the resolved runtime --
+     * the JDK is fundamentally major-keyed; MC version is only a heuristic input.
      */
     suspend fun getJavaPath(version: String): Path
 
     /**
-     * The Java major a given Minecraft version requires (8 / 17 / 21). Drives
-     * both which JDK [getJavaPath] provisions and launch-arg choices that
-     * depend on the JVM generation (e.g. `-noverify`, deprecated since 13).
+     * Major-keyed entry point used by the pack path. Same Minecraft version on a
+     * different loader can need a different Java (e.g. Cleanroom-1.12.2 -> 25 vs
+     * legacy-Forge-1.12.2 -> 8), so the pack path must pass the loader-declared
+     * major directly instead of guessing from the version string.
+     */
+    suspend fun getJavaPathForMajor(javaMajor: Int): Path
+
+    /**
+     * Fallback Java major for a Minecraft version (8 / 17 / 21), used only when
+     * nothing more authoritative declares it (Mojang's per-version `javaVersion`
+     * absent + no loader override). Also drives launch-arg choices that depend
+     * on the JVM generation (e.g. `-noverify`, deprecated since 13).
      */
     fun detectJavaVersion(mcVersion: String): Int = when {
         mcVersion.startsWith("1.21") || mcVersion.startsWith("1.20.5") || mcVersion.startsWith("1.20.6") -> 21

--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/IJavaManager.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/IJavaManager.kt
@@ -27,8 +27,13 @@ interface IJavaManager {
      * different loader can need a different Java (e.g. Cleanroom-1.12.2 -> 25 vs
      * legacy-Forge-1.12.2 -> 8), so the pack path must pass the loader-declared
      * major directly instead of guessing from the version string.
+     *
+     * [onProgress] receives human-readable status lines for the launch UI -- a
+     * download of a missing JDK is ~200 MB and the caller may sit on a fixed
+     * progress stage while it runs; the default no-op keeps the SC server path
+     * silent.
      */
-    suspend fun getJavaPathForMajor(javaMajor: Int): Path
+    suspend fun getJavaPathForMajor(javaMajor: Int, onProgress: (String) -> Unit = {}): Path
 
     /**
      * Fallback Java major for a Minecraft version (8 / 17 / 21), used only when

--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
@@ -58,9 +58,15 @@ interface ILauncherService {
      *                         java path).
      * @param clientRootPath   Absolute path to the instance's directory
      *                         (`<dataDir>/instances/<instanceDirName>`).
-     * @param javaExecutablePath Default Java executable. Used when the
-     *                         instance's [InstanceRuntime.javaPath] is
-     *                         null or empty.
+     * @param javaPathOverride Optional global Java override (the user's
+     *                         `settings.javaPath`). When null, the launcher
+     *                         provisions the loader-declared Java itself
+     *                         from the resolved runtime's `javaMajor`, which
+     *                         beats the version heuristic (same MC + different
+     *                         loader can need different Java -- Cleanroom-1.12.2
+     *                         wants 25, legacy-Forge-1.12.2 wants 8). The
+     *                         per-instance [InstanceRuntime.javaPath] still wins
+     *                         over both override and managed default.
      * @param allocatedMemoryMB Fallback heap (MB) when the instance's
      *                         own [InstanceRuntime.memoryMb] is 0 or
      *                         below the launcher floor.
@@ -73,7 +79,7 @@ interface ILauncherService {
         manifest: CachedManifestSnapshot,
         runtime: InstanceRuntime,
         clientRootPath: Path,
-        javaExecutablePath: Path,
+        javaPathOverride: Path?,
         allocatedMemoryMB: Int,
         displayName: String,
         onLog: (String, LauncherLogType) -> Unit,

--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -26,16 +26,14 @@ class JavaManagerService(
     private val httpClient get() = clientProvider.current
     private val runtimesDir: Path = baseDir.resolve("runtimes")
 
-    /**
-     * Returns the path to the Java executable.
-     * If the required version is not available, it downloads it.
-     */
-    override suspend fun getJavaPath(version: String): Path = withContext(Dispatchers.IO) {
-        val javaVersion = detectJavaVersion(version)
+    override suspend fun getJavaPath(version: String): Path =
+        getJavaPathForMajor(detectJavaVersion(version))
+
+    override suspend fun getJavaPathForMajor(javaMajor: Int): Path = withContext(Dispatchers.IO) {
         val os = getOsName()
         val arch = getArchName()
 
-        val folderName = "java-$javaVersion-$os-$arch"
+        val folderName = "java-$javaMajor-$os-$arch"
         val targetDir = runtimesDir.resolve(folderName)
 
         val existing = findJavaExecutable(targetDir)
@@ -45,9 +43,9 @@ class JavaManagerService(
         if (existing != null) {
             log.warn("Java at {} failed -version check, treating as broken and re-downloading", existing)
         } else {
-            log.info("Java {} ({}/{}) was not found locally. We are starting to download...", javaVersion, os, arch)
+            log.info("Java {} ({}/{}) was not found locally. We are starting to download...", javaMajor, os, arch)
         }
-        downloadAndUnpack(javaVersion, targetDir)
+        downloadAndUnpack(javaMajor, targetDir)
 
         val executable = findJavaExecutable(targetDir)
             ?: throw IOException("Java was downloaded, but the executable file was not found!")

--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -29,7 +29,7 @@ class JavaManagerService(
     override suspend fun getJavaPath(version: String): Path =
         getJavaPathForMajor(detectJavaVersion(version))
 
-    override suspend fun getJavaPathForMajor(javaMajor: Int): Path = withContext(Dispatchers.IO) {
+    override suspend fun getJavaPathForMajor(javaMajor: Int, onProgress: (String) -> Unit): Path = withContext(Dispatchers.IO) {
         val os = getOsName()
         val arch = getArchName()
 
@@ -45,7 +45,8 @@ class JavaManagerService(
         } else {
             log.info("Java {} ({}/{}) was not found locally. We are starting to download...", javaMajor, os, arch)
         }
-        downloadAndUnpack(javaMajor, targetDir)
+        onProgress("Downloading Java $javaMajor ($os/$arch)...")
+        downloadAndUnpack(javaMajor, targetDir, onProgress)
 
         val executable = findJavaExecutable(targetDir)
             ?: throw IOException("Java was downloaded, but the executable file was not found!")
@@ -58,10 +59,11 @@ class JavaManagerService(
             throw IOException("Java was downloaded and extracted, but $executable failed -version check. Archive may be corrupt or missing native loader files (e.g. libjli.so).")
         }
 
+        onProgress("Java $javaMajor ready")
         return@withContext executable
     }
 
-    private suspend fun downloadAndUnpack(version: Int, targetDir: Path) {
+    private suspend fun downloadAndUnpack(version: Int, targetDir: Path, onProgress: (String) -> Unit = {}) {
         val urls = getDownloadUrls(version)
         if (urls.isEmpty()) {
             throw IOException("There is no Java build for this system (${getOsName()} ${getArchName()})")
@@ -94,12 +96,21 @@ class JavaManagerService(
                     if (!httpResponse.status.isSuccess()) {
                         throw IOException("Loading error: ${httpResponse.status}")
                     }
+                    val total = httpResponse.contentLength() ?: -1L
                     val channel = httpResponse.bodyAsChannel()
                     FileOutputStream(archive.toFile()).use { fileStream ->
-                        channel.copyTo(fileStream)
+                        // Wrap to count bytes and emit progress every 5% -- a fresh
+                        // Java 25 download is ~200 MB and the UI sits on PrepareStage.JVM
+                        // otherwise.
+                        val counting = ProgressOutputStream(fileStream, total) { pct ->
+                            onProgress("Downloading Java $version: $pct%")
+                        }
+                        channel.copyTo(counting)
+                        counting.flush()
                     }
                 }
 
+                onProgress("Unpacking Java $version archive...")
                 log.info("Unpacking to {}", targetDir)
                 deleteDirectoryRecursively(targetDir)
                 Files.createDirectories(targetDir)
@@ -458,6 +469,42 @@ class JavaManagerService(
         val tagPrefix = if (major == 8) "jdk" else "jdk-"
         return "https://github.com/adoptium/temurin${major}-binaries/releases/download/" +
             "$tagPrefix$tagEncoded/OpenJDK${major}U-jdk_${arch}_${os}_hotspot_$fileVersion.$ext"
+    }
+
+    /**
+     * Counting [java.io.OutputStream] wrapper that emits a percent-progress
+     * callback every 5 percentage points (and once at 100). Used for the JDK
+     * download so the launch UI can show meaningful status during the ~200 MB
+     * first-run download instead of sitting silent on PrepareStage.JVM. The
+     * close() is a no-op -- the wrapped stream is owned by an outer `use` block.
+     */
+    private class ProgressOutputStream(
+        private val delegate: java.io.OutputStream,
+        private val totalBytes: Long,
+        private val onPct: (Int) -> Unit,
+    ) : java.io.OutputStream() {
+        private var written = 0L
+        private var lastPct = -1
+        override fun write(b: Int) {
+            delegate.write(b)
+            written++
+            emitMaybe()
+        }
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            delegate.write(b, off, len)
+            written += len
+            emitMaybe()
+        }
+        override fun flush() { delegate.flush() }
+        override fun close() { /* delegate is owned by an outer `use` */ }
+        private fun emitMaybe() {
+            if (totalBytes <= 0) return
+            val pct = ((written * 100) / totalBytes).toInt().coerceIn(0, 100)
+            if (pct >= lastPct + 5 || pct == 100) {
+                lastPct = pct
+                onPct(pct)
+            }
+        }
     }
 
     companion object {

--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -385,6 +385,13 @@ class JavaManagerService(
                 "mac" if arch == "arm64" -> "https://download.bell-sw.com/java/21.0.9+15/bellsoft-jdk21.0.9+15-macos-aarch64-full.tar.gz"
                 else -> null
             }
+            25 -> when (os) {
+                "win" if arch == "x64" -> "https://download.bell-sw.com/java/25.0.3+11/bellsoft-jdk25.0.3+11-windows-amd64-full.zip"
+                "linux" if arch == "x64" -> "https://download.bell-sw.com/java/25.0.3+11/bellsoft-jdk25.0.3+11-linux-amd64-full.tar.gz"
+                "mac" if arch == "x64" -> "https://download.bell-sw.com/java/25.0.3+11/bellsoft-jdk25.0.3+11-macos-amd64-full.tar.gz"
+                "mac" if arch == "arm64" -> "https://download.bell-sw.com/java/25.0.3+11/bellsoft-jdk25.0.3+11-macos-aarch64-full.tar.gz"
+                else -> null
+            }
             else -> null
         }
     }
@@ -424,6 +431,13 @@ class JavaManagerService(
                 "linux" if arch == "x64"   -> adoptium(21, "21.0.5+11", "21.0.5_11", "x64",     "linux",   "tar.gz")
                 "mac"   if arch == "x64"   -> adoptium(21, "21.0.5+11", "21.0.5_11", "x64",     "mac",     "tar.gz")
                 "mac"   if arch == "arm64" -> adoptium(21, "21.0.5+11", "21.0.5_11", "aarch64", "mac",     "tar.gz")
+                else -> null
+            }
+            25 -> when (os) {
+                "win"   if arch == "x64"   -> adoptium(25, "25.0.3+9", "25.0.3_9", "x64",     "windows", "zip")
+                "linux" if arch == "x64"   -> adoptium(25, "25.0.3+9", "25.0.3_9", "x64",     "linux",   "tar.gz")
+                "mac"   if arch == "x64"   -> adoptium(25, "25.0.3+9", "25.0.3_9", "x64",     "mac",     "tar.gz")
+                "mac"   if arch == "arm64" -> adoptium(25, "25.0.3+9", "25.0.3_9", "aarch64", "mac",     "tar.gz")
                 else -> null
             }
             else -> null

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -151,7 +151,9 @@ internal class LauncherService(
         val javaExec: String = if (!runtime.javaPath.isNullOrEmpty()) {
             runtime.javaPath!!
         } else {
-            val defaultJava = javaPathOverride ?: javaManager.getJavaPathForMajor(javaMajor)
+            val defaultJava = javaPathOverride ?: javaManager.getJavaPathForMajor(javaMajor) { msg ->
+                onLog(msg, LauncherLogType.INFO)
+            }
             resolvePackJavaPath(runtime, defaultJava)
         }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -116,7 +116,7 @@ internal class LauncherService(
         manifest: CachedManifestSnapshot,
         runtime: InstanceRuntime,
         clientRootPath: Path,
-        javaExecutablePath: Path,
+        javaPathOverride: Path?,
         allocatedMemoryMB: Int,
         displayName: String,
         onLog: (String, LauncherLogType) -> Unit
@@ -127,23 +127,28 @@ internal class LauncherService(
         // SC path; the InstanceRuntime value wins when positive.
         val memory = normalizeMemory(runtime.memoryMb, allocatedMemoryMB)
 
-        // 2. Java path. Pack-centric runtime carries an optional
-        // explicit override; without it the caller's resolved default
-        // wins (LauncherController already consulted JavaManager).
-        val javaExec: String = resolvePackJavaPath(runtime, javaExecutablePath)
-
-        log.info("Session initialization (pack): {}, Java: {}, Heap: {}MB", displayName, javaExec, memory)
         onLog("Running $displayName...", LauncherLogType.INFO)
 
-        // 3. Canonical runtime: vanilla + loader libraries + client + assets into
-        // the SHARED roots (idempotent). Throws clearly if it cannot provision --
-        // no more "ready" followed by an empty-classpath crash.
+        // 2. Canonical runtime: vanilla + loader libraries + client + assets into
+        // the SHARED roots (idempotent). Resolved FIRST so the loader-declared
+        // Java major can drive JDK provisioning -- same MC version on a different
+        // loader needs a different JDK (Cleanroom-1.12.2 wants 25, not 8).
         val nativesDir = commandBuilder.packNativesDir(mcVersion)
         val resolved = runtimeProvisioner.ensureRuntime(
             mcVersion = mcVersion,
             loaderName = manifest.loaderName,
             loaderVersion = manifest.loaderVersion,
         ) { current, total, file -> onLog("Runtime $current/$total: $file", LauncherLogType.INFO) }
+
+        // 3. Java. The resolved runtime declares the major (loader override wins
+        // over Mojang's per-version `javaVersion` over the heuristic). Precedence:
+        // instance override (runtime.javaPath) > caller override (javaPathOverride)
+        // > the loader-aware managed default.
+        val javaMajor = resolved.javaMajor ?: javaManager.detectJavaVersion(mcVersion)
+        val defaultJava = javaPathOverride ?: javaManager.getJavaPathForMajor(javaMajor)
+        val javaExec: String = resolvePackJavaPath(runtime, defaultJava)
+
+        log.info("Session initialization (pack): {}, Java: {} (major {}), Heap: {}MB", displayName, javaExec, javaMajor, memory)
 
         // 4. Natives stay per-instance, but are now extracted from the jars the
         // provisioner resolved from the manifest -- so the LWJGL version matches
@@ -161,7 +166,7 @@ internal class LauncherService(
             sharedLibrariesDir = sharedLibrariesDir,
             nativesDirName = nativesDir,
             versionLabel = packVersionLabel(manifest.loaderName, mcVersion),
-            javaMajor = javaManager.detectJavaVersion(mcVersion),
+            javaMajor = javaMajor,
             runtime = resolved,
             session = sessionData,
             jvmArgsOverride = runtime.jvmArgs,

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -140,13 +140,20 @@ internal class LauncherService(
             loaderVersion = manifest.loaderVersion,
         ) { current, total, file -> onLog("Runtime $current/$total: $file", LauncherLogType.INFO) }
 
-        // 3. Java. The resolved runtime declares the major (loader override wins
-        // over Mojang's per-version `javaVersion` over the heuristic). Precedence:
-        // instance override (runtime.javaPath) > caller override (javaPathOverride)
-        // > the loader-aware managed default.
-        val javaMajor = resolved.javaMajor ?: javaManager.detectJavaVersion(mcVersion)
-        val defaultJava = javaPathOverride ?: javaManager.getJavaPathForMajor(javaMajor)
-        val javaExec: String = resolvePackJavaPath(runtime, defaultJava)
+        // 3. Java. Major precedence: loader-resolved override -> the pack manifest's
+        // own declaration (authoritative for the pack) -> Mojang's per-version field
+        // (captured into the resolved runtime). The heuristic disappears here: the
+        // pack ALWAYS declares its major in the manifest. Path precedence: instance
+        // pin (runtime.javaPath) > caller override (javaPathOverride) > managed for
+        // the declared major. Skip provisioning a managed JDK we would discard --
+        // when the instance pins its own java, don't trigger the ~200 MB download.
+        val javaMajor = resolved.javaMajor ?: manifest.javaMajor
+        val javaExec: String = if (!runtime.javaPath.isNullOrEmpty()) {
+            runtime.javaPath!!
+        } else {
+            val defaultJava = javaPathOverride ?: javaManager.getJavaPathForMajor(javaMajor)
+            resolvePackJavaPath(runtime, defaultJava)
+        }
 
         log.info("Session initialization (pack): {}, Java: {} (major {}), Heap: {}MB", displayName, javaExec, javaMajor, memory)
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
@@ -293,7 +293,7 @@ internal class GameCommandBuilder(
         // substitution and a self-built classpath -- modlauncher 1.13-1.16 has
         // the template but no module path.
         val usesModulePath = runtime.mainClass.contains("bootstraplauncher", ignoreCase = true)
-        val usesModernArgs = usesModulePath || runtime.jvmArgs.any { it.contains("\${") }
+        val usesModernArgs = usesModulePath || runtime.jvmArgs.any { it.contains($$"${") }
         if (javaMajor <= 8) args.add("-noverify")
         if (System.getProperty("os.name").lowercase().contains("mac")) {
             args.add("-XstartOnFirstThread")

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -365,15 +365,16 @@ class LauncherController(
                 val (manifestSnapshot, refreshedInstance) =
                     resolveOrFetchManifest(packInstance)
 
-                // 2. Java. Same JavaManager path as the SC flow --
-                // pack manifest's declared MC version drives the
-                // managed Liberica selection.
+                // 2. Java override. The pack launch path picks the LOADER-declared
+                // Java itself (resolved.javaMajor) from the resolved runtime --
+                // same MC + different loader can need different Java (Cleanroom-
+                // 1.12.2 -> 25 vs legacy-Forge-1.12.2 -> 8), so the version-keyed
+                // heuristic moves out of the controller. We only pass the user's
+                // explicit global setting; null means "let the service provision."
                 setStage(PrepareStage.JVM, 0.7f)
-                val javaPath = if (!settings.javaPath.isNullOrEmpty()) {
-                    Path.of(settings.javaPath!!)
-                } else {
-                    javaManagerService.getJavaPath(manifestSnapshot.minecraftVersion)
-                }
+                val javaOverride: Path? = settings.javaPath
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { Path.of(it) }
 
                 // 3. Spawn. Pack-centric clientRoot lives under
                 // `<dataDir>/instances/<instanceDirName>`, not under
@@ -395,7 +396,7 @@ class LauncherController(
                     manifest             = manifestSnapshot,
                     runtime              = refreshedInstance.runtime,
                     clientRootPath       = clientDir,
-                    javaExecutablePath   = javaPath,
+                    javaPathOverride     = javaOverride,
                     allocatedMemoryMB    = settings.memoryMB,
                     displayName          = refreshedInstance.displayName,
                 ) { text, type ->

--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/MojangDtos.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/MojangDtos.kt
@@ -44,6 +44,17 @@ data class MojangVersion(
      * vanilla's (here) + the loader's.
      */
     val arguments: MojangArguments? = null,
+    /**
+     * Mojang's declared Java major (present 1.17+; absent on legacy versions
+     * -> null, where the launcher falls back to its version heuristic).
+     * Authoritative when present -- we should not guess what Mojang already states.
+     */
+    val javaVersion: MojangJavaVersion? = null,
+)
+
+@Serializable
+data class MojangJavaVersion(
+    val majorVersion: Int,
 )
 
 /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
@@ -92,6 +92,9 @@ class RuntimeProvisioner(
         /** Host-matching native jars (lwjgl etc.) resolved from the manifest,
          *  on disk in the shared root after [ensureVanilla]. */
         val natives: List<Path> = emptyList(),
+        /** Mojang's declared Java major (1.17+ vanilla json carries
+         *  `javaVersion.majorVersion`); null on legacy / when absent. */
+        val javaMajor: Int? = null,
     )
 
     /** A single file to fetch into a shared root, verified against [sha1]. */
@@ -123,6 +126,7 @@ class RuntimeProvisioner(
                 mainClass = VANILLA_MAIN_CLASS,
                 assetIndexId = vanilla.assetIndexId,
                 natives = vanilla.natives,
+                javaMajor = vanilla.javaMajor,
             )
 
         log.info("resolving loader overlay: {} {}", resolver.loaderId, loaderVersion)
@@ -158,6 +162,8 @@ class RuntimeProvisioner(
             jvmArgs = if (profile.inheritsVanillaArguments) vanilla.jvmArgs + profile.jvmArgs else profile.jvmArgs,
             gameArgs = profile.gameArgs,
             natives = vanilla.natives,
+            // Loader override (Cleanroom -> 25) wins; else inherit vanilla's declared.
+            javaMajor = profile.javaMajor ?: vanilla.javaMajor,
         )
     }
 
@@ -194,6 +200,7 @@ class RuntimeProvisioner(
             jvmArgs = version.arguments?.let { flattenArguments(it.jvm, mojangOs) } ?: emptyList(),
             gameArgs = version.arguments?.let { flattenArguments(it.game, mojangOs) } ?: emptyList(),
             natives = nativeJarPaths(version),
+            javaMajor = version.javaVersion?.majorVersion,
         )
     }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/loader/LoaderResolver.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/loader/LoaderResolver.kt
@@ -80,6 +80,13 @@ data class LoaderProfile(
      * the legacy path and set this false.
      */
     val inheritsVanillaArguments: Boolean = false,
+    /**
+     * The Java major this loader requires (e.g. Cleanroom declares 25). Null
+     * means "no override -- inherit the vanilla MC's declared Java." Loaders
+     * that don't change Java requirements (Forge legacy/modern, NeoForge,
+     * Fabric, Quilt today) leave this null.
+     */
+    val javaMajor: Int? = null,
 )
 
 /**
@@ -103,6 +110,17 @@ data class ResolvedRuntime(
      * none; this is the vanilla base's set.
      */
     val natives: List<Path> = emptyList(),
+    /**
+     * Declared Java major for this (MC version, loader): loader override
+     * ([LoaderProfile.javaMajor]) wins over Mojang's per-version `javaVersion`
+     * declaration, which wins over the launcher's heuristic. Null when nothing
+     * declares it (legacy MC pre-1.17 + no loader override) -- the launcher
+     * falls back to [hivens.core.api.interfaces.IJavaManager.detectJavaVersion].
+     * This is what should drive JDK provisioning, NOT the MC version alone --
+     * same MC, different loaders can need different Java majors (Cleanroom-
+     * 1.12.2 wants 25, legacy-Forge-1.12.2 wants 8).
+     */
+    val javaMajor: Int? = null,
 )
 
 /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolver.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolver.kt
@@ -48,6 +48,14 @@ class ModernInstallerResolver(
     private val javaManager: IJavaManager,
     private val cacheDir: Path,
     override val loaderId: String,
+    /**
+     * Java major to run the official installer under. Null means derive from the
+     * MC version via [IJavaManager.detectJavaVersion] -- matches every current
+     * loader (Forge / NeoForge target the MC version's own JDK). Pass the
+     * loader's declared major when a future loader needs a different one
+     * (e.g. Cleanroom -> 25) so the installer JDK matches the GAME's JDK.
+     */
+    private val installerJavaMajor: Int? = null,
     private val installerUrl: (mcVersion: String, loaderVersion: String) -> String,
 ) : LoaderResolver {
 
@@ -120,7 +128,8 @@ class ModernInstallerResolver(
         log.info("{}: downloading installer {}", loaderId, url)
         downloadTo(url, installer)
 
-        val java = javaManager.getJavaPath(mcVersion)
+        val major = installerJavaMajor ?: javaManager.detectJavaVersion(mcVersion)
+        val java = javaManager.getJavaPathForMajor(major)
         runInstaller(java, installer, dotMinecraft)
 
         Files.deleteIfExists(installer)

--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -210,12 +210,12 @@ class JavaManagerServiceTest {
 
     @Test
     fun `getDownloadUrl returns null for unknown Java major`() {
-        // Anything outside {8, 17, 21} -- e.g., a hypothetical 25 we
-        // haven't wired yet -- falls through to null. The download path
-        // surfaces this as a clear "no Java build for this system" error.
+        // Anything outside the wired-in matrix {8, 17, 21, 25} -- e.g. Java 11,
+        // which nothing in our target MC/loader graph needs -- falls through to
+        // null. The download path surfaces this as a clear "no Java build for
+        // this system" error.
         withSystemProp("os.name", "Linux") {
             withSystemProp("os.arch", "amd64") {
-                assertNull(svc.getDownloadUrl(25))
                 assertNull(svc.getDownloadUrl(11))
             }
         }

--- a/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
@@ -80,7 +80,7 @@ class LauncherServiceTest {
         override suspend fun getJavaPath(version: String): Path =
             if (throws) throw IOException("simulated download failure")
             else result ?: throw IOException("not available")
-        override suspend fun getJavaPathForMajor(javaMajor: Int): Path =
+        override suspend fun getJavaPathForMajor(javaMajor: Int, onProgress: (String) -> Unit): Path =
             if (throws) throw IOException("simulated download failure")
             else result ?: throw IOException("not available")
     }

--- a/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
@@ -80,6 +80,9 @@ class LauncherServiceTest {
         override suspend fun getJavaPath(version: String): Path =
             if (throws) throw IOException("simulated download failure")
             else result ?: throw IOException("not available")
+        override suspend fun getJavaPathForMajor(javaMajor: Int): Path =
+            if (throws) throw IOException("simulated download failure")
+            else result ?: throw IOException("not available")
     }
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
@@ -614,11 +614,11 @@ class GameCommandBuilderTest {
         // `-Djava.library.path` (both must be dropped), an --add-opens to keep,
         // the loader's -p with placeholders, and -DlibraryDirectory.
         jvmArgs = listOf(
-            "-Djava.library.path=\${natives_directory}",
-            "-cp", "\${classpath}",
+            $$"-Djava.library.path=${natives_directory}",
+            "-cp", $$"${classpath}",
             "--add-opens=java.base/java.lang=ALL-UNNAMED",
-            "-p", "\${library_directory}/cpw/mods/bootstraplauncher/2.0.2/bootstraplauncher-2.0.2.jar\${classpath_separator}\${library_directory}/cpw/mods/securejarhandler/3.0.8/securejarhandler-3.0.8.jar",
-            "-DlibraryDirectory=\${library_directory}",
+            "-p", $$"${library_directory}/cpw/mods/bootstraplauncher/2.0.2/bootstraplauncher-2.0.2.jar${classpath_separator}${library_directory}/cpw/mods/securejarhandler/3.0.8/securejarhandler-3.0.8.jar",
+            $$"-DlibraryDirectory=${library_directory}",
             "-DignoreList=client-extra,neoforge-",
         ),
         gameArgs = listOf("--launchTarget", "neoforgeclient", "--fml.neoForgeVersion", "21.1.66"),
@@ -644,7 +644,7 @@ class GameCommandBuilderTest {
         // remains -- ours -- and it carries the client + libs, not ${classpath}.
         assertEquals(1, cmd.count { it == "-cp" }, "only the builder's own -cp survives")
         val cp = cmd[cmd.indexOf("-cp") + 1]
-        assertFalse(cp.contains("\${classpath}"), "the placeholder must be gone, got $cp")
+        assertFalse(cp.contains($$"${classpath}"), "the placeholder must be gone, got $cp")
         assertFalse(cp.contains("minecraft-1.21.1.jar"), "vanilla client NOT on a modern cp -- FML loads its processor client")
         assertTrue(cp.contains("neoforge-21.1.66.jar"), "loader libs on the classpath")
 
@@ -652,7 +652,7 @@ class GameCommandBuilderTest {
         val pValue = cmd[cmd.indexOf("-p") + 1]
         assertTrue(pValue.contains("bootstraplauncher-2.0.2.jar"), "boot module on -p")
         assertTrue(pValue.contains("/tmp/shared/libraries"), "library_directory substituted, got $pValue")
-        assertFalse(pValue.contains("\${"), "no placeholder left in -p, got $pValue")
+        assertFalse(pValue.contains($$"${"), "no placeholder left in -p, got $pValue")
         assertTrue(pValue.contains(File.pathSeparator), "two boot jars joined by the path separator, got $pValue")
 
         assertTrue(cmd.contains("-DlibraryDirectory=/tmp/shared/libraries"), "libraryDirectory substituted")
@@ -661,7 +661,7 @@ class GameCommandBuilderTest {
 
         // Inherited -Djava.library.path is dropped; the builder emits its own.
         assertEquals(1, cmd.count { it.startsWith("-Djava.library.path") }, "exactly one java.library.path -- the builder's")
-        assertFalse(cmd.any { it.contains("\${natives_directory}") }, "natives placeholder not left dangling")
+        assertFalse(cmd.any { it.contains($$"${natives_directory}") }, "natives placeholder not left dangling")
 
         // Loader game args land after the standard set.
         assertEquals("neoforgeclient", cmd[cmd.indexOf("--launchTarget") + 1])

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -268,7 +268,7 @@ class LauncherControllerTest {
                 manifest           = any(),
                 runtime            = any(),
                 clientRootPath     = any(),
-                javaExecutablePath = any(),
+                javaPathOverride   = any(),
                 allocatedMemoryMB  = any(),
                 displayName        = any(),
                 onLog              = any(),

--- a/client-launcher/src/test/kotlin/hivens/launcher/mrpack/MrpackInstallerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/mrpack/MrpackInstallerTest.kt
@@ -56,7 +56,7 @@ class MrpackInstallerTest {
 
     private val fakeJava = object : IJavaManager {
         override suspend fun getJavaPath(version: String): Path = Path.of("/bin/java")
-        override suspend fun getJavaPathForMajor(javaMajor: Int): Path = Path.of("/bin/java")
+        override suspend fun getJavaPathForMajor(javaMajor: Int, onProgress: (String) -> Unit): Path = Path.of("/bin/java")
     }
 
     // -- pure helpers ---------------------------------------------------------

--- a/client-launcher/src/test/kotlin/hivens/launcher/mrpack/MrpackInstallerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/mrpack/MrpackInstallerTest.kt
@@ -56,6 +56,7 @@ class MrpackInstallerTest {
 
     private val fakeJava = object : IJavaManager {
         override suspend fun getJavaPath(version: String): Path = Path.of("/bin/java")
+        override suspend fun getJavaPathForMajor(javaMajor: Int): Path = Path.of("/bin/java")
     }
 
     // -- pure helpers ---------------------------------------------------------

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/MojangArgumentsTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/MojangArgumentsTest.kt
@@ -14,7 +14,7 @@ class MojangArgumentsTest {
     @Test
     fun `bare strings pass through and placeholders are preserved`() {
         val a = args("""{"jvm":["-Dfoo=bar","-cp","${'$'}{classpath}"]}""")
-        assertEquals(listOf("-Dfoo=bar", "-cp", "\${classpath}"), flattenArguments(a.jvm, "linux"))
+        assertEquals(listOf("-Dfoo=bar", "-cp", $$"${classpath}"), flattenArguments(a.jvm, "linux"))
     }
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
@@ -1,6 +1,9 @@
 package hivens.launcher.runtime
 
 import hivens.core.api.HttpClientProvider
+import hivens.launcher.runtime.loader.LoaderProfile
+import hivens.launcher.runtime.loader.LoaderRegistry
+import hivens.launcher.runtime.loader.LoaderResolver
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -319,6 +322,89 @@ class RuntimeProvisionerTest {
 
         assertFailsWith<IOException> { p.ensureVanilla("1.12.2") }
         assertTrue(!librariesDir.resolve("x/y/1/y-1.jar").exists(), "bad download must not leave a file")
+    }
+
+    // -- javaMajor declare-model (loader > vanilla > heuristic precedence) ----
+
+    @Test
+    fun `ensureVanilla captures Mojang javaVersion (and no-loader runtime inherits it)`() = runTest {
+        val clientBytes = "C".toByteArray()
+        val indexJson = """{"objects":{}}"""
+        val indexSha = sha1(indexJson)
+        // 1.17+ vanilla json shape: carries `javaVersion.majorVersion` directly.
+        val versionJson = """
+            {
+              "assetIndex": {"id":"17","sha1":"$indexSha","size":${indexJson.length},"url":"$INDEX_URL"},
+              "downloads": {"client": {"sha1":"${sha1(clientBytes)}","size":${clientBytes.size},"url":"$CLIENT_URL"}},
+              "javaVersion": {"majorVersion": 21},
+              "libraries": []
+            }
+        """.trimIndent()
+        val manifestJson = """{"versions":[{"id":"1.21.1","url":"$VERSION_URL"}]}"""
+
+        val engine = MockEngine { req ->
+            when (req.url.toString()) {
+                MANIFEST_URL -> respond(manifestJson, HttpStatusCode.OK, jsonHeaders)
+                VERSION_URL -> respond(versionJson, HttpStatusCode.OK, jsonHeaders)
+                INDEX_URL -> respond(indexJson, HttpStatusCode.OK, jsonHeaders)
+                CLIENT_URL -> respond(ByteReadChannel(clientBytes), HttpStatusCode.OK)
+                else -> respond("missing", HttpStatusCode.NotFound)
+            }
+        }
+        val p = provisioner(HttpClient(engine))
+
+        val vanilla = p.ensureVanilla("1.21.1")
+        assertEquals(21, vanilla.javaMajor, "Mojang's javaVersion.majorVersion captured from the version json")
+
+        val resolved = p.ensureRuntime(mcVersion = "1.21.1", loaderName = null, loaderVersion = "")
+        assertEquals(21, resolved.javaMajor, "no-loader runtime inherits vanilla's declared major")
+    }
+
+    @Test
+    fun `loader profile declared javaMajor wins over Mojang's vanilla declaration`() = runTest {
+        val clientBytes = "C".toByteArray()
+        val indexJson = """{"objects":{}}"""
+        val indexSha = sha1(indexJson)
+        // Vanilla declares 21; a loader profile declares 25 -- loader wins. This is
+        // the forward shape Cleanroom needs (1.12.2 on Cleanroom -> Java 25, not 8).
+        val versionJson = """
+            {
+              "assetIndex": {"id":"17","sha1":"$indexSha","size":${indexJson.length},"url":"$INDEX_URL"},
+              "downloads": {"client": {"sha1":"${sha1(clientBytes)}","size":${clientBytes.size},"url":"$CLIENT_URL"}},
+              "javaVersion": {"majorVersion": 21},
+              "libraries": []
+            }
+        """.trimIndent()
+        val manifestJson = """{"versions":[{"id":"1.21.1","url":"$VERSION_URL"}]}"""
+
+        val engine = MockEngine { req ->
+            when (req.url.toString()) {
+                MANIFEST_URL -> respond(manifestJson, HttpStatusCode.OK, jsonHeaders)
+                VERSION_URL -> respond(versionJson, HttpStatusCode.OK, jsonHeaders)
+                INDEX_URL -> respond(indexJson, HttpStatusCode.OK, jsonHeaders)
+                CLIENT_URL -> respond(ByteReadChannel(clientBytes), HttpStatusCode.OK)
+                else -> respond("missing", HttpStatusCode.NotFound)
+            }
+        }
+        // Stub resolver returns a profile declaring Java 25; empty libraries -> no extra HTTP.
+        val stub = object : LoaderResolver {
+            override val loaderId = "stub"
+            override suspend fun resolve(mcVersion: String, loaderVersion: String) =
+                LoaderProfile(libraries = emptyList(), mainClass = "fake.Main", javaMajor = 25)
+        }
+        val p = RuntimeProvisioner(
+            librariesDir = librariesDir,
+            assetsDir = assetsDir,
+            clientProvider = HttpClientProvider { HttpClient(engine) },
+            json = json,
+            loaderRegistry = LoaderRegistry(listOf(stub)),
+            osName = "Linux",
+            versionManifestUrl = MANIFEST_URL,
+            resourcesBaseUrl = RES_BASE,
+        )
+
+        val resolved = p.ensureRuntime(mcVersion = "1.21.1", loaderName = "stub", loaderVersion = "any")
+        assertEquals(25, resolved.javaMajor, "loader profile.javaMajor must win over vanilla.javaMajor")
     }
 
     private companion object {

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolverTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolverTest.kt
@@ -27,7 +27,7 @@ class ModernInstallerResolverTest {
         json = Json { ignoreUnknownKeys = true },
         javaManager = object : IJavaManager {
             override suspend fun getJavaPath(version: String): Path = Path.of("/bin/java")
-            override suspend fun getJavaPathForMajor(javaMajor: Int): Path = Path.of("/bin/java")
+            override suspend fun getJavaPathForMajor(javaMajor: Int, onProgress: (String) -> Unit): Path = Path.of("/bin/java")
         },
         cacheDir = Files.createTempDirectory("modern-cache"),
         loaderId = "neoforge",

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolverTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/loader/ModernInstallerResolverTest.kt
@@ -27,6 +27,7 @@ class ModernInstallerResolverTest {
         json = Json { ignoreUnknownKeys = true },
         javaManager = object : IJavaManager {
             override suspend fun getJavaPath(version: String): Path = Path.of("/bin/java")
+            override suspend fun getJavaPathForMajor(javaMajor: Int): Path = Path.of("/bin/java")
         },
         cacheDir = Files.createTempDirectory("modern-cache"),
         loaderId = "neoforge",


### PR DESCRIPTION
## Summary
- `ResolvedRuntime` now carries a declared `javaMajor`, sourced from the loader's profile (override wins), Mojang's per-version `javaVersion`, or the version heuristic as a last resort. Same MC version on a different loader can need a different JDK (Cleanroom-1.12.2 wants Java 25, legacy-Forge-1.12.2 wants 8), so the version-keyed `detectJavaVersion` heuristic was the wrong shape.
- `IJavaManager.getJavaPathForMajor(Int)` is the major-keyed entry point. `getJavaPath(version)` becomes a thin version-keyed shortcut delegating to it, preserving the SC server path's call shape. The pack launch path moves JDK provisioning into `LauncherService` (after `ensureRuntime`), so it picks the JDK matching the declared major. `ILauncherService.launchPackClient` now takes `javaPathOverride: Path?` instead of an eagerly-resolved `javaExecutablePath`.
- Java 25 URLs wired (BellSoft Liberica 25.0.3+11, Adoptium Temurin 25.0.3+9) so the launcher can actually provision the major when a loader declares it.

## Test plan
- [x] Two focused tests in `RuntimeProvisionerTest` pin the precedence: vanilla captures Mojang's `javaVersion.majorVersion`; loader profile.javaMajor wins over vanilla.
- [x] `:client-launcher:test` + `:client-core:test` green.
- [x] Behaviour preserved for current loaders: 1.17+ vanilla declares the same major the heuristic would have produced; pre-1.17 falls back to the heuristic exactly as before. No-op for the verified live launches (NeoForge 1.21.1, Forge 1.12.2, Fabric 1.20.1).