### PR TITLE
fix(ui): content-tab checkbox clicks register + persist across navigation

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -91,6 +91,23 @@ class LauncherController(
         return updated
     }
 
+    /**
+     * Fire-and-forget variant that runs the toggle persistence on the
+     * shared [appScope] instead of the caller's. The Content tab's
+     * `rememberCoroutineScope` is tied to the composable lifecycle, so
+     * a user clicking a checkbox and immediately navigating away
+     * cancelled the persistence mid-flight and the toggle silently
+     * reverted on next load. The launcher-side scope outlives the UI
+     * so the write always reaches disk.
+     */
+    fun setOptionalModsAsync(
+        instance: PackInstance,
+        manifest: SmrtPackManifest,
+        toggles: List<ContentToggle>,
+    ) {
+        appScope.launch { setOptionalMods(instance, manifest, toggles) }
+    }
+
     private val _state = MutableStateFlow<LaunchState>(LaunchState.Idle)
     val state: StateFlow<LaunchState> = _state.asStateFlow()
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ContentTabPane.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,7 +61,6 @@ import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
@@ -177,7 +175,6 @@ private fun LoadedBody(
 ) {
     val s = LocalStrings.current
     val listState = rememberLazyListState()
-    val scope = rememberCoroutineScope()
 
     val optionalMods = OptionalContentRules.optionalMods(manifest.mods)
     // Key on instance.id, not manifest.packId: two installed instances of the
@@ -191,7 +188,10 @@ private fun LoadedBody(
         val next = OptionalContentRules.applyToggle(manifest.mods, enabledState, filename, enable)
         enabledState = next
         val toggles = optionalMods.map { ContentToggle(it.filename, next[it.filename] ?: it.defaultEnabled) }
-        scope.launch { controller.setOptionalMods(instance, manifest, toggles) }
+        // Hand the write to the controller's long-lived scope. Doing this on a
+        // rememberCoroutineScope() one cancelled mid-flight when the user
+        // navigated away from the Content tab, so the toggle silently reverted.
+        controller.setOptionalModsAsync(instance, manifest, toggles)
     }
     // Leading checkbox per mod row: required mods are locked-on (checked +
     // disabled, kept for column alignment), optional mods toggle here.

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ModRowPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/content/ModRowPanel.kt
@@ -78,7 +78,6 @@ fun ModRowPanel(
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
             .background(glassSurfaceAlpha(0.45f * rowAlpha))
-            .clickable { expanded = !expanded }
             .padding(horizontal = 12.dp, vertical = 6.dp),
     ) {
         Row(
@@ -89,6 +88,10 @@ fun ModRowPanel(
             // Checkbox left of the avatar: optional mods toggle on/off here;
             // required mods show it checked + locked so the column stays aligned
             // and "required = always installed" reads at a glance.
+            //
+            // The expand-click below lives on the rest of the row only -- earlier
+            // it sat on the surrounding Column and ate the checkbox click before
+            // the Checkbox saw it, so toggles appeared to do nothing.
             if (toggle != null) {
                 Checkbox(
                     checked         = toggle.checked,
@@ -98,35 +101,43 @@ fun ModRowPanel(
                 )
             }
 
-            ModIconImage(mod = mod, size = 28.dp)
+            Row(
+                modifier              = Modifier
+                    .weight(1f)
+                    .clickable { expanded = !expanded },
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                ModIconImage(mod = mod, size = 28.dp)
 
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text           = mod.display?.name ?: mod.filename.removeSuffix(".jar"),
-                    style          = MaterialTheme.typography.bodyMedium,
-                    color          = CelestiaTheme.colors.textPrimary.copy(alpha = rowAlpha),
-                    fontWeight     = if (emphasis == Emphasis.Primary) FontWeight.SemiBold else FontWeight.Normal,
-                    textDecoration = titleDecoration,
-                    maxLines       = 1,
-                    overflow       = TextOverflow.Ellipsis,
-                )
-                mod.display?.category?.takeIf { it.isNotBlank() }?.let { cat ->
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text  = cat,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = CelestiaTheme.colors.textSecondary.copy(alpha = rowAlpha),
+                        text           = mod.display?.name ?: mod.filename.removeSuffix(".jar"),
+                        style          = MaterialTheme.typography.bodyMedium,
+                        color          = CelestiaTheme.colors.textPrimary.copy(alpha = rowAlpha),
+                        fontWeight     = if (emphasis == Emphasis.Primary) FontWeight.SemiBold else FontWeight.Normal,
+                        textDecoration = titleDecoration,
+                        maxLines       = 1,
+                        overflow       = TextOverflow.Ellipsis,
                     )
+                    mod.display?.category?.takeIf { it.isNotBlank() }?.let { cat ->
+                        Text(
+                            text  = cat,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = CelestiaTheme.colors.textSecondary.copy(alpha = rowAlpha),
+                        )
+                    }
                 }
+
+                SourceBadge(mod.source)
+
+                Icon(
+                    imageVector        = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    tint               = CelestiaTheme.colors.textSecondary,
+                    modifier           = Modifier.size(20.dp),
+                )
             }
-
-            SourceBadge(mod.source)
-
-            Icon(
-                imageVector        = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                contentDescription = null,
-                tint               = CelestiaTheme.colors.textSecondary,
-                modifier           = Modifier.size(20.dp),
-            )
         }
 
         if (expanded) {


### PR DESCRIPTION
Two bugs reported live with screenshots from the Content tab:

1. **Checkbox click did nothing.** The Column wrapping the row carried
   \`.clickable { expanded = !expanded }\` sitting OUTSIDE the Checkbox.
   The outer click handler caught the press before it reached the
   Checkbox's own \`onCheckedChange\`. The expand-click now lives on the
   inner Row that holds the icon + name + chevron only; the checkbox
   sits at the start of the outer Row, outside the clickable subtree.

2. **Toggle state silently reverted when navigating away.**
   \`setOptionalMods\` ran on \`rememberCoroutineScope()\`, tied to the
   composable lifecycle. The moment the composable was disposed, the
   persistence coroutine was cancelled mid-flight and the \`packs.json\`
   write never landed. New \`setOptionalModsAsync\` on
   \`LauncherController\` hands the work to the launcher-side
   \`appScope\`, which outlives the UI and reliably finishes the write.

## Test plan

- [x] \`:client-launcher:compileKotlin\` + \`:client-ui:compileKotlinDesktop\`
- [x] Click an optional checkbox -- visible state flips immediately
- [x] Click checkbox, immediately navigate to another section, return
      to Content tab -- checkbox state preserved
- [x] Click anywhere else on the row -- expanded details open