### PR TITLE
feat(widgets): Canvas slot mode + adaptive widget contract

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotControl.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/editor/SlotControl.kt
@@ -44,6 +44,9 @@ internal fun SlotControl(path: SlotPath, content: SlotContent, controller: EditM
         OrientChip("Сетка", content.orientation == SlotOrientation.Grid) {
             controller.setSlotOrientation(path, SlotOrientation.Grid)
         }
+        OrientChip("Холст", content.orientation == SlotOrientation.Canvas) {
+            controller.setSlotOrientation(path, SlotOrientation.Canvas)
+        }
         if (content.orientation == SlotOrientation.Grid) {
             StepChip("-") { controller.setGridColumns(path, content.gridColumns - 1) }
             Text(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/AdaptiveWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/AdaptiveWidget.kt
@@ -1,0 +1,57 @@
+package hivens.ui.widgets
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+
+// Content scale for a size-responsive widget. 1f in flow slots (Column/Row --
+// one axis unbounded) so existing placements render byte-identical to today;
+// it deviates from 1f only inside a both-bounded Canvas footprint, where the
+// content scales to the footprint relative to the widget's natural reference
+// size. Sub-composables read this local; AdaptiveWidget also hands it to the
+// content lambda directly.
+val LocalWidgetScale = compositionLocalOf { 1f }
+
+private const val MIN_WIDGET_SCALE = 0.4f
+private const val MAX_WIDGET_SCALE = 4f
+
+// Wraps a widget's content with a footprint-relative content scale.
+//
+// The widget does NOT grow to fill the available space -- the bounded size IS
+// its footprint (its default grid span, or a resized span on the canvas), and
+// the content adapts to that footprint. In a flow slot only one axis is bounded
+// (Column: width bounded, height wrap), so the scale is 1f and the widget
+// renders exactly as before. In a Canvas cell both axes are bounded, so the
+// content scales to the footprint vs the reference size.
+//
+// `referenceWidth/Height` are the widget's natural ("1x") content size -- the
+// footprint at which it looks correct without scaling.
+@Composable
+fun AdaptiveWidget(
+    referenceWidth: Dp,
+    referenceHeight: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.(scale: Float) -> Unit,
+) {
+    BoxWithConstraints(modifier) {
+        val scale = if (constraints.hasBoundedWidth && constraints.hasBoundedHeight) {
+            minOf(maxWidth / referenceWidth, maxHeight / referenceHeight)
+                .coerceIn(MIN_WIDGET_SCALE, MAX_WIDGET_SCALE)
+        } else {
+            1f
+        }
+        CompositionLocalProvider(LocalWidgetScale provides scale) {
+            content(scale)
+        }
+    }
+}
+
+// Scales a text style's font size by the widget scale. Identity at 1f so flow
+// placements are untouched.
+fun TextStyle.scaled(scale: Float): TextStyle =
+    if (scale == 1f) this else copy(fontSize = fontSize * scale)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
@@ -2,6 +2,7 @@ package hivens.ui.widgets.sample
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -33,6 +34,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.widgets.AdaptiveWidget
+import hivens.ui.widgets.scaled
 import hivens.ui.widgets.toWidgetColorOrNull
 import hivens.widget.api.rememberProps
 import hivens.widget.model.PropColor
@@ -92,48 +95,51 @@ fun ClockWidget(instance: WidgetInstance) {
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 12.dp)
-            .clip(RoundedCornerShape(14.dp))
-            .background(glassSurfaceAlpha(0.45f))
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        if (p.title.isNotBlank()) {
-            Text(
-                text       = p.title,
-                style      = MaterialTheme.typography.labelLarge,
-                color      = CelestiaTheme.colors.textSecondary,
-                fontWeight = FontWeight.Medium,
-                modifier   = Modifier.align(Alignment.Start),
-            )
-            Spacer(Modifier.height(10.dp))
-        }
+    AdaptiveWidget(referenceWidth = 200.dp, referenceHeight = 230.dp) { scale ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 12.dp * scale)
+                .clip(RoundedCornerShape(14.dp * scale))
+                .background(glassSurfaceAlpha(0.45f))
+                .padding(horizontal = 16.dp * scale, vertical = 14.dp * scale),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (p.title.isNotBlank()) {
+                Text(
+                    text       = p.title,
+                    style      = MaterialTheme.typography.labelLarge.scaled(scale),
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                    modifier   = Modifier.align(Alignment.Start),
+                )
+                Spacer(Modifier.height(10.dp * scale))
+            }
 
-        if (p.mode != ClockMode.Digital) {
-            ClockFace(
-                time           = now,
-                showSeconds    = p.showSeconds,
-                accentOverride = accent,
-                modifier       = Modifier.size(p.faceSize.dp),
-            )
-            Spacer(Modifier.height(10.dp))
-        }
+            if (p.mode != ClockMode.Digital) {
+                ClockFace(
+                    time           = now,
+                    showSeconds    = p.showSeconds,
+                    accentOverride = accent,
+                    modifier       = Modifier.size(p.faceSize.dp * scale),
+                )
+                Spacer(Modifier.height(10.dp * scale))
+            }
 
-        if (p.mode != ClockMode.Analog) {
-            Text(
-                text       = timeFormatter.format(now),
-                style      = MaterialTheme.typography.titleLarge,
-                color      = CelestiaTheme.colors.textPrimary,
-                fontWeight = FontWeight.Light,
-            )
-            Text(
-                text  = DATE_FORMATTER.format(now),
-                style = MaterialTheme.typography.bodySmall,
-                color = CelestiaTheme.colors.textSecondary,
-            )
+            if (p.mode != ClockMode.Analog) {
+                Text(
+                    text       = timeFormatter.format(now),
+                    style      = MaterialTheme.typography.titleLarge.scaled(scale),
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.Light,
+                )
+                Text(
+                    text  = DATE_FORMATTER.format(now),
+                    style = MaterialTheme.typography.bodySmall.scaled(scale),
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
         }
     }
 }

--- a/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
+++ b/widget-api/src/main/kotlin/hivens/widget/api/SlotRenderer.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -128,6 +130,22 @@ private fun RenderSlotContent(path: SlotPath, modifier: Modifier, spacing: Dp) {
                     repeat(cols - rowWidgets.size) { Spacer(Modifier.weight(1f)) }
                 }
             }
+        }
+        SlotOrientation.Canvas -> Box(modifier) {
+            slotControl(path, content)
+            // Free canvas: each widget at its absolute dp offset + size, painted
+            // in z-order then index. Overlap is natural in a Box. No dividers.
+            content.widgets.withIndex()
+                .sortedWith(compareBy({ it.value.canvas?.z ?: 0 }, { it.index }))
+                .forEach { (index, instance) ->
+                    val descriptor = registry[instance.kind] ?: return@forEach
+                    val cp = instance.canvas
+                    val sizeMod = if (cp != null && cp.width > 0f && cp.height > 0f)
+                        Modifier.size(cp.width.dp, cp.height.dp) else Modifier
+                    Box(Modifier.offset((cp?.x ?: 0f).dp, (cp?.y ?: 0f).dp).then(sizeMod)) {
+                        decorator(address, index, descriptor, instance) { descriptor.Render(instance) }
+                    }
+                }
         }
         // Column.
         else -> Column(modifier, verticalArrangement = Arrangement.spacedBy(spacing)) {

--- a/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
+++ b/widget-model/src/main/kotlin/hivens/widget/model/LayoutGraph.kt
@@ -25,13 +25,29 @@ data class WidgetInstance(
     // Row/Column. 0 = natural/wrap size; > 0 = a weighted share. Set via
     // the edit-mode drag-dividers.
     val weight: Float = 0f,
+    // Absolute placement when the enclosing slot is Canvas. Null for flow
+    // slots (Column/Row/Grid) -- back-compat default for old layouts.
+    val canvas: CanvasPlacement? = null,
 )
 
 // Phase G: how a slot arranges its widgets. Column (default) reproduces
 // the pre-Phase-G vertical stack; Row lays them horizontally; Grid flows
-// them into `gridColumns` uniform cells.
+// them into `gridColumns` uniform cells; Canvas places each widget at an
+// absolute offset + size (free-canvas mode).
 @Serializable
-enum class SlotOrientation { Column, Row, Grid }
+enum class SlotOrientation { Column, Row, Grid, Canvas }
+
+// Absolute placement of a widget inside a Canvas slot. x/y are dp offsets
+// from the slot's top-left; width/height 0 means intrinsic/wrap (dp when set);
+// z is the paint order (higher renders in front). Used only on Canvas slots.
+@Serializable
+data class CanvasPlacement(
+    val x: Float = 0f,
+    val y: Float = 0f,
+    val width: Float = 0f,
+    val height: Float = 0f,
+    val z: Int = 0,
+)
 
 @Serializable
 data class SlotContent(
@@ -153,6 +169,47 @@ fun LayoutGraph.setWidgetWeight(path: SlotPath, instanceId: String, weight: Floa
             },
         )
     }
+
+// Canvas placement transforms (used when the slot is Canvas). Same no-op /
+// missing-instance identity contract as the Phase G transforms above.
+fun LayoutGraph.setCanvasPlacement(path: SlotPath, instanceId: String, placement: CanvasPlacement): LayoutGraph =
+    mutate(path) { content ->
+        val target = content.widgets.firstOrNull { it.instanceId == instanceId } ?: return@mutate content
+        if (target.canvas == placement) return@mutate content
+        content.copy(
+            widgets = content.widgets.map {
+                if (it.instanceId == instanceId) it.copy(canvas = placement) else it
+            },
+        )
+    }
+
+fun LayoutGraph.setWidgetOffset(path: SlotPath, instanceId: String, x: Float, y: Float): LayoutGraph =
+    updateCanvas(path, instanceId) { it.copy(x = x, y = y) }
+
+fun LayoutGraph.setWidgetSize(path: SlotPath, instanceId: String, width: Float, height: Float): LayoutGraph =
+    updateCanvas(path, instanceId) { it.copy(width = width.coerceAtLeast(0f), height = height.coerceAtLeast(0f)) }
+
+fun LayoutGraph.setWidgetZ(path: SlotPath, instanceId: String, z: Int): LayoutGraph =
+    updateCanvas(path, instanceId) { it.copy(z = z) }
+
+// Reads the widget's current placement (or the default when null), applies
+// `edit`, and writes it back -- so offset / size / z edits compose without
+// clobbering each other. No-op when the result is unchanged.
+private fun LayoutGraph.updateCanvas(
+    path: SlotPath,
+    instanceId: String,
+    edit: (CanvasPlacement) -> CanvasPlacement,
+): LayoutGraph = mutate(path) { content ->
+    val target = content.widgets.firstOrNull { it.instanceId == instanceId } ?: return@mutate content
+    val current = target.canvas ?: CanvasPlacement()
+    val next = edit(current)
+    if (next == target.canvas) return@mutate content
+    content.copy(
+        widgets = content.widgets.map {
+            if (it.instanceId == instanceId) it.copy(canvas = next) else it
+        },
+    )
+}
 
 // Walks the path and returns the SlotContent at the leaf, or null if
 // any intermediate surface / slot / parent widget is missing.

--- a/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
+++ b/widget-model/src/test/kotlin/hivens/widget/model/LayoutGraphMutationsTest.kt
@@ -130,6 +130,51 @@ class LayoutGraphMutationsTest {
         assertSame(graph, graph.setWidgetWeight(rootPath, "i1", 0f))
     }
 
+    // ── Canvas placement (Canvas slot mode) ───────────────────────────
+
+    @Test
+    fun `setCanvasPlacement sets placement on the matching widget only`() {
+        val out = seed(w1, w2).setCanvasPlacement(rootPath, "i2", CanvasPlacement(10f, 20f, 100f, 50f, 3))
+        assertEquals(CanvasPlacement(10f, 20f, 100f, 50f, 3), out.mainWidgets().first { it.instanceId == "i2" }.canvas)
+        assertNull(out.mainWidgets().first { it.instanceId == "i1" }.canvas)
+    }
+
+    @Test
+    fun `setCanvasPlacement to the same placement is identity`() {
+        val placed = seed(w1).setCanvasPlacement(rootPath, "i1", CanvasPlacement(x = 5f))
+        assertSame(placed, placed.setCanvasPlacement(rootPath, "i1", CanvasPlacement(x = 5f)))
+    }
+
+    @Test
+    fun `setCanvasPlacement on unknown instance is identity`() {
+        val graph = seed(w1)
+        assertSame(graph, graph.setCanvasPlacement(rootPath, "ghost", CanvasPlacement(x = 1f)))
+    }
+
+    @Test
+    fun `setWidgetOffset then setWidgetSize compose without clobbering`() {
+        val out = seed(w1)
+            .setWidgetOffset(rootPath, "i1", 40f, 60f)
+            .setWidgetSize(rootPath, "i1", 200f, 120f)
+        assertEquals(
+            CanvasPlacement(x = 40f, y = 60f, width = 200f, height = 120f),
+            out.mainWidgets().first { it.instanceId == "i1" }.canvas,
+        )
+    }
+
+    @Test
+    fun `setWidgetSize coerces negatives to zero`() {
+        val p = seed(w1).setWidgetSize(rootPath, "i1", -10f, -5f).mainWidgets().first { it.instanceId == "i1" }.canvas
+        assertEquals(0f, p?.width)
+        assertEquals(0f, p?.height)
+    }
+
+    @Test
+    fun `setWidgetZ sets the layer`() {
+        val out = seed(w1).setWidgetZ(rootPath, "i1", 5)
+        assertEquals(5, out.mainWidgets().first { it.instanceId == "i1" }.canvas?.z)
+    }
+
     @Test
     fun `reorderInSlot swaps positions`() {
         val out = seed(w1, w2, w3).reorderInSlot(rootPath, fromIndex = 0, toIndex = 2)


### PR DESCRIPTION
Two commits, both Atelier-scope (per `project_free_canvas` + `project_ui_editor_arch`):

## C1 -- Canvas slot mode + absolute-placement model + render

Adds a 4th slot orientation, **Canvas**: widgets are placed at an absolute
offset + size. New `CanvasPlacement` field on `WidgetInstance`, nullable so
older serialized layouts decode unchanged.

`SlotRenderer` gains a Canvas branch (Box; widgets at `offset(x,y)` + explicit
size or intrinsic, painted in z-order then index). `SlotControl` adds a
"Холст" chip.

Transforms `setCanvasPlacement` / `setWidgetOffset` / `setWidgetSize` /
`setWidgetZ` share the Phase G no-op + missing-instance identity contract,
with tests.

Free-drag + resize land in C2/C3 follow-ups.

## Adaptive widget contract + Clock

`AdaptiveWidget` gives a widget a footprint-relative content scale:
- `1f` in flow slots (one axis unbounded -> byte-identical to today)
- scaled inside a both-bounded Canvas footprint where content adapts to span
  vs the widget's reference size

Widgets do NOT grow to fill space -- the footprint (default span, or a
resized span on the canvas) IS the size, and the content fits it.
`TextStyle.scaled()` helper. `ClockWidget` converted as the reference case
(face / fonts / padding scale by the factor; at scale 1 renders unchanged).

The remaining ~59 widgets follow once the contract is locked live on the
clock.

## Test plan

- [x] `:widget-model:test` green (`LayoutGraphMutationsTest` extended)
- [x] `:client-ui:compileKotlinDesktop`
- [ ] Mount Clock on a Canvas slot, resize via the C2/C3 follow-up, verify
      it scales by the footprint factor rather than reflowing