### PR TITLE
feat(launcher+ui): optional-mods toggle system + checkbox UI

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
@@ -38,6 +38,14 @@ data class SmrtModEntry(
     val sha1: String,
     @SerialName("size_bytes") val sizeBytes: Long,
     val required: Boolean = true,
+    /**
+     * Install-time default for an OPTIONAL entry (`required = false`): whether
+     * it is enabled before the user touches it. Absent defaults to true, so an
+     * optional mod installs unless the curator explicitly opts it out (e.g. a
+     * mod that conflicts with a default-on one). Ignored for required entries,
+     * which are always installed.
+     */
+    @SerialName("default_enabled") val defaultEnabled: Boolean = true,
     val source: SmrtSource,
     val display: SmrtDisplay? = null,
 )

--- a/client-core/src/main/kotlin/hivens/core/data/OptionalContentRules.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/OptionalContentRules.kt
@@ -1,0 +1,73 @@
+package hivens.core.data
+
+import hivens.core.api.dto.smrt.SmrtModEntry
+
+/**
+ * Pure rules for a pack instance's optional mods, shared by the install/sync
+ * path and the toggle UI. A mod is OPTIONAL when `required = false`; required
+ * mods are always installed and never appear in the toggle list.
+ *
+ * State is a `filename -> enabled` view derived from [PackInstance.optionalContent]
+ * (a list of [ContentToggle]); the manifest's `default_enabled` is the fallback
+ * for an optional the user has not touched. Incompatibility is the mutual closure
+ * of each mod's `display.incompatibleWith`.
+ */
+object OptionalContentRules {
+
+    /** The optional entries of [mods], in manifest order. */
+    fun optionalMods(mods: List<SmrtModEntry>): List<SmrtModEntry> = mods.filter { !it.required }
+
+    /**
+     * Seed toggles for a fresh install: one [ContentToggle] per optional mod at
+     * its manifest `default_enabled`. Required mods are omitted (always on).
+     */
+    fun defaultToggles(mods: List<SmrtModEntry>): List<ContentToggle> =
+        optionalMods(mods).map { ContentToggle(it.filename, it.defaultEnabled) }
+
+    /**
+     * Effective `filename -> enabled` for the sync path. Required mods are always
+     * enabled; an optional uses the user's [toggles] entry, else its manifest
+     * `default_enabled`.
+     */
+    fun enabledState(mods: List<SmrtModEntry>, toggles: List<ContentToggle>): Map<String, Boolean> {
+        val userState = toggles.associate { it.entryId to it.enabled }
+        return mods.associate { mod ->
+            mod.filename to if (mod.required) true else (userState[mod.filename] ?: mod.defaultEnabled)
+        }
+    }
+
+    /**
+     * True when [a] and [b] declare each other (in either direction) under
+     * `display.incompatibleWith`. Mutual so the curator only has to mark one side.
+     */
+    fun conflicts(mods: List<SmrtModEntry>, a: String, b: String): Boolean {
+        if (a == b) return false
+        val byName = mods.associateBy { it.filename }
+        val aIncompat = byName[a]?.display?.incompatibleWith.orEmpty()
+        val bIncompat = byName[b]?.display?.incompatibleWith.orEmpty()
+        return b in aIncompat || a in bIncompat
+    }
+
+    /**
+     * Applies a single user toggle to [current], enforcing incompatibilities:
+     * enabling a mod disables every mod that conflicts with it. Disabling never
+     * cascades. Returns the new state (only optional + present entries change).
+     */
+    fun applyToggle(
+        mods: List<SmrtModEntry>,
+        current: Map<String, Boolean>,
+        filename: String,
+        enable: Boolean,
+    ): Map<String, Boolean> {
+        val next = current.toMutableMap()
+        next[filename] = enable
+        if (enable) {
+            for (other in mods) {
+                if (other.filename != filename && conflicts(mods, filename, other.filename)) {
+                    next[other.filename] = false
+                }
+            }
+        }
+        return next
+    }
+}

