### PR TITLE
fix(launcher): re-auth before pack spawn so SC join sees a fresh token

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
@@ -1,5 +1,6 @@
 package hivens.core.api.dto.smrt
 
+import hivens.core.data.PackAuthRequirement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,9 +20,46 @@ data class SmrtPackManifest(
     val minecraft: SmrtMinecraft,
     val loader: SmrtLoader,
     val java: SmrtJava,
+    /**
+     * Auth provider the pack requires the user to be signed in with
+     * before launch. Absent for vanilla / offline-only packs; present
+     * (today only `smartycraft`) for packs bound to a specific game
+     * server. The launcher uses this to (a) gate Play on the right
+     * sign-in and (b) refresh the session right before spawn so a
+     * cold mod-load does not age the token out.
+     */
+    val auth: SmrtAuth? = null,
     val mods: List<SmrtModEntry> = emptyList(),
     val assets: List<SmrtAssetEntry> = emptyList(),
 )
+
+/**
+ * Wire shape of the optional `auth` block on a pack manifest.
+ * Discriminated by `kind` so the mirror can add provider variants
+ * (mojang / elyby / one_of) without breaking older clients --
+ * `ignoreUnknownKeys` on the decoder lets a future field land
+ * additively.
+ */
+@Serializable
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@kotlinx.serialization.json.JsonClassDiscriminator("kind")
+sealed class SmrtAuth {
+    @Serializable
+    @SerialName("smartycraft")
+    data class Smartycraft(
+        /** SC server id the join + auth bind to (e.g. `Industrial`). */
+        @SerialName("server_id") val serverId: String,
+    ) : SmrtAuth()
+}
+
+/**
+ * Bridge the wire-shape [SmrtAuth] to the domain
+ * [PackAuthRequirement] the launcher consumes. New provider variants
+ * land here as the mirror grows additional `kind` values.
+ */
+fun SmrtAuth.toDomain(): PackAuthRequirement = when (this) {
+    is SmrtAuth.Smartycraft -> PackAuthRequirement.SmartyCraft(serverId)
+}
 
 @Serializable
 data class SmrtMinecraft(val version: String)

