### PR TITLE
fix(ui): clock widget -- 1Hz tick, drop redundant title, legibility

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/sample/ClockWidget.kt
@@ -59,12 +59,12 @@ data class ClockProps(
     @PropLabel("Режим") val mode: ClockMode = ClockMode.Both,
     @PropLabel("24-часовой формат") val format24h: Boolean = true,
     @PropLabel("Секунды") val showSeconds: Boolean = true,
-    @PropLabel("Заголовок") val title: String = "Часы",
+    @PropLabel("Заголовок") val title: String = "",
     @PropLabel("Размер циферблата") @PropRange(80.0, 200.0) val faceSize: Int = 140,
     @PropLabel("Цвет акцента") @PropColor val accent: String = "",
 )
 
-// Analog + digital clock with smooth-sweeping seconds. Theme-aware: dial
+// Analog + digital clock with a once-per-second second hand. Theme-aware: dial
 // reads surface, hands read textPrimary, accent (second hand / hub) reads
 // the accent prop or falls back to primary. Per-second tick recomposes
 // only the Canvas + the digital time line; the surrounding card stays
@@ -88,10 +88,11 @@ fun ClockWidget(instance: WidgetInstance) {
     LaunchedEffect(Unit) {
         while (true) {
             now = LocalDateTime.now()
-            // 1Hz tick is enough; the second hand interpolates smoothly
-            // in the canvas using milliseconds-of-second so we do not
-            // need 60Hz recomposition.
-            delay(500L)
+            // Tick once per second, aligned to the next second boundary so the
+            // hand steps cleanly on the second (quartz-style) rather than
+            // drifting or double-stepping. A continuous sweep would need
+            // per-frame recomposition, which a background clock does not earn.
+            delay(1000L - now.nano / 1_000_000L)
         }
     }
 
@@ -101,7 +102,7 @@ fun ClockWidget(instance: WidgetInstance) {
                 .fillMaxSize()
                 .padding(top = 12.dp * scale)
                 .clip(RoundedCornerShape(14.dp * scale))
-                .background(glassSurfaceAlpha(0.45f))
+                .background(glassSurfaceAlpha(0.65f))
                 .padding(horizontal = 16.dp * scale, vertical = 14.dp * scale),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
First-impression UX fix for the home/widget clock.

- Tick once per second, aligned to the next second boundary. It was `delay(500L)` (2Hz): the second hand double-stepped each second and read as "time running 2x fast". The comment also claimed a smooth sub-second sweep the code never did -- corrected to match reality.
- Drop the redundant default title. The widget is self-evidently a clock, so a default title row was noise; the default is now blank (no row), and a user-set title still renders.
- Bump the card backing from 0.45 to 0.65 glass so the clock stays legible over a busy custom wallpaper. This is the one tunable knob here -- adjust if it reads too heavy or too light.

Scope: clock only. The "preparing notification fires x3" item from the same first-impression pass was investigated separately and turns out to be intentional, tested behaviour -- each launch sub-stage (INIT / AUTH / SYNC / JVM) is retained in the notification group's history (NotificationCenterTest asserts it). Collapsing Progress history in-place is a notification-subsystem design call, not bundled here.