--- a/client-core/src/test/kotlin/hivens/core/data/OptionalContentRulesTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/data/OptionalContentRulesTest.kt
@@ -1,0 +1,71 @@
+package hivens.core.data
+
+import hivens.core.api.dto.smrt.SmrtDisplay
+import hivens.core.api.dto.smrt.SmrtModEntry
+import hivens.core.api.dto.smrt.SmrtSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OptionalContentRulesTest {
+
+    private fun mod(
+        filename: String,
+        required: Boolean = true,
+        defaultEnabled: Boolean = true,
+        incompatibleWith: List<String> = emptyList(),
+    ) = SmrtModEntry(
+        filename = filename,
+        sha1 = "x",
+        sizeBytes = 1,
+        required = required,
+        defaultEnabled = defaultEnabled,
+        source = SmrtSource.SmrtStatic("https://example/$filename"),
+        display = if (incompatibleWith.isEmpty()) null else SmrtDisplay(incompatibleWith = incompatibleWith),
+    )
+
+    private val mods = listOf(
+        mod("required.jar"),
+        mod("foamfix.jar", required = false, defaultEnabled = false, incompatibleWith = listOf("mixinbooter.jar")),
+        mod("mixinbooter.jar", required = false, defaultEnabled = true),
+    )
+
+    @Test
+    fun `defaultToggles lists only optionals at their default_enabled`() {
+        val toggles = OptionalContentRules.defaultToggles(mods)
+        assertEquals(2, toggles.size)
+        assertFalse(toggles.any { it.entryId == "required.jar" }, "required mods are never toggles")
+        assertEquals(false, toggles.first { it.entryId == "foamfix.jar" }.enabled)
+        assertEquals(true, toggles.first { it.entryId == "mixinbooter.jar" }.enabled)
+    }
+
+    @Test
+    fun `enabledState forces required on and uses toggle-or-default for optionals`() {
+        val state = OptionalContentRules.enabledState(mods, listOf(ContentToggle("foamfix.jar", true)))
+        assertEquals(true, state["required.jar"], "required always on")
+        assertEquals(true, state["foamfix.jar"], "user toggle wins over default")
+        assertEquals(true, state["mixinbooter.jar"], "untouched optional uses default_enabled")
+    }
+
+    @Test
+    fun `conflicts is mutual even when only one side declares it`() {
+        assertTrue(OptionalContentRules.conflicts(mods, "foamfix.jar", "mixinbooter.jar"))
+        assertTrue(OptionalContentRules.conflicts(mods, "mixinbooter.jar", "foamfix.jar"))
+        assertFalse(OptionalContentRules.conflicts(mods, "foamfix.jar", "foamfix.jar"))
+        assertFalse(OptionalContentRules.conflicts(mods, "required.jar", "mixinbooter.jar"))
+    }
+
+    @Test
+    fun `applyToggle enabling disables conflicts and disabling does not cascade`() {
+        val current = mapOf("foamfix.jar" to false, "mixinbooter.jar" to true)
+
+        val afterEnable = OptionalContentRules.applyToggle(mods, current, "foamfix.jar", true)
+        assertEquals(true, afterEnable["foamfix.jar"])
+        assertEquals(false, afterEnable["mixinbooter.jar"], "enabling foamfix disables the incompatible mixinbooter")
+
+        val afterDisable = OptionalContentRules.applyToggle(mods, afterEnable, "foamfix.jar", false)
+        assertEquals(false, afterDisable["foamfix.jar"])
+        assertEquals(false, afterDisable["mixinbooter.jar"], "disabling foamfix must not silently re-enable mixinbooter")
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
@@ -4,8 +4,8 @@ import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.CachedManifestSnapshot
-import hivens.core.data.ContentToggle
 import hivens.core.data.InstanceRuntime
+import hivens.core.data.OptionalContentRules
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
 import hivens.core.data.PackReference
@@ -58,10 +58,15 @@ class PackInstaller(
         log.info("install: pack={} version={} -> instance={} dir={}",
             packId, manifest.packVersion, instanceId, clientDir)
 
+        // Optional-content defaults from the manifest: each optional mod
+        // (required=false) seeds at its default_enabled. Sync places toggled-off
+        // optionals as `.disabled` so a later flip is a rename, not a re-download.
+        val optionalToggles = OptionalContentRules.defaultToggles(manifest.mods)
         syncService.sync(
             packId    = packId,
             clientDir = clientDir,
             progress  = progress,
+            enabledState = OptionalContentRules.enabledState(manifest.mods, optionalToggles),
         )
 
         // Provision the canonical runtime (vanilla + loader libraries + client +
@@ -87,7 +92,7 @@ class PackInstaller(
             lastPlayedEpochOrZero = 0L,
             pinnedPackVersion     = manifest.packVersion,
             runtime               = InstanceRuntime(),
-            optionalContent       = emptyList<ContentToggle>(),
+            optionalContent       = optionalToggles,
             forkedFrom            = null,
             notes                 = "",
             cachedManifest        = CachedManifestSnapshot(

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -3,7 +3,10 @@ package hivens.launcher.launch
 import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.*
 import hivens.core.api.model.ServerProfile
+import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.data.CachedManifestSnapshot
+import hivens.core.data.ContentToggle
+import hivens.core.data.OptionalContentRules
 import hivens.core.data.PackInstance
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData
@@ -13,6 +16,7 @@ import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
 import hivens.launcher.di.AppCoroutineScopeHook
 import hivens.launcher.smrt.SmrtPackClient
+import hivens.launcher.smrt.SmrtSyncService
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -53,11 +57,37 @@ class LauncherController(
     private val profileManager: ProfileManager,
     private val packRepository: IPackRepository,
     private val smrtPackClient: SmrtPackClient,
+    private val smrtSyncService: SmrtSyncService,
     private val dataDirectory: Path,
     private val appScope: CoroutineScope,
 ) {
 
     private val logger = LoggerFactory.getLogger(LauncherController::class.java)
+
+    /**
+     * Persists a pack instance's optional-content [toggles] and re-labels the
+     * already-downloaded mods on disk to match -- no network, a flip is just a
+     * `.disabled` rename. The caller passes the [manifest] it already loaded for
+     * the Content tab. Returns the updated instance for the UI to adopt.
+     */
+    suspend fun setOptionalMods(
+        instance: PackInstance,
+        manifest: SmrtPackManifest,
+        toggles: List<ContentToggle>,
+    ): PackInstance {
+        val updated = instance.copy(optionalContent = toggles)
+        packRepository.put(updated)
+        val clientDir = dataDirectory.resolve("instances").resolve(instance.instanceDirName)
+        withContext(Dispatchers.IO) {
+            smrtSyncService.relabel(
+                clientDir,
+                manifest.mods,
+                OptionalContentRules.enabledState(manifest.mods, toggles),
+            )
+        }
+        ActionRing.record("Optional content updated: ${instance.displayName}")
+        return updated
+    }
 
     private val _state = MutableStateFlow<LaunchState>(LaunchState.Idle)
     val state: StateFlow<LaunchState> = _state.asStateFlow()

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -4,9 +4,11 @@ import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.*
 import hivens.core.api.model.ServerProfile
 import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.toDomain
 import hivens.core.data.CachedManifestSnapshot
 import hivens.core.data.ContentToggle
 import hivens.core.data.OptionalContentRules
+import hivens.core.data.PackAuthRequirement
 import hivens.core.data.PackInstance
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -104,6 +104,29 @@ class SmrtSyncService(
         writeSourceMarker(marker, SOURCE_MIRROR)
     }
 
+    /**
+     * Re-labels already-downloaded optional mods to match [enabledState] with NO
+     * network: an active jar that should be off becomes `.disabled` and vice
+     * versa. The toggle UI calls this -- the bytes are already on disk, only the
+     * name (and thus whether Forge loads it) changes. A variant that is missing
+     * on disk is left for the next full sync to fetch.
+     */
+    fun relabel(clientDir: Path, mods: List<SmrtModEntry>, enabledState: Map<String, Boolean>) {
+        val modsDir = clientDir.resolve("mods")
+        if (!Files.isDirectory(modsDir)) return
+        for (mod in mods) {
+            val enabled = enabledState[mod.filename] ?: (mod.required || mod.defaultEnabled)
+            val active = resolveSafe(modsDir, mod.filename, "mod ${mod.filename}")
+            val disabled = resolveSafe(modsDir, "${mod.filename}.disabled", "mod ${mod.filename}")
+            val from = if (enabled) disabled else active
+            val to = if (enabled) active else disabled
+            if (Files.exists(from) && !Files.exists(to)) {
+                runCatching { Files.move(from, to, StandardCopyOption.REPLACE_EXISTING) }
+                    .onFailure { log.warn("smrt relabel: failed to move {} -> {}", from, to, it) }
+            }
+        }
+    }
+
     private fun pruneOrphanMods(clientDir: Path, expected: Set<String>) {
         val modsDir = clientDir.resolve("mods")
         if (!Files.isDirectory(modsDir)) return

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -13,6 +13,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.Comparator
 
@@ -33,10 +34,17 @@ class SmrtSyncService(
 ) {
     private val log = LoggerFactory.getLogger(SmrtSyncService::class.java)
 
+    /**
+     * [enabledState] maps a mod `filename` to whether it should be active.
+     * Required mods are always active regardless; an optional absent from the
+     * map falls back to its manifest `default_enabled`. Empty map = install
+     * every mod at its manifest default (the pre-toggle behaviour).
+     */
     suspend fun sync(
         packId: String,
         clientDir: Path,
         progress: ((current: Int, total: Int, filename: String) -> Unit)? = null,
+        enabledState: Map<String, Boolean> = emptyMap(),
     ) = withContext(Dispatchers.IO) {
         val manifest = client.fetchManifest(packId)
         log.info(
@@ -77,7 +85,8 @@ class SmrtSyncService(
         for (mod in manifest.mods) {
             current++
             progress?.invoke(current, total, mod.filename)
-            syncMod(mod, clientDir)
+            val enabled = enabledState[mod.filename] ?: (mod.required || mod.defaultEnabled)
+            syncMod(mod, clientDir, enabled)
         }
         for (asset in manifest.assets) {
             current++
@@ -90,7 +99,7 @@ class SmrtSyncService(
         // without touching the marker, so the wipe gate saw a stale
         // "mirror" value). Only top-level mods/{expected_filename}
         // entries survive.
-        pruneOrphanMods(clientDir, manifest.mods.map { it.filename }.toSet())
+        pruneOrphanMods(clientDir, manifest.mods.flatMap { listOf(it.filename, "${it.filename}.disabled") }.toSet())
 
         writeSourceMarker(marker, SOURCE_MIRROR)
     }
@@ -146,15 +155,26 @@ class SmrtSyncService(
     }
 
     /**
-     * Mods land at `mods/{filename}` regardless of SC's dual-tier
-     * convention. Forge 1.12.2 scans both `mods/` and
-     * `mods/{mcversion}/`, so flat placement still loads. Optional
-     * mods that the user didn't enable (required=false and no future
-     * toggle infrastructure yet) are still pulled in this v0 cut --
-     * later iterations will respect a per-user opt-out map.
+     * Mods land at `mods/{filename}`; an optional mod toggled OFF lands at
+     * `mods/{filename}.disabled` (Forge ignores non-`.jar` names), so flipping a
+     * toggle is a rename rather than a re-download. When the stale variant
+     * already holds the right bytes it is moved into place; otherwise it is
+     * removed and the active variant fetched. Forge 1.12.2 scans both `mods/`
+     * and `mods/{mcversion}/`, so flat placement still loads.
      */
-    private suspend fun syncMod(mod: SmrtModEntry, clientDir: Path) {
-        val dest = resolveSafe(clientDir.resolve("mods"), mod.filename, "mod ${mod.filename}")
+    private suspend fun syncMod(mod: SmrtModEntry, clientDir: Path, enabled: Boolean) {
+        val modsDir = clientDir.resolve("mods")
+        val activeDest = resolveSafe(modsDir, mod.filename, "mod ${mod.filename}")
+        val disabledDest = resolveSafe(modsDir, "${mod.filename}.disabled", "mod ${mod.filename}")
+        val dest = if (enabled) activeDest else disabledDest
+        val stale = if (enabled) disabledDest else activeDest
+
+        if (!isUpToDate(dest, mod.sha1, mod.sizeBytes) && isUpToDate(stale, mod.sha1, mod.sizeBytes)) {
+            Files.createDirectories(dest.parent)
+            Files.move(stale, dest, StandardCopyOption.REPLACE_EXISTING)
+            return
+        }
+        runCatching { Files.deleteIfExists(stale) }
         downloadIfNeeded(dest, mod.sha1, mod.sizeBytes, mod.source, "mod ${mod.filename}")
     }
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -137,6 +137,7 @@ class LauncherControllerTest {
         profileManager     = profileManager,
         packRepository     = packRepository,
         smrtPackClient     = smrtPackClient,
+        smrtSyncService    = mockk(relaxed = true),
         dataDirectory      = sandbox,
         appScope           = scope,
     )

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtSyncServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtSyncServiceTest.kt
@@ -1,0 +1,82 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.launcher.ProtectedPaths
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SmrtSyncServiceTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val temps = mutableListOf<Path>()
+
+    @AfterTest
+    fun cleanup() = temps.forEach { it.toFile().deleteRecursively() }
+
+    private fun tempDir(p: String) = Files.createTempDirectory(p).also { temps.add(it) }
+
+    private fun sha1(b: ByteArray) = MessageDigest.getInstance("SHA-1").digest(b).joinToString("") { "%02x".format(it) }
+
+    private val reqBytes = "REQUIRED".toByteArray()
+    private val optBytes = "OPTIONAL".toByteArray()
+
+    private fun manifest() = """
+        {"schema_version":2,"pack_id":"test","pack_version":"1","generated_at":"now",
+         "minecraft":{"version":"1.20.1"},"loader":{"name":"fabric","version":"0.19.2"},"java":{"major":17},
+         "mods":[
+           {"filename":"req.jar","sha1":"${sha1(reqBytes)}","size_bytes":${reqBytes.size},"required":true,"source":{"type":"smrt_static","url":"$REQ_URL"}},
+           {"filename":"opt.jar","sha1":"${sha1(optBytes)}","size_bytes":${optBytes.size},"required":false,"default_enabled":false,"source":{"type":"smrt_static","url":"$OPT_URL"}}
+         ],"assets":[]}
+    """.trimIndent()
+
+    private fun syncService(): SmrtSyncService {
+        val engine = MockEngine { req ->
+            when (req.url.toString()) {
+                MANIFEST_URL -> respond(manifest(), HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                REQ_URL -> respond(ByteReadChannel(reqBytes), HttpStatusCode.OK)
+                OPT_URL -> respond(ByteReadChannel(optBytes), HttpStatusCode.OK)
+                else -> respond("missing ${req.url}", HttpStatusCode.NotFound)
+            }
+        }
+        val client = SmrtPackClient(HttpClientProvider { HttpClient(engine) }, MIRROR_BASE, json)
+        return SmrtSyncService(client, ProtectedPaths(tempDir("pp").resolve("pp.json"), json))
+    }
+
+    @Test
+    fun `optional default-off lands as disabled, required stays active`() = runTest {
+        val dir = tempDir("sync")
+        syncService().sync("test", dir)
+        assertTrue(Files.exists(dir.resolve("mods/req.jar")), "required mod active")
+        assertFalse(Files.exists(dir.resolve("mods/opt.jar")), "default-off optional not active")
+        assertTrue(Files.exists(dir.resolve("mods/opt.jar.disabled")), "default-off optional placed as .disabled")
+    }
+
+    @Test
+    fun `enabledState activates an otherwise default-off optional`() = runTest {
+        val dir = tempDir("sync2")
+        syncService().sync("test", dir, enabledState = mapOf("req.jar" to true, "opt.jar" to true))
+        assertTrue(Files.exists(dir.resolve("mods/opt.jar")), "user-enabled optional is active")
+        assertFalse(Files.exists(dir.resolve("mods/opt.jar.disabled")), "no leftover .disabled variant")
+    }
+
+    private companion object {
+        const val MIRROR_BASE = "https://mirror.test"
+        const val MANIFEST_URL = "https://mirror.test/v1/packs/test/manifest"
+        const val REQ_URL = "https://mirror.test/req.jar"
+        const val OPT_URL = "https://mirror.test/opt.jar"
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -610,6 +610,8 @@ interface AppStrings {
     val contentTabFetchErrorGeneric: String
     val contentTabRetry: String
     val contentTabRoleSection: String
+    fun contentTabOptionalSection(count: Int): String
+    fun contentTabIncompatibleWith(name: String): String
     fun contentTabModsSection(count: Int): String
     fun contentTabAssetsSection(count: Int): String
     val contentTabResolverIssuesTitle: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -571,6 +571,8 @@ object EnglishStrings : AppStrings {
     override val contentTabFetchErrorGeneric    = "The mirror manifest failed to load."
     override val contentTabRetry                = "Retry"
     override val contentTabRoleSection          = "Role slots"
+    override fun contentTabOptionalSection(count: Int) = "Optional mods ($count)"
+    override fun contentTabIncompatibleWith(name: String) = "Incompatible with $name"
     override fun contentTabModsSection(count: Int) = "Mods ($count)"
     override fun contentTabAssetsSection(count: Int) = "Assets ($count)"
     override val contentTabResolverIssuesTitle  = "Manifest issues detected"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -571,6 +571,8 @@ object GermanStrings : AppStrings {
     override val contentTabFetchErrorGeneric    = "Das Mirror-Manifest konnte nicht geladen werden."
     override val contentTabRetry                = "Erneut versuchen"
     override val contentTabRoleSection          = "Rollen-Slots"
+    override fun contentTabOptionalSection(count: Int) = "Optionale Mods ($count)"
+    override fun contentTabIncompatibleWith(name: String) = "Inkompatibel mit $name"
     override fun contentTabModsSection(count: Int) = "Mods ($count)"
     override fun contentTabAssetsSection(count: Int) = "Assets ($count)"
     override val contentTabResolverIssuesTitle  = "Manifest-Probleme erkannt"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -572,6 +572,8 @@ object RussianStrings : AppStrings {
     override val contentTabFetchErrorGeneric    = "Манифест с зеркала не загрузился."
     override val contentTabRetry                = "Повторить"
     override val contentTabRoleSection          = "Слоты по ролям"
+    override fun contentTabOptionalSection(count: Int) = "Опциональные моды ($count)"
+    override fun contentTabIncompatibleWith(name: String) = "Несовместим с $name"
     override fun contentTabModsSection(count: Int) = "Моды ($count)"
     override fun contentTabAssetsSection(count: Int) = "Ассеты ($count)"
     override val contentTabResolverIssuesTitle  = "Найдены проблемы в манифесте"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
@@ -29,8 +29,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -191,6 +189,18 @@ private fun LoadedBody(
         val toggles = optionalMods.map { ContentToggle(it.filename, next[it.filename] ?: it.defaultEnabled) }
         scope.launch { controller.setOptionalMods(instance, manifest, toggles) }
     }
+    // Leading checkbox per mod row: required mods are locked-on (checked +
+    // disabled, kept for column alignment), optional mods toggle here.
+    fun toggleFor(mod: SmrtModEntry): ModToggle =
+        if (mod.required) {
+            ModToggle(checked = true, locked = true, onToggle = {})
+        } else {
+            ModToggle(
+                checked = enabledState[mod.filename] ?: mod.defaultEnabled,
+                locked = false,
+                onToggle = { enable -> onToggleOptional(mod.filename, enable) },
+            )
+        }
 
     // Split ungrouped mods so libraries land in their own bucket.
     // Mirror tags lib-only mods with display.category=lib (8 of 90 on
@@ -229,14 +239,6 @@ private fun LoadedBody(
                 item { ResolverWarnings(graph = graph) }
             }
 
-            optionalContentSection(
-                title         = s.contentTabOptionalSection(optionalMods.size),
-                mods          = optionalMods,
-                enabledState  = enabledState,
-                incompatLabel = { s.contentTabIncompatibleWith(it) },
-                onToggle      = onToggleOptional,
-            )
-
             if (grouping.byRole.isNotEmpty()) {
                 item { SectionHeader(text = s.contentTabRoleSection) }
                 items(items = grouping.byRole, key = { it.role }) { group ->
@@ -247,7 +249,7 @@ private fun LoadedBody(
             if (regularMods.isNotEmpty()) {
                 item { SectionHeader(text = s.contentTabModsSection(regularMods.size)) }
                 items(items = regularMods, key = { it.filename }) { mod ->
-                    ModRowPanel(mod = mod, graph = graph)
+                    ModRowPanel(mod = mod, graph = graph, toggle = toggleFor(mod))
                 }
             }
 
@@ -257,6 +259,7 @@ private fun LoadedBody(
                 graph = graph,
                 isOpen = libsOpen,
                 onToggle = { libsOpen = !libsOpen },
+                toggleFor = ::toggleFor,
             )
             collapsibleAssetSection(
                 title    = s.contentTabResourcePacksSection(resourcePacks.size),
@@ -295,77 +298,19 @@ private fun LoadedBody(
 private fun SmrtModEntry.libraryLike(): Boolean =
     display?.category?.lowercase()?.let { it == "lib" || it == "library" } == true
 
-private fun LazyListScope.optionalContentSection(
-    title: String,
-    mods: List<SmrtModEntry>,
-    enabledState: Map<String, Boolean>,
-    incompatLabel: (String) -> String,
-    onToggle: (String, Boolean) -> Unit,
-) {
-    if (mods.isEmpty()) return
-    item { SectionHeader(text = title) }
-    items(items = mods, key = { "opt:${it.filename}" }) { mod ->
-        OptionalModRow(
-            mod           = mod,
-            enabled       = enabledState[mod.filename] ?: mod.defaultEnabled,
-            incompatLabel = incompatLabel,
-            onToggle      = { onToggle(mod.filename, it) },
-        )
-    }
-}
-
-@Composable
-private fun OptionalModRow(
-    mod: SmrtModEntry,
-    enabled: Boolean,
-    incompatLabel: (String) -> String,
-    onToggle: (Boolean) -> Unit,
-) {
-    Row(
-        modifier          = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
-            .background(CelestiaTheme.colors.primary.copy(alpha = 0.05f))
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text       = mod.display?.name ?: mod.filename,
-                style      = MaterialTheme.typography.bodyMedium,
-                color      = CelestiaTheme.colors.textPrimary,
-                fontWeight = FontWeight.SemiBold,
-            )
-            val incompatible = mod.display?.incompatibleWith.orEmpty()
-            if (incompatible.isNotEmpty()) {
-                Text(
-                    text  = incompatLabel(incompatible.joinToString(", ")),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = CelestiaTheme.colors.textSecondary,
-                )
-            }
-        }
-        Spacer(Modifier.size(12.dp))
-        Switch(
-            checked         = enabled,
-            onCheckedChange = onToggle,
-            colors          = SwitchDefaults.colors(checkedTrackColor = CelestiaTheme.colors.primary),
-        )
-    }
-}
-
 private fun LazyListScope.collapsibleModSection(
     title: String,
     mods: List<SmrtModEntry>,
     graph: DepGraph,
     isOpen: Boolean,
     onToggle: () -> Unit,
+    toggleFor: (SmrtModEntry) -> ModToggle,
 ) {
     if (mods.isEmpty()) return
     item { CollapsibleSectionHeader(text = title, isOpen = isOpen, onToggle = onToggle) }
     if (isOpen) {
         items(items = mods, key = { "mod:${it.filename}" }) { mod ->
-            ModRowPanel(mod = mod, graph = graph)
+            ModRowPanel(mod = mod, graph = graph, toggle = toggleFor(mod))
         }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
@@ -180,7 +180,11 @@ private fun LoadedBody(
     val scope = rememberCoroutineScope()
 
     val optionalMods = OptionalContentRules.optionalMods(manifest.mods)
-    var enabledState by remember(manifest.packId) {
+    // Key on instance.id, not manifest.packId: two installed instances of the
+    // same pack reuse this composable but carry independent optionalContent;
+    // keying on the pack id would leak the previous instance's checkbox state
+    // into the second instance and persist it on the next click.
+    var enabledState by remember(instance.id) {
         mutableStateOf(OptionalContentRules.enabledState(manifest.mods, instance.optionalContent))
     }
     val onToggleOptional: (String, Boolean) -> Unit = { filename, enable ->

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,8 +50,11 @@ import androidx.compose.ui.unit.dp
 import hivens.core.api.dto.smrt.SmrtAssetEntry
 import hivens.core.api.dto.smrt.SmrtModEntry
 import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.data.ContentToggle
+import hivens.core.data.OptionalContentRules
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
+import hivens.launcher.launch.LauncherController
 import hivens.launcher.smrt.DepGraph
 import hivens.launcher.smrt.DepGraphResolver
 import hivens.launcher.smrt.ModGrouping
@@ -58,6 +64,7 @@ import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
@@ -92,6 +99,7 @@ fun ContentTabPane(instance: PackInstance, modifier: Modifier = Modifier) {
     }
 
     val client: SmrtPackClient = koinInject()
+    val controller: LauncherController = koinInject()
     var state by remember(instance.id) { mutableStateOf<ContentState>(ContentState.Loading) }
     var retryTick by remember(instance.id) { mutableIntStateOf(0) }
 
@@ -117,10 +125,12 @@ fun ContentTabPane(instance: PackInstance, modifier: Modifier = Modifier) {
         }
         is ContentState.Error -> ErrorBlock(modifier = modifier, message = st.message, onRetry = { retryTick++ })
         is ContentState.Loaded -> LoadedBody(
-            modifier = modifier,
-            manifest = st.manifest,
-            graph    = st.graph,
-            grouping = st.grouping,
+            modifier   = modifier,
+            instance   = instance,
+            controller = controller,
+            manifest   = st.manifest,
+            graph      = st.graph,
+            grouping   = st.grouping,
         )
     }
 }
@@ -161,12 +171,26 @@ private fun ErrorBlock(modifier: Modifier, message: String, onRetry: () -> Unit)
 @Composable
 private fun LoadedBody(
     modifier: Modifier,
+    instance: PackInstance,
+    controller: LauncherController,
     manifest: SmrtPackManifest,
     graph: DepGraph,
     grouping: ModGrouping,
 ) {
     val s = LocalStrings.current
     val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    val optionalMods = OptionalContentRules.optionalMods(manifest.mods)
+    var enabledState by remember(manifest.packId) {
+        mutableStateOf(OptionalContentRules.enabledState(manifest.mods, instance.optionalContent))
+    }
+    val onToggleOptional: (String, Boolean) -> Unit = { filename, enable ->
+        val next = OptionalContentRules.applyToggle(manifest.mods, enabledState, filename, enable)
+        enabledState = next
+        val toggles = optionalMods.map { ContentToggle(it.filename, next[it.filename] ?: it.defaultEnabled) }
+        scope.launch { controller.setOptionalMods(instance, manifest, toggles) }
+    }
 
     // Split ungrouped mods so libraries land in their own bucket.
     // Mirror tags lib-only mods with display.category=lib (8 of 90 on
@@ -204,6 +228,14 @@ private fun LoadedBody(
             if (graph.cycles.isNotEmpty() || graph.missingRequirements.isNotEmpty()) {
                 item { ResolverWarnings(graph = graph) }
             }
+
+            optionalContentSection(
+                title         = s.contentTabOptionalSection(optionalMods.size),
+                mods          = optionalMods,
+                enabledState  = enabledState,
+                incompatLabel = { s.contentTabIncompatibleWith(it) },
+                onToggle      = onToggleOptional,
+            )
 
             if (grouping.byRole.isNotEmpty()) {
                 item { SectionHeader(text = s.contentTabRoleSection) }
@@ -262,6 +294,65 @@ private fun LoadedBody(
 
 private fun SmrtModEntry.libraryLike(): Boolean =
     display?.category?.lowercase()?.let { it == "lib" || it == "library" } == true
+
+private fun LazyListScope.optionalContentSection(
+    title: String,
+    mods: List<SmrtModEntry>,
+    enabledState: Map<String, Boolean>,
+    incompatLabel: (String) -> String,
+    onToggle: (String, Boolean) -> Unit,
+) {
+    if (mods.isEmpty()) return
+    item { SectionHeader(text = title) }
+    items(items = mods, key = { "opt:${it.filename}" }) { mod ->
+        OptionalModRow(
+            mod           = mod,
+            enabled       = enabledState[mod.filename] ?: mod.defaultEnabled,
+            incompatLabel = incompatLabel,
+            onToggle      = { onToggle(mod.filename, it) },
+        )
+    }
+}
+
+@Composable
+private fun OptionalModRow(
+    mod: SmrtModEntry,
+    enabled: Boolean,
+    incompatLabel: (String) -> String,
+    onToggle: (Boolean) -> Unit,
+) {
+    Row(
+        modifier          = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(CelestiaTheme.colors.primary.copy(alpha = 0.05f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text       = mod.display?.name ?: mod.filename,
+                style      = MaterialTheme.typography.bodyMedium,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.SemiBold,
+            )
+            val incompatible = mod.display?.incompatibleWith.orEmpty()
+            if (incompatible.isNotEmpty()) {
+                Text(
+                    text  = incompatLabel(incompatible.joinToString(", ")),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+        }
+        Spacer(Modifier.size(12.dp))
+        Switch(
+            checked         = enabled,
+            onCheckedChange = onToggle,
+            colors          = SwitchDefaults.colors(checkedTrackColor = CelestiaTheme.colors.primary),
+        )
+    }
+}
 
 private fun LazyListScope.collapsibleModSection(
     title: String,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ModRowPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ModRowPanel.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -62,6 +63,7 @@ fun ModRowPanel(
     mod: SmrtModEntry,
     graph: DepGraph,
     emphasis: Emphasis = Emphasis.Primary,
+    toggle: ModToggle? = null,
     modifier: Modifier = Modifier,
 ) {
     val s = LocalStrings.current
@@ -84,6 +86,18 @@ fun ModRowPanel(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier              = Modifier.fillMaxWidth(),
         ) {
+            // Checkbox left of the avatar: optional mods toggle on/off here;
+            // required mods show it checked + locked so the column stays aligned
+            // and "required = always installed" reads at a glance.
+            if (toggle != null) {
+                Checkbox(
+                    checked         = toggle.checked,
+                    onCheckedChange = if (toggle.locked) null else toggle.onToggle,
+                    enabled         = !toggle.locked,
+                    modifier        = Modifier.size(24.dp),
+                )
+            }
+
             ModIconImage(mod = mod, size = 28.dp)
 
             Column(modifier = Modifier.weight(1f)) {
@@ -105,7 +119,6 @@ fun ModRowPanel(
                 }
             }
 
-            if (!mod.required) MetaChip(text = s.contentTabModOptional)
             SourceBadge(mod.source)
 
             Icon(
@@ -124,6 +137,18 @@ fun ModRowPanel(
 }
 
 enum class Emphasis { Primary, Alternative }
+
+/**
+ * Drives the leading checkbox on a mod row. [locked] (required mods) renders a
+ * checked, disabled box; otherwise [checked] is the optional mod's current state
+ * and [onToggle] flips it. Null on a [ModRowPanel] means no checkbox (e.g. a
+ * role-group alternative, where selection is its own UI).
+ */
+data class ModToggle(
+    val checked: Boolean,
+    val locked: Boolean,
+    val onToggle: (Boolean) -> Unit,
+)
 
 @Composable
 private fun ExpandedDetails(mod: SmrtModEntry, graph: DepGraph) {


### PR DESCRIPTION
## Why

The data model for [`ContentToggle`](client-core/src/main/kotlin/hivens/core/data/PackInstance.kt) shipped in stable, but the three commits that wire it through were left on a local branch and never landed. As a result the launcher persists `optionalContent` but the Library Content tab has no controls to flip a mod on/off, and the sync path does not respect the toggle state.

## What

Three commits, cherry-picked off the original `feat-optional-mods` branch onto fresh stable:

1. **core** -- `OptionalContentRules` (incompatibility / default_off / default_enabled), `SmrtSyncService` honoring the rules + `.disabled` rename mechanic, mirror manifest `default_enabled` + `incompatible_with` wire fields.
2. **Content tab** -- per-mod toggle list on `PackDetail` Content tab, persists via `PackRepository.put`. i18n added for ru/en/de.
3. **Checkbox UI** -- replaces the previous chip with a checkbox left of the mod avatar; the Content tab row matches the pattern used elsewhere.

## Test plan

- [x] `:client-core:test` (new `OptionalContentRulesTest`)
- [x] `:client-launcher:test` (new `SmrtSyncServiceTest` covering the rule-respecting sync)
- [x] `:client-ui:compileKotlinDesktop`
- [x] Click a checkbox on a real pack, relaunch, verify the toggled mod no longer ships in the spawn classpath