--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
@@ -1,8 +1,20 @@
 package hivens.core.api.dto.smrt
 
 import hivens.core.data.PackAuthRequirement
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Wire shape of a v2 smrt mirror pack manifest. Mirrors the spec in
@@ -26,8 +38,13 @@ data class SmrtPackManifest(
      * (today only `smartycraft`) for packs bound to a specific game
      * server. The launcher uses this to (a) gate Play on the right
      * sign-in and (b) refresh the session right before spawn so a
-     * cold mod-load does not age the token out.
+     * cold mod-load does not age the token out. A future
+     * `kind` value the client does not recognise decodes to null
+     * (see [SmrtAuthLenientSerializer]) -- the launcher then treats
+     * the pack as unrestricted rather than failing the whole
+     * manifest parse.
      */
+    @Serializable(with = SmrtAuthLenientSerializer::class)
     val auth: SmrtAuth? = null,
     val mods: List<SmrtModEntry> = emptyList(),
     val assets: List<SmrtAssetEntry> = emptyList(),
@@ -41,8 +58,8 @@ data class SmrtPackManifest(
  * additively.
  */
 @Serializable
-@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
-@kotlinx.serialization.json.JsonClassDiscriminator("kind")
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("kind")
 sealed class SmrtAuth {
     @Serializable
     @SerialName("smartycraft")
@@ -59,6 +76,39 @@ sealed class SmrtAuth {
  */
 fun SmrtAuth.toDomain(): PackAuthRequirement = when (this) {
     is SmrtAuth.Smartycraft -> PackAuthRequirement.SmartyCraft(serverId)
+}
+
+/**
+ * Wire decoder that accepts the known [SmrtAuth] variants and silently
+ * folds any other `kind` value (or a malformed payload) to null --
+ * forward-compat for mirror manifests that gain `mojang` / `elyby` /
+ * other providers before the client learns them. Without this the
+ * default sealed-class serializer would throw on unknown discriminator
+ * and abort the entire [SmrtPackManifest] decode, breaking browse +
+ * install for older clients.
+ *
+ * Encoding stays on the standard sealed path so writing a known
+ * requirement round-trips byte-identically.
+ */
+object SmrtAuthLenientSerializer : KSerializer<SmrtAuth?> {
+    private val delegate = SmrtAuth.serializer().nullable
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun deserialize(decoder: Decoder): SmrtAuth? {
+        val jsonDecoder = decoder as? JsonDecoder ?: return delegate.deserialize(decoder)
+        val element = jsonDecoder.decodeJsonElement()
+        if (element is JsonNull) return null
+        val obj = element as? JsonObject ?: return null
+        val kind = obj["kind"]?.jsonPrimitive?.contentOrNull
+        return when (kind) {
+            "smartycraft" -> jsonDecoder.json.decodeFromJsonElement(SmrtAuth.Smartycraft.serializer(), obj)
+            else          -> null
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: SmrtAuth?) {
+        delegate.serialize(encoder, value)
+    }
 }
 
 @Serializable
@@ -91,8 +141,8 @@ data class SmrtAssetEntry(
 )
 
 @Serializable
-@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
-@kotlinx.serialization.json.JsonClassDiscriminator("type")
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("type")
 sealed class SmrtSource {
     @Serializable
     @SerialName("modrinth")

--- a/client-core/src/main/kotlin/hivens/core/data/CachedManifestSnapshot.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/CachedManifestSnapshot.kt
@@ -20,4 +20,11 @@ data class CachedManifestSnapshot(
     val loaderName: String,
     val loaderVersion: String,
     val javaMajor: Int,
+    /**
+     * Which auth provider the launcher must have a live session for
+     * before spawning this pack. Null = no precondition (vanilla,
+     * future offline-only packs); existing serialized instances
+     * predate this field and read back as null cleanly.
+     */
+    val authRequirement: PackAuthRequirement? = null,
 )

--- a/client-core/src/main/kotlin/hivens/core/data/PackAuthRequirement.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackAuthRequirement.kt
@@ -1,0 +1,47 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Auth provider a pack needs the user to be signed in with before
+ * the game process is spawned. Carried on
+ * [CachedManifestSnapshot.authRequirement] -- null means the pack
+ * launches without an auth precondition (vanilla, future offline-only
+ * packs).
+ *
+ * The launcher uses this for two things on a Play click:
+ *   1. Precondition gate -- if the user is not signed in with the
+ *      required provider, the spawn is refused with a friendly
+ *      surface ("this pack needs <provider>") instead of starting the
+ *      game and failing later with a stale-token error.
+ *   2. Session refresh -- when the provider IS available, the
+ *      launcher re-authenticates right before spawn so the game's
+ *      first server join sees a fresh token (a cold mod-load can
+ *      take minutes; server-side sessions age out in the meantime).
+ *
+ * Today the launcher only knows [SmartyCraft]. Additional providers
+ * (Mojang, Elyby, OneOf, ...) land alongside the auth SPI
+ * extraction; existing serialized snapshots without `authRequirement`
+ * stay valid (the field is nullable and defaults to null).
+ */
+@Serializable
+sealed interface PackAuthRequirement {
+    /**
+     * Pack joins a SmartyCraft game server identified by [serverId].
+     * The launcher re-runs `authService.login(player, pass, serverId)`
+     * before spawn -- mirrors the SC server-list launch path.
+     */
+    @Serializable
+    data class SmartyCraft(val serverId: String) : PackAuthRequirement {
+        companion object {
+            /**
+             * Stable provider identifier the UI uses to look up a
+             * localized name (`AppStrings.providerSmartycraft`) and
+             * the launcher logs to tag missing-provider errors.
+             * Lives here so the launcher, UI, and tests reference one
+             * source of truth.
+             */
+            const val PROVIDER_KEY: String = "smartycraft"
+        }
+    }
+}

--- a/client-core/src/main/kotlin/hivens/core/data/PackAuthRequirement.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackAuthRequirement.kt
@@ -35,11 +35,14 @@ sealed interface PackAuthRequirement {
     data class SmartyCraft(val serverId: String) : PackAuthRequirement {
         companion object {
             /**
-             * Stable provider identifier the UI uses to look up a
-             * localized name (`AppStrings.providerSmartycraft`) and
-             * the launcher logs to tag missing-provider errors.
-             * Lives here so the launcher, UI, and tests reference one
-             * source of truth.
+             * Stable provider identifier shared by the launcher and
+             * the UI. Carried on `LaunchError.MissingAuthProvider`;
+             * each locale's `stateMissingAuthProvider(providerKey)`
+             * and `notifReasonMissingAuthProvider(providerKey)` keys
+             * the localized string off this constant. Lives here so
+             * the three sites (launcher controller, UI rendering,
+             * tests) reference one source of truth instead of
+             * trading bare strings.
              */
             const val PROVIDER_KEY: String = "smartycraft"
         }

--- a/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
@@ -2,6 +2,7 @@ package hivens.launcher
 
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
+import hivens.core.api.dto.smrt.toDomain
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.CachedManifestSnapshot
 import hivens.core.data.ContentToggle
@@ -95,6 +96,7 @@ class PackInstaller(
                 loaderName       = manifest.loader.name,
                 loaderVersion    = manifest.loader.version,
                 javaMajor        = manifest.java.major,
+                authRequirement  = manifest.auth?.toDomain(),
             ),
         )
         repository.put(instance)

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
@@ -27,4 +27,14 @@ sealed class LaunchError {
 
     /** Auth call failed for a non-2FA reason (network, server reject, etc.). */
     data class AuthFail(val cause: String?) : LaunchError()
+
+    /**
+     * Pack declares an auth requirement the user has no live session
+     * for. The UI renders a "sign in with <provider> to play this
+     * pack" hint -- distinct from [AuthFail] (where the user IS
+     * signed in but the call failed) and [TwoFactorExpired] (where
+     * the cached session is unusable). [providerKey] is a stable
+     * identifier the UI maps to a localized provider name.
+     */
+    data class MissingAuthProvider(val providerKey: String) : LaunchError()
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -367,7 +367,19 @@ class LauncherController(
                 val (manifestSnapshot, refreshedInstance) =
                     resolveOrFetchManifest(packInstance)
 
-                // 2. Auth requirement: refresh the session right before
+                // 2. Local sanity: instance directory must exist before
+                // we run a network auth round. A broken instance would
+                // otherwise burn an SC login (and on 2FA accounts a
+                // prompt) only to bail right after with the same error.
+                val clientDir = dataDirectory
+                    .resolve("instances")
+                    .resolve(refreshedInstance.instanceDirName)
+                if (!Files.exists(clientDir)) {
+                    fail(LaunchError.OfflineNoClient)
+                    return@launch
+                }
+
+                // 3. Auth requirement: refresh the session right before
                 // spawn so a cold mod-load (server-side SC tokens age out
                 // in ~minutes) does not invalidate the join. Mirrors the
                 // SC server path's pre-spawn re-auth. Packs that declare
@@ -382,7 +394,7 @@ class LauncherController(
                         ?: return@launch
                 }
 
-                // 3. Java override. The pack launch path picks the LOADER-declared
+                // 4. Java override. The pack launch path picks the LOADER-declared
                 // Java itself (resolved.javaMajor) from the resolved runtime --
                 // same MC + different loader can need different Java (Cleanroom-
                 // 1.12.2 -> 25 vs legacy-Forge-1.12.2 -> 8), so the version-keyed
@@ -393,20 +405,10 @@ class LauncherController(
                     ?.takeIf { it.isNotEmpty() }
                     ?.let { Path.of(it) }
 
-                // 4. Spawn. Pack-centric clientRoot lives under
-                // `<dataDir>/instances/<instanceDirName>`, not under
-                // `<dataDir>/clients/<serverId>` like the SC flow.
+                // 5. Spawn. clientDir was validated up front (step 2).
                 setStage(PrepareStage.LAUNCH, 0.95f)
                 ActionRing.record("Game running: ${packInstance.displayName}")
                 emit(LaunchLogEvent.Launching)
-
-                val clientDir = dataDirectory
-                    .resolve("instances")
-                    .resolve(refreshedInstance.instanceDirName)
-                if (!Files.exists(clientDir)) {
-                    fail(LaunchError.OfflineNoClient)
-                    return@launch
-                }
 
                 val process = launcherService.launchPackClient(
                     sessionData          = session,

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -3,7 +3,9 @@ package hivens.launcher.launch
 import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.*
 import hivens.core.api.model.ServerProfile
+import hivens.core.api.dto.smrt.toDomain
 import hivens.core.data.CachedManifestSnapshot
+import hivens.core.data.PackAuthRequirement
 import hivens.core.data.PackInstance
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData
@@ -361,11 +363,26 @@ class LauncherController(
                 // 1. Resolve the manifest snapshot. Stored on the
                 // instance after install; one-shot fetch + write-back
                 // covers instances that predate the field.
-                setStage(PrepareStage.SYNC, 0.3f)
+                setStage(PrepareStage.SYNC, 0.2f)
                 val (manifestSnapshot, refreshedInstance) =
                     resolveOrFetchManifest(packInstance)
 
-                // 2. Java override. The pack launch path picks the LOADER-declared
+                // 2. Auth requirement: refresh the session right before
+                // spawn so a cold mod-load (server-side SC tokens age out
+                // in ~minutes) does not invalidate the join. Mirrors the
+                // SC server path's pre-spawn re-auth. Packs that declare
+                // no requirement (vanilla, future offline-only) pass
+                // through untouched.
+                val authRequirement = manifestSnapshot.authRequirement
+                    ?: fallbackAuthRequirement(refreshedInstance)
+                var session = currentSession
+                if (authRequirement != null) {
+                    setStage(PrepareStage.AUTH, 0.4f)
+                    session = preparePackAuth(authRequirement, currentSession, refreshedInstance)
+                        ?: return@launch
+                }
+
+                // 3. Java override. The pack launch path picks the LOADER-declared
                 // Java itself (resolved.javaMajor) from the resolved runtime --
                 // same MC + different loader can need different Java (Cleanroom-
                 // 1.12.2 -> 25 vs legacy-Forge-1.12.2 -> 8), so the version-keyed
@@ -376,7 +393,7 @@ class LauncherController(
                     ?.takeIf { it.isNotEmpty() }
                     ?.let { Path.of(it) }
 
-                // 3. Spawn. Pack-centric clientRoot lives under
+                // 4. Spawn. Pack-centric clientRoot lives under
                 // `<dataDir>/instances/<instanceDirName>`, not under
                 // `<dataDir>/clients/<serverId>` like the SC flow.
                 setStage(PrepareStage.LAUNCH, 0.95f)
@@ -392,7 +409,7 @@ class LauncherController(
                 }
 
                 val process = launcherService.launchPackClient(
-                    sessionData          = currentSession,
+                    sessionData          = session,
                     manifest             = manifestSnapshot,
                     runtime              = refreshedInstance.runtime,
                     clientRootPath       = clientDir,
@@ -473,11 +490,90 @@ class LauncherController(
             loaderName       = manifest.loader.name,
             loaderVersion    = manifest.loader.version,
             javaMajor        = manifest.java.major,
+            authRequirement  = manifest.auth?.toDomain(),
         )
         val refreshed = instance.copy(cachedManifest = snapshot)
         runCatching { packRepository.put(refreshed) }
             .onFailure { logger.warn("Failed to persist cachedManifest for ${instance.id}", it) }
         return snapshot to refreshed
+    }
+
+    /**
+     * Run the pack-side auth refresh, mirroring the SC server-list
+     * path's pre-spawn re-auth (see [launch], around the AUTH stage).
+     * Returns the refreshed [SessionData], a 2FA-fallback session
+     * with the cached manifest attached, or null after [fail] has
+     * already set the error state -- the caller bails on null.
+     *
+     * Precondition: missing player + password for an SC requirement
+     * fails with [LaunchError.MissingAuthProvider] rather than
+     * spawning the game and waiting for the SC join to reject the
+     * stale token; the surface is friendlier and the diagnosis is
+     * unambiguous.
+     */
+    private suspend fun preparePackAuth(
+        requirement: PackAuthRequirement,
+        currentSession: SessionData,
+        instance: PackInstance,
+    ): SessionData? {
+        when (requirement) {
+            is PackAuthRequirement.SmartyCraft -> {
+                val saved = credentialsManager.load()
+                val pass = saved?.cachedPassword ?: currentSession.cachedPassword
+                val playerName = currentSession.playerName.ifBlank { saved?.playerName ?: "" }
+                if (playerName.isBlank() || pass.isNullOrEmpty()) {
+                    ActionRing.record(
+                        "Pack launch ${instance.displayName}: missing SC credentials for '${requirement.serverId}'",
+                    )
+                    fail(LaunchError.MissingAuthProvider(PackAuthRequirement.SmartyCraft.PROVIDER_KEY))
+                    return null
+                }
+                return try {
+                    val fresh = authService.login(playerName, pass, requirement.serverId)
+                    emit(LaunchLogEvent.AuthSucceeded(fresh.uuid))
+                    fresh
+                } catch (_: TwoFactorRequiredException) {
+                    val cached = manifestCache.loadManifest(requirement.serverId)
+                    if (cached != null) {
+                        ActionRing.record(
+                            "Pack launch ${instance.displayName}: 2FA account, using cached manifest for '${requirement.serverId}'",
+                        )
+                        currentSession.copy(fileManifest = cached)
+                    } else {
+                        ActionRing.record(
+                            "Pack launch ${instance.displayName}: 2FA + no cached manifest for '${requirement.serverId}' -- re-login required",
+                        )
+                        fail(LaunchError.TwoFactorExpired)
+                        null
+                    }
+                } catch (e: Exception) {
+                    // Non-2FA login failure: log + keep the existing
+                    // session. Same graceful-degradation as the SC
+                    // server path -- a real expired token surfaces as
+                    // a more specific reject from the game itself.
+                    emit(LaunchLogEvent.AuthFailed(e.message))
+                    currentSession
+                }
+            }
+        }
+    }
+
+    /**
+     * Synthesize an [PackAuthRequirement] for SC-bound packs whose
+     * mirror manifest has not yet been updated with an explicit
+     * `auth` block. Recognises the shipping SC pack identities by
+     * name; new packs added here as they go live until the mirror
+     * authors fill in `auth: { kind: smartycraft, server_id: ... }`
+     * and this map drains naturally.
+     */
+    private fun fallbackAuthRequirement(instance: PackInstance): PackAuthRequirement? {
+        val matchesIndustrial = listOf(instance.displayName, instance.packRef.id)
+            .any { it.equals("Industrial", ignoreCase = true) }
+        return if (matchesIndustrial) {
+            PackAuthRequirement.SmartyCraft("Industrial")
+        } else {
+            null
+        }
     }
 
     /**

--- a/client-launcher/src/test/kotlin/hivens/launcher/JsonPackRepositoryTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JsonPackRepositoryTest.kt
@@ -1,10 +1,13 @@
 package hivens.launcher
 
+import hivens.core.data.CachedManifestSnapshot
 import hivens.core.data.ContentToggle
 import hivens.core.data.InstanceRuntime
+import hivens.core.data.PackAuthRequirement
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
 import hivens.core.data.PackReference
+import kotlin.test.assertIs
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -113,6 +116,53 @@ class JsonPackRepositoryTest {
 
         repo.delete("id-1")
         assertEquals(0, flow.first().size)
+    }
+
+    @Test
+    fun `cachedManifest with SC auth requirement round-trips through the repo`() = runBlocking {
+        // The wire SmrtAuth uses @JsonClassDiscriminator("kind"); the
+        // domain PackAuthRequirement uses the default ("type"). With two
+        // different discriminators in play on the same repo Json config,
+        // a misconfigured serializer module would silently drop the
+        // requirement on the way to disk or fail to decode it back. This
+        // pins the round-trip end-to-end through the real repository.
+        val original = sampleInstance(id = "id-sc", name = "Industrial").copy(
+            cachedManifest = CachedManifestSnapshot(
+                minecraftVersion = "1.12.2",
+                loaderName       = "forge",
+                loaderVersion    = "14.23.5.2922",
+                javaMajor        = 8,
+                authRequirement  = PackAuthRequirement.SmartyCraft("Industrial"),
+            ),
+        )
+        val repo = JsonPackRepository(file, json)
+        repo.put(original)
+
+        val reloaded = JsonPackRepository(file, json).get("id-sc")
+        assertNotNull(reloaded)
+        val req = reloaded.cachedManifest?.authRequirement
+        assertIs<PackAuthRequirement.SmartyCraft>(req)
+        assertEquals("Industrial", req.serverId)
+        assertEquals(original, reloaded, "the full snapshot must round-trip byte-equal")
+    }
+
+    @Test
+    fun `cachedManifest without auth requirement round-trips with null`() = runBlocking {
+        // Backward compat: instances persisted before the auth field
+        // existed have authRequirement = null and stay null on reload.
+        val original = sampleInstance(id = "id-vanilla", name = "Vanilla").copy(
+            cachedManifest = CachedManifestSnapshot(
+                minecraftVersion = "1.21.1",
+                loaderName       = "vanilla",
+                loaderVersion    = "1.21.1",
+                javaMajor        = 21,
+            ),
+        )
+        val repo = JsonPackRepository(file, json)
+        repo.put(original)
+        val reloaded = JsonPackRepository(file, json).get("id-vanilla")
+        assertNotNull(reloaded)
+        assertNull(reloaded.cachedManifest?.authRequirement)
     }
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -10,6 +10,7 @@ import hivens.core.api.interfaces.IPackRepository
 import hivens.core.api.interfaces.ISettingsService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.FileManifest
+import hivens.core.data.PackAuthRequirement
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData
 import hivens.core.security.IKeyringStorage
@@ -275,17 +276,20 @@ class LauncherControllerTest {
             )
         } returns process
 
-        // PackInstance with cachedManifest already filled. Controller
-        // must skip the SmrtPackClient fetch entirely.
+        // PackInstance with cachedManifest already filled AND no auth
+        // requirement -- the pass-through case. SC-bound packs are
+        // covered separately further down; this test asserts the
+        // launch flow for vanilla / future offline-only packs lands
+        // in Idle without ever calling authService.
         val instance = hivens.core.data.PackInstance(
             id                    = "i-1",
             packRef               = hivens.core.data.PackReference(
                 origin  = hivens.core.data.PackOrigin.Mirror,
-                id      = "Industrial",
+                id      = "modern-explorer",
                 version = "2026.05.26.1",
             ),
-            displayName           = "Industrial",
-            instanceDirName       = "Industrial-i-1",
+            displayName           = "Modern Explorer",
+            instanceDirName       = "modern-explorer-i-1",
             createdAtEpoch        = 0L,
             lastPlayedEpochOrZero = 0L,
             pinnedPackVersion     = "2026.05.26.1",
@@ -319,6 +323,187 @@ class LauncherControllerTest {
         // header) and the launch coroutine would have thrown.
         coVerify(exactly = 1) { packRepository.put(any()) }
         assertTrue(captured.captured.lastPlayedEpochOrZero > 0)
+    }
+
+    /**
+     * Build an SC-bound mirror pack with a cached manifest declaring
+     * an explicit [PackAuthRequirement.SmartyCraft] target. The
+     * matching instance dir is materialised in the sandbox so the
+     * controller's "client dir missing" guard passes.
+     */
+    private fun scBoundPackInstance(
+        id: String = "i-sc",
+        displayName: String = "TestSC",
+        packId: String = "test-sc",
+        serverId: String = "Industrial",
+        authRequirement: PackAuthRequirement? = PackAuthRequirement.SmartyCraft(serverId),
+    ): hivens.core.data.PackInstance {
+        val instance = hivens.core.data.PackInstance(
+            id                    = id,
+            packRef               = hivens.core.data.PackReference(
+                origin  = hivens.core.data.PackOrigin.Mirror,
+                id      = packId,
+                version = "v1",
+            ),
+            displayName           = displayName,
+            instanceDirName       = "$packId-$id",
+            createdAtEpoch        = 0L,
+            lastPlayedEpochOrZero = 0L,
+            pinnedPackVersion     = "v1",
+            cachedManifest        = hivens.core.data.CachedManifestSnapshot(
+                minecraftVersion = "1.12.2",
+                loaderName       = "forge",
+                loaderVersion    = "14.23.5.2922",
+                javaMajor        = 8,
+                authRequirement  = authRequirement,
+            ),
+        )
+        Files.createDirectories(sandbox.resolve("instances").resolve(instance.instanceDirName))
+        return instance
+    }
+
+    @Test
+    fun `pack with SC requirement re-auths before spawn and uses the refreshed session`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+        coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/opt/jdk8/bin/java")
+
+        // Pre-populate the on-disk credentials so launchPackInstance
+        // resolves a cached password without round-tripping the
+        // keyring (relaxed mockk -> AES file fallback).
+        credentialsManager.save(
+            SessionData(
+                playerName     = "tester",
+                uuid           = "u",
+                accessToken    = "stale-token",
+                cachedPassword = "pw",
+            ),
+        )
+
+        val refreshed = SessionData(
+            playerName  = "tester",
+            uuid        = "u",
+            accessToken = "fresh-token",
+        )
+        coEvery { authService.login("tester", "pw", "Industrial") } returns refreshed
+
+        val process = mockk<Process>()
+        every { process.waitFor() } returns 0
+        val sessionPassed = slot<SessionData>()
+        coEvery {
+            launcherService.launchPackClient(
+                sessionData        = capture(sessionPassed),
+                manifest           = any(),
+                runtime            = any(),
+                clientRootPath     = any(),
+                javaPathOverride   = any(),
+                allocatedMemoryMB  = any(),
+                displayName        = any(),
+                onLog              = any(),
+            )
+        } returns process
+        coJustRun { packRepository.put(any()) }
+
+        val instance = scBoundPackInstance()
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "stale-token"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        assertEquals(LaunchState.Idle, controller.state.value)
+        assertEquals("fresh-token", sessionPassed.captured.accessToken, "spawn must use the refreshed session")
+        coVerify(exactly = 1) { authService.login("tester", "pw", "Industrial") }
+    }
+
+    @Test
+    fun `pack with SC requirement and no cached password fails with MissingAuthProvider`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+
+        // No credentialsManager.save() -- on-disk file does not
+        // exist, so load() returns null. The in-session also has no
+        // cachedPassword. The precondition must fail.
+
+        val instance = scBoundPackInstance()
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "tok"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertIs<LaunchState.Error>(state)
+        assertEquals(
+            LaunchError.MissingAuthProvider(PackAuthRequirement.SmartyCraft.PROVIDER_KEY),
+            state.reason,
+        )
+        coVerify(exactly = 0) {
+            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        coVerify(exactly = 0) { authService.login(any(), any(), any()) }
+    }
+
+    @Test
+    fun `pack with Industrial display name synthesizes SC requirement when manifest has none`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+
+        // No authRequirement on the manifest; the name-based fallback
+        // recognises "Industrial" and synthesizes SC("Industrial").
+        // Same no-password setup, so the precondition surfaces.
+        val instance = scBoundPackInstance(
+            packId          = "industrial",
+            displayName     = "Industrial",
+            authRequirement = null,
+        )
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "tok"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertIs<LaunchState.Error>(state)
+        assertEquals(
+            LaunchError.MissingAuthProvider(PackAuthRequirement.SmartyCraft.PROVIDER_KEY),
+            state.reason,
+            "Industrial fallback must drive the same precondition surface as an explicit requirement",
+        )
+    }
+
+    @Test
+    fun `pack with SC requirement and 2FA without cached manifest fails with TwoFactorExpired`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+        coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/opt/jdk8/bin/java")
+        credentialsManager.save(
+            SessionData(
+                playerName     = "tester",
+                uuid           = "u",
+                accessToken    = "stale-token",
+                cachedPassword = "pw",
+            ),
+        )
+        coEvery {
+            authService.login("tester", "pw", "Industrial")
+        } throws TwoFactorRequiredException(uid = "uid-stub", login = "tester")
+        // Real ManifestCache returns null for "Industrial" since no
+        // file was saved -- exactly the "no cached manifest" branch.
+
+        val instance = scBoundPackInstance()
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "stale-token"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertIs<LaunchState.Error>(state)
+        assertEquals(LaunchError.TwoFactorExpired, state.reason)
+        coVerify(exactly = 0) {
+            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any())
+        }
     }
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
@@ -1,5 +1,6 @@
 package hivens.launcher.smrt
 
+import hivens.core.api.dto.smrt.SmrtAuth
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
 import hivens.core.api.dto.smrt.SmrtSource
@@ -116,6 +117,92 @@ class SmrtManifestParseTest {
         assertNull(s.bannerUrl)
         assertTrue(s.galleryUrls.isEmpty())
         assertNull(s.descriptionMd)
+    }
+
+    @Test
+    fun `parses smartycraft auth block on a manifest`() {
+        val payload = """
+        {
+            "schema_version": 2,
+            "pack_id": "Industrial",
+            "pack_version": "2026.05.30.1",
+            "generated_at": "2026-05-30T00:00:00Z",
+            "minecraft": {"version": "1.12.2"},
+            "loader": {"name": "forge", "version": "14.23.5.2922"},
+            "java": {"major": 8},
+            "auth": {"kind": "smartycraft", "server_id": "Industrial"}
+        }
+        """.trimIndent()
+        val pm: SmrtPackManifest = json.decodeFromString(payload)
+        val auth = pm.auth
+        assertIs<SmrtAuth.Smartycraft>(auth)
+        assertEquals("Industrial", auth.serverId)
+    }
+
+    @Test
+    fun `unknown auth kind decodes as null without failing the whole manifest`() {
+        // Forward-compat: a mirror manifest carrying a future provider
+        // (mojang / elyby / etc.) must NOT abort the entire parse on
+        // older clients -- the launcher would lose browse + install.
+        // SmrtAuthLenientSerializer folds unknown kinds to null so the
+        // pack just appears unrestricted to the older client.
+        val payload = """
+        {
+            "schema_version": 2,
+            "pack_id": "FutureBound",
+            "pack_version": "2027.01.01",
+            "generated_at": "2027-01-01T00:00:00Z",
+            "minecraft": {"version": "1.21.4"},
+            "loader": {"name": "neoforge", "version": "21.4.99"},
+            "java": {"major": 21},
+            "auth": {"kind": "mojang", "client_id": "abcd1234"}
+        }
+        """.trimIndent()
+        val pm: SmrtPackManifest = json.decodeFromString(payload)
+        assertNull(pm.auth, "unknown auth.kind must decode as null, not throw")
+        assertEquals("FutureBound", pm.packId, "the rest of the manifest must decode normally")
+    }
+
+    @Test
+    fun `manifest without auth block parses with null and round-trips`() {
+        val payload = """
+        {
+            "schema_version": 2,
+            "pack_id": "Vanilla",
+            "pack_version": "2026.05.30.1",
+            "generated_at": "2026-05-30T00:00:00Z",
+            "minecraft": {"version": "1.21.1"},
+            "loader": {"name": "vanilla", "version": "1.21.1"},
+            "java": {"major": 21}
+        }
+        """.trimIndent()
+        val pm: SmrtPackManifest = json.decodeFromString(payload)
+        assertNull(pm.auth)
+
+        // Round-trip: a vanilla manifest stays vanilla.
+        val encoded = json.encodeToString(SmrtPackManifest.serializer(), pm)
+        val decoded: SmrtPackManifest = json.decodeFromString(encoded)
+        assertEquals(pm, decoded)
+    }
+
+    @Test
+    fun `smartycraft auth block round-trips byte-identically`() {
+        // Lock the encode path: writing a known requirement and reading
+        // it back yields the same object. Catches accidental regressions
+        // in SmrtAuthLenientSerializer.serialize.
+        val original = SmrtPackManifest(
+            schemaVersion = 2,
+            packId        = "Industrial",
+            packVersion   = "2026.05.30.1",
+            generatedAt   = "2026-05-30T00:00:00Z",
+            minecraft     = hivens.core.api.dto.smrt.SmrtMinecraft("1.12.2"),
+            loader        = hivens.core.api.dto.smrt.SmrtLoader("forge", "14.23.5.2922"),
+            java          = hivens.core.api.dto.smrt.SmrtJava(8),
+            auth          = SmrtAuth.Smartycraft("Industrial"),
+        )
+        val encoded = json.encodeToString(SmrtPackManifest.serializer(), original)
+        val decoded: SmrtPackManifest = json.decodeFromString(encoded)
+        assertEquals(original, decoded)
     }
 
     @Test

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -201,12 +201,13 @@ private fun localizeStage(stage: PrepareStage, s: hivens.ui.i18n.AppStrings): St
  * known terminal states.
  */
 private fun localizeError(error: LaunchError, s: hivens.ui.i18n.AppStrings): String = when (error) {
-    is LaunchError.ExitCode          -> s.stateExitCode(error.code)
-    is LaunchError.Internal          -> s.stateError(error.message)
-    is LaunchError.OfflineNoClient   -> s.stateOfflineNoClient
-    is LaunchError.OfflineNoManifest -> s.stateOfflineNoManifest
-    is LaunchError.TwoFactorExpired  -> s.auth2faExpired
-    is LaunchError.AuthFail          -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.ExitCode             -> s.stateExitCode(error.code)
+    is LaunchError.Internal             -> s.stateError(error.message)
+    is LaunchError.OfflineNoClient      -> s.stateOfflineNoClient
+    is LaunchError.OfflineNoManifest    -> s.stateOfflineNoManifest
+    is LaunchError.TwoFactorExpired     -> s.auth2faExpired
+    is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }
 
 /**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -46,6 +46,7 @@ interface AppStrings {
     val stateLaunching: String
     fun stateExitCode(code: Int): String
     fun stateError(msg: String): String
+    fun stateMissingAuthProvider(providerKey: String): String
 
     // --- Auth Success ---
     fun authSuccess(uuid: String): String
@@ -704,6 +705,7 @@ interface AppStrings {
     val notifReasonOfflineNoClient: String
     val notifReasonOfflineNoManifest: String
     val notifReasonTwoFactorExpired: String
+    fun notifReasonMissingAuthProvider(providerKey: String): String
 
     // --- Notification relative-time formatter (header label) ---
     val notifTimeNow: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -1,5 +1,7 @@
 package hivens.ui.i18n
 
+import hivens.core.data.PackAuthRequirement
+
 object EnglishStrings : AppStrings {
 
     // App
@@ -44,6 +46,12 @@ object EnglishStrings : AppStrings {
     override val stateLaunching   = "Starting process..."
     override fun stateExitCode(code: Int)  = "Game exited with code $code"
     override fun stateError(msg: String)   = "Error: $msg"
+    override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
+            "This pack needs a SmartyCraft account. Sign in to play."
+        else ->
+            "This pack needs to sign in with '$providerKey'."
+    }
     override fun authSuccess(uuid: String) = "Login successful. UUID: $uuid"
 
     // Profile
@@ -662,6 +670,10 @@ object EnglishStrings : AppStrings {
     override val notifReasonOfflineNoClient             = "Pack files missing on disk"
     override val notifReasonOfflineNoManifest           = "No cached manifest; go online once to sync"
     override val notifReasonTwoFactorExpired            = "Sign in again to refresh credentials"
+    override fun notifReasonMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY -> "Sign in to SmartyCraft to play this pack"
+        else                                          -> "Sign in with '$providerKey' to play this pack"
+    }
 
     override val notifTimeNow                           = "Now"
     override fun notifTimeSeconds(seconds: Long)        = "${seconds}s"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -1,5 +1,7 @@
 package hivens.ui.i18n
 
+import hivens.core.data.PackAuthRequirement
+
 object GermanStrings : AppStrings {
 
     // App
@@ -44,6 +46,12 @@ object GermanStrings : AppStrings {
     override val stateLaunching   = "Prozess starten..."
     override fun stateExitCode(code: Int)  = "Spiel mit Code $code beendet"
     override fun stateError(msg: String)   = "Fehler: $msg"
+    override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
+            "Dieses Pack braucht ein SmartyCraft-Konto. Bitte anmelden, um zu spielen."
+        else ->
+            "Dieses Pack erfordert eine Anmeldung bei '$providerKey'."
+    }
     override fun authSuccess(uuid: String) = "Anmeldung erfolgreich. UUID: $uuid"
 
     // Profile
@@ -665,6 +673,10 @@ object GermanStrings : AppStrings {
     override val notifReasonOfflineNoClient             = "Pack-Dateien fehlen auf der Platte"
     override val notifReasonOfflineNoManifest           = "Kein Manifest im Cache; einmal online gehen, um zu synchronisieren"
     override val notifReasonTwoFactorExpired            = "Bitte erneut anmelden, um die Anmeldedaten zu aktualisieren"
+    override fun notifReasonMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY -> "Bei SmartyCraft anmelden, um dieses Pack zu spielen"
+        else                                          -> "Anmeldung bei '$providerKey' nötig, um dieses Pack zu spielen"
+    }
 
     override val notifTimeNow                           = "Jetzt"
     override fun notifTimeSeconds(seconds: Long)        = "${seconds} s"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -1,5 +1,7 @@
 package hivens.ui.i18n
 
+import hivens.core.data.PackAuthRequirement
+
 object RussianStrings : AppStrings {
 
     // App
@@ -44,6 +46,12 @@ object RussianStrings : AppStrings {
     override val stateLaunching   = "Запуск процесса..."
     override fun stateExitCode(code: Int)  = "Игра закрылась с кодом $code"
     override fun stateError(msg: String)   = "Ошибка: $msg"
+    override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
+            "Этой сборке нужен аккаунт SmartyCraft. Войдите, чтобы играть."
+        else ->
+            "Этой сборке нужен вход в '$providerKey'."
+    }
     override fun authSuccess(uuid: String) = "Успешный вход. UUID: $uuid"
 
     // Profile
@@ -666,6 +674,10 @@ object RussianStrings : AppStrings {
     override val notifReasonOfflineNoClient             = "Файлы сборки отсутствуют на диске"
     override val notifReasonOfflineNoManifest           = "Нет кэша манифеста; выйди в сеть один раз для синхронизации"
     override val notifReasonTwoFactorExpired            = "Войди ещё раз, чтобы обновить учётные данные"
+    override fun notifReasonMissingAuthProvider(providerKey: String) = when (providerKey) {
+        PackAuthRequirement.SmartyCraft.PROVIDER_KEY -> "Войдите в SmartyCraft, чтобы играть на этой сборке"
+        else                                          -> "Нужен вход в '$providerKey', чтобы играть"
+    }
 
     override val notifTimeNow                           = "сейчас"
     override fun notifTimeSeconds(seconds: Long)        = "${seconds} с"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
@@ -75,10 +75,11 @@ fun LaunchLogCollector(
  * a global) so the caller controls which locale snapshot is used.
  */
 private fun localizeError(error: LaunchError, s: AppStrings): String = when (error) {
-    is LaunchError.ExitCode          -> s.stateExitCode(error.code)
-    is LaunchError.Internal          -> s.stateError(error.message)
-    is LaunchError.OfflineNoClient   -> s.stateOfflineNoClient
-    is LaunchError.OfflineNoManifest -> s.stateOfflineNoManifest
-    is LaunchError.TwoFactorExpired  -> s.auth2faExpired
-    is LaunchError.AuthFail          -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.ExitCode             -> s.stateExitCode(error.code)
+    is LaunchError.Internal             -> s.stateError(error.message)
+    is LaunchError.OfflineNoClient      -> s.stateOfflineNoClient
+    is LaunchError.OfflineNoManifest    -> s.stateOfflineNoManifest
+    is LaunchError.TwoFactorExpired     -> s.auth2faExpired
+    is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -195,15 +195,16 @@ class PackLaunchDriver(
     private fun iconUrlFor(pack: PackInstance): String? = null
 
     private fun humanReason(reason: LaunchError, s: AppStrings): String = when (reason) {
-        is LaunchError.ExitCode       -> s.notifReasonExitCode(reason.code)
-        is LaunchError.Internal       -> reason.message.ifBlank { null }
-                                            ?.let { s.notifReasonInternalDetail(it) }
-                                            ?: s.notifReasonInternal
-        is LaunchError.AuthFail       -> reason.cause?.ifBlank { null }
-                                            ?.let { s.notifReasonAuthFailDetail(it) }
-                                            ?: s.notifReasonAuthFail
-        LaunchError.OfflineNoClient   -> s.notifReasonOfflineNoClient
-        LaunchError.OfflineNoManifest -> s.notifReasonOfflineNoManifest
-        LaunchError.TwoFactorExpired  -> s.notifReasonTwoFactorExpired
+        is LaunchError.ExitCode            -> s.notifReasonExitCode(reason.code)
+        is LaunchError.Internal            -> reason.message.ifBlank { null }
+                                                ?.let { s.notifReasonInternalDetail(it) }
+                                                ?: s.notifReasonInternal
+        is LaunchError.AuthFail            -> reason.cause?.ifBlank { null }
+                                                ?.let { s.notifReasonAuthFailDetail(it) }
+                                                ?: s.notifReasonAuthFail
+        is LaunchError.MissingAuthProvider -> s.notifReasonMissingAuthProvider(reason.providerKey)
+        LaunchError.OfflineNoClient        -> s.notifReasonOfflineNoClient
+        LaunchError.OfflineNoManifest      -> s.notifReasonOfflineNoManifest
+        LaunchError.TwoFactorExpired       -> s.notifReasonTwoFactorExpired
     }
 }


### PR DESCRIPTION
## Why

Pack-centric Play passed the in-memory session straight to the spawn. A
cold mod-load of an Industrial-tier pack takes minutes; the SC-side
token aged out during the load and the in-game Multiplayer -> Connect
landed on "Недействительная сессия". The SC server-list path already
re-authenticates right before spawn for exactly this reason; the pack
path now does the same.

Reproduces tonight against Industrial: login -> pack launch -> ~5 min
cold mod-load -> Connect -> SC rejects.

## What

Pack manifests gain an optional `auth` block (today only `smartycraft`
with a `server_id`). The launcher carries it on the cached manifest
snapshot. Before spawn, `launchPackInstance`:

- With no requirement: pass-through, no auth call -- vanilla, future
  offline-only packs.
- With a SmartyCraft requirement and no cached credentials: surfaces
  `LaunchError.MissingAuthProvider` so the UI says "this pack needs
  SmartyCraft, sign in to play" instead of spawning and waiting for a
  stale-token reject.
- With a SmartyCraft requirement and cached credentials: runs
  `authService.login(player, pass, serverId)` and feeds the fresh
  session into `launchPackClient`. `TwoFactorRequiredException` falls
  back to the cached manifest like the SC server path does.

Existing mirror packs predate the manifest field. Until the mirror
authors fill it in, a name-based fallback synthesises
`SmartyCraft("Industrial")` for any pack whose display name or pack id
matches "Industrial" -- the only SC-bound pack live on the mirror
today. The map drains naturally as manifests get the `auth` block.

`PackAuthRequirement` is sealed for forward compatibility with future
providers (Mojang, Elyby, etc.). UI rendering and the launcher both
reference `PackAuthRequirement.SmartyCraft.PROVIDER_KEY` so the
localized strings track the type.

## Test plan

- [x] `:client-launcher:test` -- 4 new `LauncherControllerTest` cases:
  - re-auth before spawn uses the refreshed session
  - no cached password -> `MissingAuthProvider`
  - "Industrial" display name synthesises the SC requirement
  - 2FA without a cached manifest -> `TwoFactorExpired`
- [x] `:client-ui:compileKotlinDesktop` green; localized strings added
  for ru/en/de.
- [ ] Live Industrial cold-start: login, wait through the full mod-load,
  Connect -- SC must accept the fresh token.