### PR TITLE
Smarty -> open-smrt helper swap + Exact Mod Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ below are for the GitHub release page and CHANGELOG readers.
 
 ## [Unreleased]
 
+### Highlights
+- **Smarty servers, without the spyware**. A new Settings -> Smarty section
+  can swap SmartyCraft's proprietary Smarty mod for our open-source helper:
+  same network compatibility, none of the client-side surveillance. If no
+  open replacement exists for a server's game version, the launch is blocked
+  rather than quietly running the original mod.
+- **Exact mod verification**. Optionally delete anything in a server's mods
+  folder it did not ask for. Keeps installs clean, but it also removes mods
+  you added by hand, so it is a deliberate opt-out of a curated set.
+- **Quieter launch errors**. Launch failures now surface through the
+  notification system instead of an in-panel banner.
+
+### Added
+- Settings -> Smarty section with "Use the alternative smrt network helper"
+  and "Exact mod verification" toggles (both on by default).
+
+### Changed
+- Launch failures are delivered as notifications; the in-panel error banner
+  was removed.
+
 ## [2.3.3] - 2026-05-25
 
 Visual customization release. Custom background gains real

--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/IFileDownloadService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/IFileDownloadService.kt
@@ -12,6 +12,14 @@ interface IFileDownloadService {
      *   integrity walk *before* downloads. Keeps the UI bar moving while
      *   hashing a 1000-file modpack -- otherwise the user sees the
      *   launcher silent for tens of seconds and assumes a hang.
+     * [injectModJar]: an open-smrt-network helper jar copied into `mods/`
+     *   in place of the upstream Smarty coremod (whose manifest name the
+     *   caller adds to [ignoredFiles]). Null leaves the manifest untouched.
+     * [strictModCheck]: when true, deletes every jar in `mods/` the manifest
+     *   does not list ([injectModJar] and [helperKeepGlobs] excepted) -- "only
+     *   what the server asks for runs".
+     * [helperKeepGlobs]: jar-name globs strict verification must always keep
+     *   (the open-smrt helper), even when [injectModJar] is null this launch.
      */
     suspend fun processSession(
         session: SessionData,
@@ -22,5 +30,8 @@ interface IFileDownloadService {
         messageUI: ((String) -> Unit)?,
         progressUI: ((Int, Int, Long, Long, String) -> Unit)?,
         verifyUI: ((Int, Int) -> Unit)? = null,
+        injectModJar: Path? = null,
+        strictModCheck: Boolean = false,
+        helperKeepGlobs: List<String> = emptyList(),
     )
 }

--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -135,4 +135,25 @@ data class SettingsData(
      * (current visual feel); see [UiStyle] for available variants.
      */
     val uiStyle: UiStyle = UiStyle.Celestia,
+
+    // ── Smarty server controls ───────────────────────────────────────────
+
+    /**
+     * Swap the upstream Smarty surveillance coremod for our open-smrt-network
+     * helper when syncing a raw SmartyCraft server. The mirror packs already
+     * carry the replacement in their manifest; this brings the same swap to
+     * servers synced straight from SC. The replacement jar is resolved per
+     * MC version from open-smrt-network's GitHub releases -- if no release is
+     * resolvable yet, the sync falls back to the upstream Smarty jar so the
+     * launcher stays functional (with a loud warning).
+     */
+    val useOpenSmrtHelper: Boolean = true,
+
+    /**
+     * After sync, delete every jar in `mods/` that the server manifest does not
+     * list (the injected open-smrt helper aside). The blunt, exact version of
+     * "only what the server asks for runs". Removes user-added client mods
+     * too -- that is the point, and the Settings copy says so.
+     */
+    val strictModVerification: Boolean = true,
 )

--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -143,9 +143,10 @@ data class SettingsData(
      * helper when syncing a raw SmartyCraft server. The mirror packs already
      * carry the replacement in their manifest; this brings the same swap to
      * servers synced straight from SC. The replacement jar is resolved per
-     * MC version from open-smrt-network's GitHub releases -- if no release is
-     * resolvable yet, the sync falls back to the upstream Smarty jar so the
-     * launcher stays functional (with a loud warning).
+     * MC version from open-smrt-network's GitHub releases. Authoritative: the
+     * Smarty jar is always stripped, never re-admitted. If no replacement is
+     * available for the server's MC version (and none is cached on disk), the
+     * launch is BLOCKED rather than running the surveillance mod.
      */
     val useOpenSmrtHelper: Boolean = true,
 

--- a/client-core/src/main/kotlin/hivens/core/data/SmrtHelperDescriptor.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SmrtHelperDescriptor.kt
@@ -1,0 +1,52 @@
+package hivens.core.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Out-of-band descriptor that pins, per Minecraft version, which
+ * open-smrt-network release jar replaces the upstream Smarty coremod on
+ * a raw SmartyCraft server sync. Lives in the open-smrt-network repo
+ * (`meta/smrt-helper.json` on its `main` branch) so the pinned release
+ * can move without cutting a Nexira launcher release -- same out-of-band
+ * pattern as [UpdateChannelMeta].
+ *
+ * Fetched remote-only; an absent file, parse failure, or network error
+ * means "no helper available", and the sync falls back to the upstream
+ * Smarty jar. The mirror packs do not consult this -- they already carry
+ * the replacement inline in their smrt manifest.
+ */
+@Serializable
+data class SmrtHelperDescriptor(
+    @SerialName("schema_version") val schemaVersion: Int = 1,
+    val variants: List<SmrtHelperVariant> = emptyList(),
+) {
+    /**
+     * The variant whose [SmrtHelperVariant.mcPrefix] is the longest prefix of
+     * [mcVersion], or null if none match. Longest-prefix so a "1.12.2" entry
+     * wins over a broader "1.12" entry when both are present.
+     */
+    fun variantFor(mcVersion: String): SmrtHelperVariant? =
+        variants
+            .filter { mcVersion.startsWith(it.mcPrefix) }
+            .maxByOrNull { it.mcPrefix.length }
+}
+
+/**
+ * One Minecraft-version variant of the open-smrt-network helper.
+ *
+ * [smartyNames] are the manifest filenames (or `*`-globs) that identify the
+ * upstream Smarty jar to strip for this version; the default catches the
+ * common `Smarty-<version>.jar`. The jar is downloaded from the
+ * open-smrt-network release tagged [tag], asset [asset], and must hash to
+ * [sha256] (lowercase hex SHA-256) before it is trusted.
+ */
+@Serializable
+data class SmrtHelperVariant(
+    @SerialName("mc_prefix") val mcPrefix: String,
+    val tag: String,
+    val asset: String,
+    val sha256: String,
+    @SerialName("size_bytes") val sizeBytes: Long = 0,
+    @SerialName("smarty_names") val smartyNames: List<String> = listOf("Smarty*.jar"),
+)

--- a/client-core/src/test/kotlin/hivens/core/data/SmrtHelperDescriptorTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/data/SmrtHelperDescriptorTest.kt
@@ -1,0 +1,53 @@
+package hivens.core.data
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SmrtHelperDescriptorTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val descriptor = SmrtHelperDescriptor(
+        variants = listOf(
+            SmrtHelperVariant("1.12", tag = "v1", asset = "broad.jar", sha256 = "aa"),
+            SmrtHelperVariant("1.12.2", tag = "v2", asset = "exact.jar", sha256 = "bb"),
+            SmrtHelperVariant("1.7", tag = "v3", asset = "legacy.jar", sha256 = "cc"),
+        ),
+    )
+
+    @Test
+    fun `variantFor picks the longest matching prefix`() {
+        assertEquals("exact.jar", descriptor.variantFor("1.12.2")?.asset)
+    }
+
+    @Test
+    fun `variantFor falls back to a broader prefix`() {
+        assertEquals("broad.jar", descriptor.variantFor("1.12.1")?.asset)
+    }
+
+    @Test
+    fun `variantFor returns null when nothing matches`() {
+        assertNull(descriptor.variantFor("1.21.1"))
+    }
+
+    @Test
+    fun `parses wire JSON and defaults smarty names`() {
+        val parsed = json.decodeFromString<SmrtHelperDescriptor>(
+            """
+            {
+              "schema_version": 1,
+              "variants": [
+                { "mc_prefix": "1.12.2", "tag": "v2", "asset": "open-smrt-1.12.2.jar",
+                  "sha256": "deadbeef", "size_bytes": 1234 }
+              ]
+            }
+            """.trimIndent(),
+        )
+        val v = parsed.variantFor("1.12.2")!!
+        assertEquals("open-smrt-1.12.2.jar", v.asset)
+        assertEquals(1234, v.sizeBytes)
+        assertEquals(listOf("Smarty*.jar"), v.smartyNames)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
@@ -1,11 +1,16 @@
 package hivens.launcher
 
+import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.IAuthService
 import hivens.core.api.interfaces.IFileDownloadService
 import hivens.core.api.interfaces.IManifestProcessorService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.SessionData
+import hivens.core.data.SettingsData
 import hivens.core.diag.ActionRing
+import hivens.launcher.smrt.ClientSyncCoordinator
+import hivens.launcher.smrt.OpenSmrtHelperResolver
+import hivens.launcher.smrt.SmartyModPlanner
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -52,6 +57,13 @@ class AutoSyncService(
      * [credentialsProvider].
      */
     private val optionalModsStateProvider: (serverId: String) -> Map<String, Boolean>,
+    /**
+     * Builds the Smarty swap + strict-verification plan so background sync
+     * applies the same mod handling as a foreground launch.
+     */
+    private val smartyPlanner: SmartyModPlanner,
+    /** Current settings, read per-server so a mid-session toggle is honoured. */
+    private val settingsProvider: () -> SettingsData,
 ) {
     private val log = LoggerFactory.getLogger(AutoSyncService::class.java)
 
@@ -158,7 +170,7 @@ class AutoSyncService(
             var sessionFailed = false
             val session: SessionData? = try {
                 authService.login(creds.playerName, pass, server.assetDir)
-            } catch (_: hivens.core.api.TwoFactorRequiredException) {
+            } catch (_: TwoFactorRequiredException) {
                 val cached = manifestCache.loadManifest(server.assetDir)
                 if (cached == null) {
                     log.info(
@@ -185,27 +197,44 @@ class AutoSyncService(
             if (session == null) continue  // SKIPPED above; counters not bumped (it's neither succeeded nor failed)
 
             val ok = runCatching {
+                val settings = settingsProvider()
                 val userState = optionalModsStateProvider(server.assetDir)
                 val ignoredFiles = manifestProcessor.calculateIgnoredFiles(server, userState)
                 val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)
+                val smartyPlan = smartyPlanner.plan(server, session.fileManifest, settings)
 
-                downloadService.processSession(
-                    session = session,
-                    serverId = server.assetDir,
-                    targetDir = clientDir,
-                    extraCheckSum = server.extraCheckSum,
-                    ignoredFiles = ignoredFiles,
-                    messageUI = null,
-                    progressUI = { _, _, bytesRead, totalBytes, _ ->
-                        setOverall(OverallState.InProgress(
-                            currentServer = server.title ?: server.name,
-                            currentIdx = idx + 1,
-                            total = installed.size,
-                            bytesRead = bytesRead,
-                            totalBytes = totalBytes,
-                        ))
-                    },
-                )
+                // Refuse to strip Smarty with no replacement (same gate as a
+                // foreground launch): don't mutate the pack into a broken state in
+                // the background. Surfaces as FAILED for this server.
+                if (settings.useOpenSmrtHelper && smartyPlan.ignoredAddon.isNotEmpty() &&
+                    !helperPresent(clientDir, server.version, smartyPlan)) {
+                    throw IllegalStateException(
+                        "open-smrt helper unavailable for ${server.version}; refusing to strip Smarty without a replacement"
+                    )
+                }
+
+                ClientSyncCoordinator.withClientLock(clientDir) {
+                    downloadService.processSession(
+                        session = session,
+                        serverId = server.assetDir,
+                        targetDir = clientDir,
+                        extraCheckSum = server.extraCheckSum,
+                        ignoredFiles = ignoredFiles + smartyPlan.ignoredAddon,
+                        messageUI = null,
+                        progressUI = { _, _, bytesRead, totalBytes, _ ->
+                            setOverall(OverallState.InProgress(
+                                currentServer = server.title ?: server.name,
+                                currentIdx = idx + 1,
+                                total = installed.size,
+                                bytesRead = bytesRead,
+                                totalBytes = totalBytes,
+                            ))
+                        },
+                        injectModJar = smartyPlan.injectJar,
+                        strictModCheck = smartyPlan.strict,
+                        helperKeepGlobs = smartyPlan.helperKeepGlobs,
+                    )
+                }
             }
 
             if (ok.isSuccess) {
@@ -234,4 +263,8 @@ class AutoSyncService(
         if (!Files.isDirectory(dir)) return false
         return Files.list(dir).use { it.findFirst().isPresent }
     }
+
+    private fun helperPresent(clientDir: Path, mcVersion: String, plan: SmartyModPlanner.Plan): Boolean =
+        plan.injectJar != null ||
+            Files.isRegularFile(clientDir.resolve("mods").resolve(OpenSmrtHelperResolver.helperFileName(mcVersion)))
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
@@ -196,23 +196,30 @@ class AutoSyncService(
             }
             if (session == null) continue  // SKIPPED above; counters not bumped (it's neither succeeded nor failed)
 
-            val ok = runCatching {
-                val settings = settingsProvider()
-                val userState = optionalModsStateProvider(server.assetDir)
-                val ignoredFiles = manifestProcessor.calculateIgnoredFiles(server, userState)
-                val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)
-                val smartyPlan = smartyPlanner.plan(server, session.fileManifest, settings)
-
-                // Refuse to strip Smarty with no replacement (same gate as a
-                // foreground launch): don't mutate the pack into a broken state in
-                // the background. Surfaces as FAILED for this server.
-                if (settings.useOpenSmrtHelper && smartyPlan.ignoredAddon.isNotEmpty() &&
-                    !helperPresent(clientDir, server.version, smartyPlan)) {
-                    throw IllegalStateException(
-                        "open-smrt helper unavailable for ${server.version}; refusing to strip Smarty without a replacement"
-                    )
+            val settings = settingsProvider()
+            val userState = optionalModsStateProvider(server.assetDir)
+            val ignoredFiles = manifestProcessor.calculateIgnoredFiles(server, userState)
+            val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)
+            val smartyPlan = runCatching { smartyPlanner.plan(server, session.fileManifest, settings) }
+                .getOrElse {
+                    log.warn("Auto-sync: Smarty planning failed for {}: {}", server.assetDir, it.message)
+                    updateServerState(server.assetDir, ServerState.FAILED)
+                    failed++
+                    continue
                 }
 
+            // Refuse to strip Smarty with no replacement (same gate as a foreground
+            // launch): don't mutate the pack into a broken state in the background.
+            // This is "awaiting upstream/user action", not a failure -> SKIPPED, the
+            // same convention the 2FA branch uses.
+            if (settings.useOpenSmrtHelper && smartyPlan.ignoredAddon.isNotEmpty() &&
+                !helperPresent(clientDir, server.version, smartyPlan)) {
+                log.info("Auto-sync skipped for {}: no open-smrt helper for MC {}", server.assetDir, server.version)
+                updateServerState(server.assetDir, ServerState.SKIPPED)
+                continue
+            }
+
+            val ok = runCatching {
                 ClientSyncCoordinator.withClientLock(clientDir) {
                     downloadService.processSession(
                         session = session,

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -59,9 +59,14 @@ class FileDownloadService(
         messageUI: ((String) -> Unit)?,
         progressUI: ((Int, Int, Long, Long, String) -> Unit)?,
         verifyUI: ((Int, Int) -> Unit)?,
+        injectModJar: Path?,
+        strictModCheck: Boolean,
+        helperKeepGlobs: List<String>,
     ) = withContext(Dispatchers.IO) {
         val manifest = session.fileManifest ?: throw IOException("File manifest is empty!")
         Files.createDirectories(targetDir)
+
+        val filesMap = flattenManifest(manifest)
 
         // ── Disabled-mod cleanup runs UNCONDITIONALLY ────────────────────
         // Must precede the cache short-circuit below: a stale jar in
@@ -75,6 +80,34 @@ class FileDownloadService(
         // of launch latency.
         if (!ignoredFiles.isNullOrEmpty()) {
             cleanupIgnoredFiles(targetDir, ignoredFiles)
+        }
+
+        // Drop ignored entries from the working set BEFORE the cache gate.
+        // An ignored mod that the manifest still lists (e.g. the upstream
+        // Smarty jar we replace with open-smrt) is deliberately absent from
+        // disk; leaving it in filesMap would fail the disk-sanity walk on
+        // every launch and defeat the cache. The cache key already carries
+        // the ignored set, so a toggle change still invalidates correctly.
+        if (!ignoredFiles.isNullOrEmpty()) {
+            filesMap.keys.removeIf { relativePath ->
+                val clean = normalizePath(relativePath)
+                ignoredFiles.any { clean.endsWith("/$it") || clean == it }
+            }
+        }
+
+        // ── Smarty swap + strict verification -- also pre-cache ──────────
+        // Same reasoning as the disabled-mod cleanup: both must run before
+        // the cache gate so a cache hit still strips foreign jars and keeps
+        // the injected open-smrt helper in place. Strict prune first, then
+        // inject, so the prune can never delete the jar we just placed (it
+        // is also name-excepted as a belt-and-suspenders). The allowed set is
+        // the post-ignored filesMap, so a stripped Smarty jar is not re-admitted.
+        val injectName = injectModJar?.fileName?.toString()
+        if (strictModCheck) {
+            strictPruneMods(targetDir, filesMap.keys, injectName, helperKeepGlobs)
+        }
+        if (injectModJar != null) {
+            injectHelperJar(targetDir, injectModJar)
         }
 
         // ── Manifest cache short-circuit ─────────────────────────────────
@@ -91,7 +124,7 @@ class FileDownloadService(
         // cleanupIgnoredFiles above is the belt that catches stale jars,
         // the cache key is the suspenders that catches missing
         // newly-enabled jars.
-        val manifestHash = manifestCache.hashOf(cacheKeyInputFor(manifest, ignoredFiles))
+        val manifestHash = manifestCache.hashOf(cacheKeyInputFor(manifest, ignoredFiles, injectName, strictModCheck))
         // Disk-sanity gate: the manifest-cache file alone can't tell
         // that the user moved their data dir leaving manifest-cache/
         // behind, deleted clients/<id>/ by hand, removed one mod, or
@@ -116,7 +149,6 @@ class FileDownloadService(
         // entry or the cache silently masks a missing mod and the
         // game crashes downstream with a NoClassDefFoundError the
         // user can't map back to a launcher-side cause.
-        val filesMap = flattenManifest(manifest)
         val cacheValid = manifestCache.isClean(serverId, manifestHash) {
             filesMap.entries.all { (rawPath, fileData) ->
                 val path = targetDir.resolve(normalizePath(rawPath))
@@ -129,16 +161,6 @@ class FileDownloadService(
         if (cacheValid) {
             messageUI?.invoke("Files verified (cached)")
             return@withContext
-        }
-
-        // 2. Filtering -- remove disabled mods from the download set.
-        // (Their on-disk copies, if any, were already removed by the
-        // unconditional cleanupIgnoredFiles pass above the cache gate.)
-        if (!ignoredFiles.isNullOrEmpty()) {
-            filesMap.keys.removeIf { relativePath ->
-                val clean = normalizePath(relativePath)
-                ignoredFiles.any { clean.endsWith("/$it") || clean == it }
-            }
         }
 
         // 3. Downloading
@@ -156,14 +178,105 @@ class FileDownloadService(
     }
 
     /**
-     * Composes the cache-key input as `<canonical-manifest-json>|ignored:<sorted-csv>`.
+     * Composes the cache-key input as
+     * `<canonical-manifest-json>|ignored:<sorted-csv>|inject:<name>|strict:<bool>`.
      * Sorting the ignored set is mandatory -- `Set` iteration order isn't
      * stable, and the cache must be insensitive to insertion order while
-     * sensitive to membership changes.
+     * sensitive to membership changes. The inject + strict bits join the key so
+     * flipping either Smarty setting invalidates a previously-clean sync.
      */
-    private fun cacheKeyInputFor(manifest: FileManifest, ignoredFiles: Set<String>?): String {
+    private fun cacheKeyInputFor(
+        manifest: FileManifest,
+        ignoredFiles: Set<String>?,
+        injectName: String?,
+        strictModCheck: Boolean,
+    ): String {
         val ignored = ignoredFiles?.toSortedSet()?.joinToString(",") ?: ""
-        return indexJson.encodeToString(manifest) + "|ignored:" + ignored
+        return indexJson.encodeToString(manifest) +
+            "|ignored:" + ignored +
+            "|inject:" + (injectName ?: "") +
+            "|strict:" + strictModCheck
+    }
+
+    /**
+     * Deletes every jar in `mods/` whose basename is neither in the manifest
+     * ([manifestKeys], full manifest paths), the injected helper ([injectName]),
+     * nor a match for one of [helperKeepGlobs]. The blunt enforcement behind
+     * "Strict mod verification": removes user-added jars too, which is the
+     * documented intent. [helperKeepGlobs] is what keeps the open-smrt helper
+     * alive on a launch where the resolver couldn't refresh it (so [injectName]
+     * is null) -- without it, strict verification would delete the helper and
+     * the next sync would have no network mod. Mirrors
+     * `SmrtSyncService.pruneOrphanMods`; the recursive walk covers both
+     * top-level `mods/` and version subdirs like `mods/1.12.2/`.
+     */
+    private fun strictPruneMods(
+        baseDir: Path,
+        manifestKeys: Set<String>,
+        injectName: String?,
+        helperKeepGlobs: List<String>,
+    ) {
+        val modsDir = baseDir.resolve("mods")
+        if (!Files.isDirectory(modsDir)) return
+
+        val allowed = HashSet<String>(manifestKeys.size + 1)
+        manifestKeys.forEach { allowed.add(normalizePath(it).substringAfterLast('/')) }
+        if (injectName != null) allowed.add(injectName)
+        val keepPatterns = helperKeepGlobs.map { globToRegex(it) }
+
+        var removed = 0
+        try {
+            Files.walk(modsDir).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".jar") }
+                    .forEach { jar ->
+                        val name = jar.fileName.toString()
+                        if (name !in allowed && keepPatterns.none { it.matches(name) }) {
+                            runCatching {
+                                Files.delete(jar)
+                                removed++
+                                logger.debug("Strict mod check: pruned {}", jar)
+                            }.onFailure { logger.warn("Strict mod check: failed to prune {}", jar, it) }
+                        }
+                    }
+            }
+        } catch (e: Exception) {
+            logger.error("Strict mod check: error walking mods folder", e)
+        }
+        if (removed > 0) logger.info("Strict mod check: pruned {} foreign jar(s) from mods/", removed)
+    }
+
+    private fun globToRegex(glob: String): Regex {
+        val sb = StringBuilder()
+        for (c in glob) {
+            when (c) {
+                '*' -> sb.append(".*")
+                '?' -> sb.append('.')
+                else -> sb.append(Regex.escape(c.toString()))
+            }
+        }
+        return Regex(sb.toString(), RegexOption.IGNORE_CASE)
+    }
+
+    /**
+     * Copies the open-smrt-network helper into `mods/`, replacing the upstream
+     * Smarty coremod the caller stripped via `ignoredFiles`. Always overwrites:
+     * the source bytes were already SHA-256 verified by `OpenSmrtHelperResolver`,
+     * and a size-only skip would miss a same-size helper rebuild. The jar is tiny
+     * (single-digit KB), so an unconditional copy per sync is negligible.
+     */
+    private fun injectHelperJar(baseDir: Path, jar: Path) {
+        if (!Files.isRegularFile(jar)) {
+            logger.warn("open-smrt helper: jar {} missing at inject time; skipping", jar)
+            return
+        }
+        runCatching {
+            val modsDir = baseDir.resolve("mods")
+            Files.createDirectories(modsDir)
+            val dest = modsDir.resolve(jar.fileName.toString())
+            Files.copy(jar, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+            logger.info("open-smrt helper: injected {}", dest.fileName)
+        }.onFailure { logger.warn("open-smrt helper: failed to inject {}", jar, it) }
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -103,8 +103,14 @@ class FileDownloadService(
         // is also name-excepted as a belt-and-suspenders). The allowed set is
         // the post-ignored filesMap, so a stripped Smarty jar is not re-admitted.
         val injectName = injectModJar?.fileName?.toString()
+        // Canonical manifest locations (normalized, relative to the client dir),
+        // e.g. "mods/1.12.2/Foo.jar". Strict verification keeps a jar only at its
+        // manifest path, not by basename -- otherwise a stray top-level
+        // mods/Foo.jar would survive whenever the manifest lists
+        // mods/1.12.2/Foo.jar, and Forge (which scans both) loads the duplicate.
+        val strictAllowed: Set<String> = filesMap.keys.mapTo(HashSet()) { normalizePath(it) }
         if (strictModCheck) {
-            strictPruneMods(targetDir, filesMap.keys, injectName, helperKeepGlobs)
+            strictPruneMods(targetDir, strictAllowed, injectName, helperKeepGlobs)
         }
         if (injectModJar != null) {
             injectHelperJar(targetDir, injectModJar)
@@ -169,6 +175,15 @@ class FileDownloadService(
         // 4. Processing Extra.zip
         processExtraZip(targetDir, filesMap, extraCheckSum, messageUI)
 
+        // Re-run strict verification AFTER extra.zip extraction: the pre-cache
+        // pass above can't see a jar that an upstream extra.zip drops into mods/
+        // during this same sync, so without this the first launch wouldn't be
+        // exact. (In practice SC extra.zip payloads carry configs/scripts, not
+        // mods, so this is normally a no-op -- but it closes the window.)
+        if (strictModCheck) {
+            strictPruneMods(targetDir, strictAllowed, injectName, helperKeepGlobs)
+        }
+
         // 5. Mark this manifest as cleanly synced -- next session with the
         // same manifest hash short-circuits the integrity walk above.
         // Pass the manifest content too: the offline-launch path
@@ -199,30 +214,29 @@ class FileDownloadService(
     }
 
     /**
-     * Deletes every jar in `mods/` whose basename is neither in the manifest
-     * ([manifestKeys], full manifest paths), the injected helper ([injectName]),
-     * nor a match for one of [helperKeepGlobs]. The blunt enforcement behind
-     * "Strict mod verification": removes user-added jars too, which is the
-     * documented intent. [helperKeepGlobs] is what keeps the open-smrt helper
-     * alive on a launch where the resolver couldn't refresh it (so [injectName]
-     * is null) -- without it, strict verification would delete the helper and
-     * the next sync would have no network mod. Mirrors
-     * `SmrtSyncService.pruneOrphanMods`; the recursive walk covers both
-     * top-level `mods/` and version subdirs like `mods/1.12.2/`.
+     * Deletes every jar under `mods/` that the manifest does not place at that
+     * exact relative path ([allowedRelPaths], normalized like
+     * `mods/1.12.2/Foo.jar`), except the injected helper ([injectName] /
+     * [helperKeepGlobs], matched by basename since the helper lives at a single
+     * canonical location). Matching by path rather than basename is what makes
+     * verification *exact*: a stray top-level `mods/Foo.jar` is pruned even when
+     * the manifest legitimately ships `mods/1.12.2/Foo.jar`, so Forge (which
+     * scans both) never loads the duplicate. The blunt enforcement behind
+     * "Strict mod verification" -- removes user-added jars too, which is the
+     * documented intent. The recursive walk covers both top-level `mods/` and
+     * version subdirs.
      */
     private fun strictPruneMods(
         baseDir: Path,
-        manifestKeys: Set<String>,
+        allowedRelPaths: Set<String>,
         injectName: String?,
         helperKeepGlobs: List<String>,
     ) {
         val modsDir = baseDir.resolve("mods")
         if (!Files.isDirectory(modsDir)) return
 
-        val allowed = HashSet<String>(manifestKeys.size + 1)
-        manifestKeys.forEach { allowed.add(normalizePath(it).substringAfterLast('/')) }
-        if (injectName != null) allowed.add(injectName)
         val keepPatterns = helperKeepGlobs.map { globToRegex(it) }
+        val baseNorm = baseDir.normalize()
 
         var removed = 0
         try {
@@ -231,7 +245,11 @@ class FileDownloadService(
                     .filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".jar") }
                     .forEach { jar ->
                         val name = jar.fileName.toString()
-                        if (name !in allowed && keepPatterns.none { it.matches(name) }) {
+                        val rel = baseNorm.relativize(jar.normalize()).toString().replace('\\', '/')
+                        val keep = rel in allowedRelPaths ||
+                            name == injectName ||
+                            keepPatterns.any { it.matches(name) }
+                        if (!keep) {
                             runCatching {
                                 Files.delete(jar)
                                 removed++

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -31,6 +31,8 @@ import hivens.launcher.runtime.loader.LoaderRegistry
 import hivens.launcher.runtime.loader.ModernInstallerResolver
 import hivens.launcher.security.KeyringStorageFactory
 import hivens.launcher.smrt.ModIconResolver
+import hivens.launcher.smrt.OpenSmrtHelperResolver
+import hivens.launcher.smrt.SmartyModPlanner
 import hivens.launcher.smrt.SmrtPackClient
 import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.update.UpdateApplicators
@@ -403,6 +405,12 @@ val appModule = module {
     // Always wired so toggling on at runtime requires no graph rebuild.
     single { SmrtPackClient(get(named("direct"))) }
     single { SmrtSyncService(get(), get()) }
+
+    // Smarty -> open-smrt-network swap. Direct channel: GitHub releases +
+    // raw.githubusercontent.com are public, no SC proxy. The planner is what
+    // both sync paths (LauncherController, AutoSyncService) consult.
+    single { OpenSmrtHelperResolver(get(named("direct")), get(), get()) }
+    single { SmartyModPlanner(get<OpenSmrtHelperResolver>()::resolve, get()) }
     single { PackInstaller(syncService = get(), runtimeProvisioner = get(), repository = get(), dataDir = get()) }
     single {
         MrpackInstaller(
@@ -531,6 +539,7 @@ val appModule = module {
         val dataDir: Path = get()
         val profiles: ProfileManager = get()
         val credentials: CredentialsManager = get()
+        val settings: ISettingsService = get()
         AutoSyncService(
             authService = get(),
             downloadService = get(),
@@ -541,6 +550,8 @@ val appModule = module {
             optionalModsStateProvider = { serverId ->
                 profiles.getProfile(serverId).optionalModsState
             },
+            smartyPlanner = get(),
+            settingsProvider = { settings.getSettings() },
         )
     }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
@@ -29,6 +29,15 @@ sealed class LaunchError {
     data class AuthFail(val cause: String?) : LaunchError()
 
     /**
+     * The open-smrt helper swap is enabled and the server ships the
+     * proprietary Smarty jar, but no helper is available for [mcVersion]
+     * (unsupported version / descriptor down / nothing cached). The launch
+     * is blocked rather than stripping Smarty with no replacement (broken
+     * join) or silently keeping the surveillance mod.
+     */
+    data class HelperUnavailable(val mcVersion: String) : LaunchError()
+
+    /**
      * Pack declares an auth requirement the user has no live session
      * for. The UI renders a "sign in with <provider> to play this
      * pack" hint -- distinct from [AuthFail] (where the user IS

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -11,12 +11,14 @@ import hivens.core.data.OptionalContentRules
 import hivens.core.data.PackAuthRequirement
 import hivens.core.data.PackInstance
 import hivens.core.data.SessionData
-import hivens.core.data.SettingsData
 import hivens.core.diag.ActionRing
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
 import hivens.launcher.di.AppCoroutineScopeHook
+import hivens.launcher.smrt.ClientSyncCoordinator
+import hivens.launcher.smrt.OpenSmrtHelperResolver
+import hivens.launcher.smrt.SmartyModPlanner
 import hivens.launcher.smrt.SmrtPackClient
 import hivens.launcher.smrt.SmrtSyncService
 import kotlinx.coroutines.*
@@ -61,6 +63,7 @@ class LauncherController(
     private val packRepository: IPackRepository,
     private val smrtPackClient: SmrtPackClient,
     private val smrtSyncService: SmrtSyncService,
+    private val smartyPlanner: SmartyModPlanner,
     private val dataDirectory: Path,
     private val appScope: CoroutineScope,
 ) {
@@ -297,34 +300,55 @@ class LauncherController(
                     }
                     emit(LaunchLogEvent.OfflineSkipSync)
                 } else {
-                    downloadService.processSession(
-                        session = session,
-                        serverId = targetServerId,
-                        targetDir = clientDir,
-                        extraCheckSum = server.extraCheckSum,
-                        ignoredFiles = ignoredFiles,
-                        messageUI = { /* log */ },
-                        progressUI = { current, total, bytesRead, totalBytes, speed ->
-                            if (!isActive) return@processSession
-                            _state.value = LaunchState.Downloading(
-                                currentFileIdx   = current,
-                                totalFiles       = total,
-                                downloadedBytes  = bytesRead,
-                                totalBytes       = totalBytes,
-                                speedBytesPerSec = parseSpeedString(speed),
-                            )
-                        },
-                        // Map integrity-walk progress onto the SYNC stage's 0.2..0.7
-                        // sub-range. The actual download progress takes over from
-                        // 0.7 upward via the Downloading state above. Without
-                        // this, the progress bar froze at 20% during the MD5
-                        // walk on 1000-file modpacks -- 5-30s of perceived hang.
-                        verifyUI = { verified, total ->
-                            if (!isActive) return@processSession
-                            val fraction = if (total > 0) verified.toFloat() / total else 0f
-                            setStage(PrepareStage.SYNC, 0.2f + 0.5f * fraction)
-                        },
-                    )
+                    // Smarty swap / strict plan -- computed here (not in the offline
+                    // branch) so an offline launch never makes the resolver's
+                    // doomed network fetch.
+                    val smartyPlan = smartyPlanner.plan(server, session.fileManifest, settings)
+
+                    // Block rather than strip Smarty with no replacement: if the swap
+                    // is on and the manifest ships Smarty but no helper is available
+                    // for this MC version (unsupported version / descriptor down /
+                    // nothing cached), launching would either join with no network
+                    // mod (kick) or, if we kept Smarty, run the surveillance mod.
+                    if (settings.useOpenSmrtHelper && smartyPlan.ignoredAddon.isNotEmpty() &&
+                        !helperPresent(clientDir, server.version, smartyPlan)) {
+                        fail(LaunchError.HelperUnavailable(server.version))
+                        return@launch
+                    }
+
+                    ClientSyncCoordinator.withClientLock(clientDir) {
+                        downloadService.processSession(
+                            session = session,
+                            serverId = targetServerId,
+                            targetDir = clientDir,
+                            extraCheckSum = server.extraCheckSum,
+                            ignoredFiles = ignoredFiles + smartyPlan.ignoredAddon,
+                            messageUI = { /* log */ },
+                            progressUI = { current, total, bytesRead, totalBytes, speed ->
+                                if (!isActive) return@processSession
+                                _state.value = LaunchState.Downloading(
+                                    currentFileIdx   = current,
+                                    totalFiles       = total,
+                                    downloadedBytes  = bytesRead,
+                                    totalBytes       = totalBytes,
+                                    speedBytesPerSec = parseSpeedString(speed),
+                                )
+                            },
+                            // Map integrity-walk progress onto the SYNC stage's 0.2..0.7
+                            // sub-range. The actual download progress takes over from
+                            // 0.7 upward via the Downloading state above. Without
+                            // this, the progress bar froze at 20% during the MD5
+                            // walk on 1000-file modpacks -- 5-30s of perceived hang.
+                            verifyUI = { verified, total ->
+                                if (!isActive) return@processSession
+                                val fraction = if (total > 0) verified.toFloat() / total else 0f
+                                setStage(PrepareStage.SYNC, 0.2f + 0.5f * fraction)
+                            },
+                            injectModJar = smartyPlan.injectJar,
+                            strictModCheck = smartyPlan.strict,
+                            helperKeepGlobs = smartyPlan.helperKeepGlobs,
+                        )
+                    }
                 }
 
                 // 4. Java
@@ -674,6 +698,15 @@ class LauncherController(
         val userState = profileManager.getProfile(server.assetDir).optionalModsState
         return manifestProcessor.calculateIgnoredFiles(server, userState)
     }
+
+    /**
+     * A helper is usable for [mcVersion] when one was resolved this launch
+     * ([SmartyModPlanner.Plan.injectJar]) or a previously-injected one of the
+     * exact expected name is still on disk.
+     */
+    private fun helperPresent(clientDir: Path, mcVersion: String, plan: SmartyModPlanner.Plan): Boolean =
+        plan.injectJar != null ||
+            Files.isRegularFile(clientDir.resolve("mods").resolve(OpenSmrtHelperResolver.helperFileName(mcVersion)))
 
     /**
      * Best-effort parse of FileDownloadService's pre-formatted speed string

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/ClientSyncCoordinator.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/ClientSyncCoordinator.kt
@@ -1,0 +1,31 @@
+package hivens.launcher.smrt
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Serializes file-mutating sync of a single `clients/<id>/` directory across the
+ * two entry points that touch it -- a foreground launch
+ * ([hivens.launcher.launch.LauncherController]) and background auto-sync
+ * ([hivens.launcher.AutoSyncService]). Both can fire for the same pack at the
+ * same time; without a lock, one path's strict-prune (`Files.delete`) races the
+ * other's download / helper inject (`Files.copy`) over the same `mods/`, which
+ * corrupts the install (a just-pruned jar, a half-copied helper, a
+ * `NoSuchFileException` surfaced as a generic launch error).
+ *
+ * A process-wide registry of per-directory mutexes (keyed by the normalized
+ * absolute path). An `object` rather than a DI singleton so it needs no
+ * constructor plumbing through both call sites; the lock is global by nature.
+ * The map is bounded by the number of installed packs, so no eviction needed.
+ */
+object ClientSyncCoordinator {
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
+    suspend fun <T> withClientLock(clientDir: Path, block: suspend () -> T): T {
+        val key = clientDir.toAbsolutePath().normalize().toString()
+        val mutex = locks.computeIfAbsent(key) { Mutex() }
+        return mutex.withLock { block() }
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolver.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolver.kt
@@ -1,0 +1,196 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.data.SmrtHelperDescriptor
+import hivens.core.data.SmrtHelperVariant
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+
+/**
+ * Resolves the open-smrt-network helper jar that replaces the upstream Smarty
+ * coremod for a raw SmartyCraft server of a given Minecraft version.
+ *
+ * The per-version pin (release tag, asset, SHA-256, Smarty filenames to strip)
+ * comes from an out-of-band [SmrtHelperDescriptor] hosted in the
+ * open-smrt-network repo -- so the pin moves without a Nexira release, the same
+ * pattern `UpdateService` uses for `update-channel.json`. The jar is downloaded
+ * from the corresponding GitHub release, SHA-256 verified, and cached once per
+ * version under `<dataDir>/helpers/` for reuse across every pack.
+ *
+ * Every failure path returns null: no descriptor, no matching variant, network
+ * error, or hash mismatch all mean "no helper available", and the caller falls
+ * back to the upstream Smarty jar so the launcher stays usable until the
+ * open-smrt-network release pipeline exists.
+ */
+class OpenSmrtHelperResolver(
+    private val clientProvider: HttpClientProvider,
+    private val json: Json,
+    dataDirectory: Path,
+) {
+    private val log = LoggerFactory.getLogger(OpenSmrtHelperResolver::class.java)
+    private val helpersDir = dataDirectory.resolve("helpers")
+    private val descriptorCache = helpersDir.resolve("smrt-helper.json")
+    private val client get() = clientProvider.current
+
+    /** A resolved helper: the local jar to inject + the Smarty names it replaces. */
+    data class Resolved(val jar: Path, val smartyNames: List<String>)
+
+    /**
+     * Resolves + downloads the helper for [mcVersion], or null when no usable
+     * replacement could be obtained. Cheap on a warm cache (one stat + hash of
+     * an already-present jar), one network round-trip cold.
+     */
+    suspend fun resolve(mcVersion: String): Resolved? = withContext(Dispatchers.IO) {
+        // Bounded so a slow/hung CDN can't stall the launch hot path; null on
+        // timeout (handled like any other resolve miss).
+        withTimeoutOrNull(RESOLVE_TIMEOUT_MS) {
+            val descriptor = fetchDescriptor() ?: return@withTimeoutOrNull null
+            val variant = descriptor.variantFor(mcVersion) ?: run {
+                log.warn("open-smrt helper: no variant for MC {} in descriptor", mcVersion)
+                return@withTimeoutOrNull null
+            }
+            val jar = downloadVerified(mcVersion, variant) ?: return@withTimeoutOrNull null
+            Resolved(jar, variant.smartyNames)
+        }
+    }
+
+    /**
+     * Fetches the descriptor from the open-smrt-network repo, writing every
+     * successful fetch to a local last-good cache. A failed fetch (offline,
+     * non-200, parse error) falls back to that cache instead of returning null
+     * -- so a brief GitHub outage doesn't drop the pinned variant and, with it,
+     * flip the launcher back toward the upstream Smarty jar. Returns null only
+     * when the network failed AND no cache has ever been written.
+     */
+    internal suspend fun fetchDescriptor(): SmrtHelperDescriptor? {
+        val fetched = try {
+            val response = client.get(DESCRIPTOR_URL) { header("Accept", "application/json") }
+            if (response.status.value != 200) {
+                log.debug("smrt-helper.json fetch returned {}", response.status)
+                null
+            } else {
+                val body = response.bodyAsText()
+                val parsed = json.decodeFromString<SmrtHelperDescriptor>(body)
+                // Only overwrite the last-good cache with a USEFUL descriptor: a
+                // 200 serving an empty `variants:[]` (placeholder / mis-deploy)
+                // must not poison the cache and leave us variant-less offline.
+                if (parsed.variants.isNotEmpty()) {
+                    runCatching {
+                        Files.createDirectories(helpersDir)
+                        Files.writeString(descriptorCache, body)
+                    }
+                }
+                parsed
+            }
+        } catch (e: Exception) {
+            log.debug("Failed to fetch smrt-helper.json", e)
+            null
+        }
+        if (fetched != null) return fetched
+        return readCachedDescriptor()?.also {
+            log.info("open-smrt helper: using last-good descriptor cache (live fetch failed)")
+        }
+    }
+
+    private fun readCachedDescriptor(): SmrtHelperDescriptor? = runCatching {
+        if (Files.isRegularFile(descriptorCache)) {
+            json.decodeFromString<SmrtHelperDescriptor>(Files.readString(descriptorCache))
+        } else null
+    }.getOrNull()
+
+    private suspend fun downloadVerified(mcVersion: String, variant: SmrtHelperVariant): Path? {
+        val dest = helpersDir.resolve(helperFileName(mcVersion))
+        if (sha256Of(dest)?.equals(variant.sha256, ignoreCase = true) == true) {
+            return dest
+        }
+        return try {
+            Files.createDirectories(helpersDir)
+            val url = "https://github.com/$OPEN_SMRT_REPO/releases/download/${variant.tag}/${variant.asset}"
+            log.info("open-smrt helper: downloading {} <- {}", dest.fileName, url)
+            downloadToFile(url, dest)
+            val onDisk = sha256Of(dest)
+            if (onDisk?.equals(variant.sha256, ignoreCase = true) != true) {
+                log.warn(
+                    "open-smrt helper: SHA-256 mismatch for {} (expected {}, got {}); discarding",
+                    variant.asset, variant.sha256, onDisk,
+                )
+                Files.deleteIfExists(dest)
+                null
+            } else {
+                dest
+            }
+        } catch (e: Exception) {
+            log.warn("open-smrt helper: download failed for {}", variant.asset, e)
+            runCatching { Files.deleteIfExists(dest) }
+            null
+        }
+    }
+
+    private suspend fun downloadToFile(url: String, dest: Path) {
+        val tmp = dest.resolveSibling("${dest.fileName}.tmp")
+        runCatching { Files.deleteIfExists(tmp) }
+        client.prepareGet(url).execute { response ->
+            if (response.status.value != 200) throw java.io.IOException("HTTP ${response.status} for $url")
+            val channel = response.bodyAsChannel()
+            FileOutputStream(tmp.toFile()).use { out ->
+                val buf = ByteArray(64 * 1024)
+                while (!channel.isClosedForRead) {
+                    val n = channel.readAvailable(buf, 0, buf.size)
+                    if (n <= 0) break
+                    out.write(buf, 0, n)
+                }
+            }
+        }
+        Files.move(tmp, dest, StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    private fun sha256Of(p: Path): String? {
+        if (!Files.isRegularFile(p)) return null
+        return runCatching {
+            val md = MessageDigest.getInstance("SHA-256")
+            Files.newInputStream(p).use { input ->
+                val buf = ByteArray(64 * 1024)
+                while (true) {
+                    val n = input.read(buf)
+                    if (n <= 0) break
+                    md.update(buf, 0, n)
+                }
+            }
+            md.digest().joinToString("") { "%02x".format(it) }
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val OPEN_SMRT_REPO = "Kitty-Hivens/open-smrt-network"
+        private const val DESCRIPTOR_URL =
+            "https://raw.githubusercontent.com/$OPEN_SMRT_REPO/main/meta/smrt-helper.json"
+
+        /** Bound the whole resolve so a slow CDN can't stall the launch hot path. */
+        private const val RESOLVE_TIMEOUT_MS = 15_000L
+
+        private fun sanitize(version: String): String =
+            version.map { if (it.isLetterOrDigit() || it == '.') it else '_' }.joinToString("")
+
+        /**
+         * The exact `mods/` filename the helper is injected under for [mcVersion]
+         * (one per MC version, reused across pin bumps). Shared with the planner so
+         * strict verification keeps THIS file by exact name rather than a wildcard
+         * that would also shield a stale sibling-version jar or a lookalike.
+         */
+        fun helperFileName(mcVersion: String): String = "open-smrt-network-${sanitize(mcVersion)}.jar"
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolver.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolver.kt
@@ -32,9 +32,9 @@ import java.security.MessageDigest
  * version under `<dataDir>/helpers/` for reuse across every pack.
  *
  * Every failure path returns null: no descriptor, no matching variant, network
- * error, or hash mismatch all mean "no helper available", and the caller falls
- * back to the upstream Smarty jar so the launcher stays usable until the
- * open-smrt-network release pipeline exists.
+ * error, or hash mismatch all mean "no helper available". The caller still
+ * strips Smarty (never re-admits the surveillance mod) and, if nothing is
+ * cached on disk either, blocks the launch rather than running it.
  */
 class OpenSmrtHelperResolver(
     private val clientProvider: HttpClientProvider,

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmartyModPlanner.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmartyModPlanner.kt
@@ -1,0 +1,116 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.interfaces.IManifestProcessorService
+import hivens.core.api.model.ServerProfile
+import hivens.core.data.FileManifest
+import hivens.core.data.SettingsData
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+/**
+ * Turns the two Smarty settings + a server's manifest into a concrete sync
+ * plan: which Smarty jars to strip, which open-smrt-network jar to inject, and
+ * whether to run strict mod verification. Shared by both sync entry points
+ * ([hivens.launcher.launch.LauncherController] and
+ * [hivens.launcher.AutoSyncService]) so foreground launch and background sync
+ * apply the same swap.
+ *
+ * Swap ON is authoritative: the proprietary Smarty jar is stripped from the
+ * sync set whether or not the helper resolves this launch, so a transient
+ * resolver failure can never re-admit the surveillance mod. Fetching the
+ * open-smrt-network jar is best-effort on top -- a launch that can't refresh it
+ * relies on the on-disk copy (protected from strict verification by
+ * [Plan.helperKeepGlobs]). Strict verification is independent of the helper.
+ */
+class SmartyModPlanner(
+    /**
+     * Resolves the open-smrt-network helper for an MC version, or null when none
+     * is available. A function rather than the concrete [OpenSmrtHelperResolver]
+     * so the planner is unit-testable without a live network (the resolver is a
+     * final class and this codebase runs mockk without the inline-mock agent).
+     */
+    private val resolveHelper: suspend (mcVersion: String) -> OpenSmrtHelperResolver.Resolved?,
+    private val manifestProcessor: IManifestProcessorService,
+) {
+    private val log = LoggerFactory.getLogger(SmartyModPlanner::class.java)
+
+    /**
+     * @param ignoredAddon Smarty jar basenames to remove from the sync set
+     *        (composed with the optional-mod ignore set by the caller).
+     * @param injectJar local open-smrt-network jar to copy into `mods/`, or null
+     *        when the helper couldn't be fetched this launch.
+     * @param strict whether to delete every jar in `mods/` absent from the manifest.
+     * @param helperKeepGlobs jar-name globs strict verification must always keep
+     *        (the open-smrt helper), even on a launch where [injectJar] is null.
+     *        Non-empty only while the swap is on, so turning the swap off lets the
+     *        leftover helper be pruned and the upstream mod return.
+     */
+    data class Plan(
+        val ignoredAddon: Set<String>,
+        val injectJar: Path?,
+        val strict: Boolean,
+        val helperKeepGlobs: List<String>,
+    ) {
+        companion object {
+            val NONE = Plan(emptySet(), null, false, emptyList())
+        }
+    }
+
+    suspend fun plan(server: ServerProfile, manifest: FileManifest?, settings: SettingsData): Plan {
+        val strict = settings.strictModVerification
+        if (!settings.useOpenSmrtHelper) {
+            return Plan(emptySet(), null, strict, emptyList())
+        }
+
+        // Best-effort: may be null on a network hiccup, an empty descriptor, or a
+        // hash mismatch. We strip Smarty regardless -- never re-admit it.
+        val resolved = resolveHelper(server.version)
+        val smartyGlobs = resolved?.smartyNames?.takeIf { it.isNotEmpty() } ?: DEFAULT_SMARTY_GLOBS
+        val ignored = manifest?.let { matchingSmartyNames(it, smartyGlobs) } ?: emptySet()
+        if (resolved == null) {
+            log.warn(
+                "open-smrt helper not fetched for {} (MC {}); Smarty stripped anyway, " +
+                    "relying on the on-disk helper if present",
+                server.name, server.version,
+            )
+        } else if (ignored.isEmpty()) {
+            log.info("open-smrt helper: no Smarty jar in {} manifest matched {}", server.name, smartyGlobs)
+        }
+        // Keep ONLY this version's exact helper filename -- a wildcard would also
+        // shield a stale sibling-version jar (two coremods loaded) or an unrelated
+        // open-smrt-network-*.jar a hostile manifest dropped in.
+        return Plan(ignored, resolved?.jar, strict, listOf(OpenSmrtHelperResolver.helperFileName(server.version)))
+    }
+
+    /** Manifest jar basenames matching any of the [smartyNames] globs. */
+    private fun matchingSmartyNames(manifest: FileManifest, smartyNames: List<String>): Set<String> {
+        val patterns = smartyNames.map { globToRegex(it) }
+        return manifestProcessor.flattenManifest(manifest).keys
+            .map { it.substringAfterLast('/') }
+            .filter { name -> patterns.any { it.matches(name) } }
+            .toSet()
+    }
+
+    private fun globToRegex(glob: String): Regex {
+        val sb = StringBuilder()
+        for (c in glob) {
+            when (c) {
+                '*' -> sb.append(".*")
+                '?' -> sb.append('.')
+                else -> sb.append(Regex.escape(c.toString()))
+            }
+        }
+        return Regex(sb.toString(), RegexOption.IGNORE_CASE)
+    }
+
+    companion object {
+        /**
+         * Fallback Smarty matcher when the descriptor is empty/unreachable. A
+         * broad prefix catch (not `Smarty-*`) on purpose: missing the surveillance
+         * jar (it keeps spying) is worse than stripping a same-prefixed third-party
+         * mod. Per-version exact names can override via the descriptor's
+         * `smarty_names` once the real upstream filenames are verified.
+         */
+        private val DEFAULT_SMARTY_GLOBS = listOf("Smarty*.jar")
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/AutoSyncServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/AutoSyncServiceTest.kt
@@ -5,6 +5,8 @@ import hivens.core.api.interfaces.IFileDownloadService
 import hivens.core.api.interfaces.IManifestProcessorService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.SessionData
+import hivens.core.data.SettingsData
+import hivens.launcher.smrt.SmartyModPlanner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -45,6 +47,11 @@ class AutoSyncServiceTest {
 
         every { manifestProcessor.calculateIgnoredFiles(any(), any()) } returns emptySet()
 
+        // Smarty planning is exercised in SmartyModPlannerTest; here the helper
+        // never resolves and both Smarty settings are off, so the plan is a
+        // no-op and these tests stay focused on the queue / state machine.
+        val smartyPlanner = SmartyModPlanner(resolveHelper = { null }, manifestProcessor = manifestProcessor)
+
         service = AutoSyncService(
             authService = authService,
             downloadService = downloadService,
@@ -53,6 +60,8 @@ class AutoSyncServiceTest {
             dataDirectory = sandbox,
             credentialsProvider = { stubCredentials },
             optionalModsStateProvider = { emptyMap() },
+            smartyPlanner = smartyPlanner,
+            settingsProvider = { SettingsData(useOpenSmrtHelper = false, strictModVerification = false) },
         )
     }
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
@@ -376,6 +376,160 @@ class FileDownloadDiskIntegrationTest {
             "non-ignored jar must survive cleanup")
     }
 
+    // ── Smarty swap: strict verification + helper injection ───────────────
+
+    @Test
+    fun `strict mod check deletes foreign jar, keeps manifest jar and injected helper`() = runBlocking {
+        val files = mapOf("mods/keeper.jar" to "keep me".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        // A user-added jar the manifest never lists -- strict mode must remove it.
+        Files.createDirectories(clientDir.resolve("mods"))
+        Files.write(clientDir.resolve("mods/foreign.jar"), "i should not be here".toByteArray())
+
+        // The open-smrt helper the launcher injects in Smarty's place.
+        val helper = workDir / "helpers" / "open-smrt-network-1.12.jar"
+        Files.createDirectories(helper.parent)
+        Files.write(helper, "open-smrt bytes".toByteArray())
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, null, null, null,
+            injectModJar = helper, strictModCheck = true,
+        )
+
+        assertTrue(Files.exists(clientDir.resolve("mods/keeper.jar")),
+            "manifest jar must survive strict check")
+        assertTrue(!Files.exists(clientDir.resolve("mods/foreign.jar")),
+            "foreign jar absent from manifest must be pruned")
+        assertTrue(Files.exists(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "injected helper must be present and exempt from the strict prune")
+        assertEquals("open-smrt bytes",
+            Files.readString(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "injected helper bytes must match the resolved source")
+    }
+
+    @Test
+    fun `without strict check a foreign jar survives while the helper still injects`() = runBlocking {
+        val files = mapOf("mods/keeper.jar" to "keep me".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        Files.createDirectories(clientDir.resolve("mods"))
+        Files.write(clientDir.resolve("mods/foreign.jar"), "left alone".toByteArray())
+
+        val helper = workDir / "helpers" / "open-smrt-network-1.12.jar"
+        Files.createDirectories(helper.parent)
+        Files.write(helper, "open-smrt bytes".toByteArray())
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, null, null, null,
+            injectModJar = helper, strictModCheck = false,
+        )
+
+        assertTrue(Files.exists(clientDir.resolve("mods/foreign.jar")),
+            "foreign jar must survive when strict check is off")
+        assertTrue(Files.exists(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "helper must inject regardless of strict check")
+    }
+
+    @Test
+    fun `helper injection is idempotent across re-sync`() = runBlocking {
+        val files = mapOf("mods/keeper.jar" to "keep me".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        val helper = workDir / "helpers" / "open-smrt-network-1.12.jar"
+        Files.createDirectories(helper.parent)
+        Files.write(helper, "open-smrt bytes".toByteArray())
+
+        repeat(2) {
+            svc.processSession(
+                sessionWith(manifest), "Industrial", clientDir,
+                null, null, null, null,
+                injectModJar = helper, strictModCheck = true,
+            )
+        }
+
+        assertEquals("open-smrt bytes",
+            Files.readString(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "second sync must leave the helper intact, not duplicate or corrupt it")
+    }
+
+    @Test
+    fun `swapped Smarty in manifest still allows the cache to short-circuit`() = runBlocking {
+        // The upstream manifest lists Smarty; we ignore it (swap) and the jar
+        // never lands on disk. The disk-sanity walk must not treat that
+        // deliberate absence as a reason to refetch on every launch -- otherwise
+        // the default-on swap would kill the cache for every SmartyCraft server.
+        val files = mapOf(
+            "mods/keeper.jar" to "keep me".toByteArray(),
+            "mods/Smarty-1.12.2.jar" to "surveillance".toByteArray(),
+        )
+        val manifest = manifestOf(files)
+        val (svc, requests) = newService(files)
+
+        val helper = workDir / "helpers" / "open-smrt-network-1.12.jar"
+        Files.createDirectories(helper.parent)
+        Files.write(helper, "open-smrt bytes".toByteArray())
+        val ignored = setOf("Smarty-1.12.2.jar")
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, ignored, null, null,
+            injectModJar = helper, strictModCheck = true,
+        )
+        val afterFirst = requests.get()
+        assertTrue(!Files.exists(clientDir.resolve("mods/Smarty-1.12.2.jar")),
+            "Smarty must not be downloaded when swapped")
+        assertTrue(Files.exists(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "helper present after first sync")
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, ignored, null, null,
+            injectModJar = helper, strictModCheck = true,
+        )
+
+        assertEquals(afterFirst, requests.get(),
+            "second swapped sync must hit the cache -- zero new fetches")
+        assertTrue(!Files.exists(clientDir.resolve("mods/Smarty-1.12.2.jar")),
+            "Smarty stays gone on the cache-hot path")
+        assertTrue(Files.exists(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "helper stays put on the cache-hot path")
+    }
+
+    @Test
+    fun `strict prune keeps the helper by glob even when nothing is injected this launch`() = runBlocking {
+        // The stability fix: a launch where the resolver couldn't refresh the
+        // helper passes injectModJar = null, but helperKeepGlobs still protects
+        // the on-disk helper from strict verification. Without it, strict mode
+        // would delete the helper and the join would lose its network mod.
+        val files = mapOf("mods/keeper.jar" to "keep me".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        Files.createDirectories(clientDir.resolve("mods"))
+        Files.write(clientDir.resolve("mods/open-smrt-network-1.12.jar"), "helper bytes".toByteArray())
+        Files.write(clientDir.resolve("mods/foreign.jar"), "delete me".toByteArray())
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, null, null, null,
+            injectModJar = null, strictModCheck = true,
+            helperKeepGlobs = listOf("open-smrt-network*.jar"),
+        )
+
+        assertTrue(Files.exists(clientDir.resolve("mods/open-smrt-network-1.12.jar")),
+            "helper must survive strict prune via the keep-glob with no injection this launch")
+        assertTrue(!Files.exists(clientDir.resolve("mods/foreign.jar")),
+            "foreign jar is still pruned")
+        assertTrue(Files.exists(clientDir.resolve("mods/keeper.jar")),
+            "manifest jar kept")
+    }
+
     // ── Network failure ───────────────────────────────────────────────────
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
@@ -530,6 +530,31 @@ class FileDownloadDiskIntegrationTest {
             "manifest jar kept")
     }
 
+    @Test
+    fun `strict prune matches the manifest path, not the basename`() = runBlocking {
+        // The manifest places Foo.jar in a version subdir. A stray top-level
+        // mods/Foo.jar with the same basename is NOT what the server asked for
+        // and Forge would load it as a duplicate -- strict verification must
+        // prune it even though a jar of that name appears in the manifest.
+        val files = mapOf("mods/1.12.2/Foo.jar" to "the real foo".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        Files.createDirectories(clientDir.resolve("mods"))
+        Files.write(clientDir.resolve("mods/Foo.jar"), "stray duplicate".toByteArray())
+
+        svc.processSession(
+            sessionWith(manifest), "Industrial", clientDir,
+            null, null, null, null,
+            injectModJar = null, strictModCheck = true,
+        )
+
+        assertTrue(Files.exists(clientDir.resolve("mods/1.12.2/Foo.jar")),
+            "the manifest jar at its declared path is kept")
+        assertTrue(!Files.exists(clientDir.resolve("mods/Foo.jar")),
+            "a same-name jar at a non-manifest path is pruned (no basename free pass)")
+    }
+
     // ── Network failure ───────────────────────────────────────────────────
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -17,6 +17,7 @@ import hivens.core.security.IKeyringStorage
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
+import hivens.launcher.smrt.SmartyModPlanner
 import hivens.launcher.smrt.SmrtPackClient
 import io.mockk.coEvery
 import io.mockk.coJustRun
@@ -80,6 +81,7 @@ class LauncherControllerTest {
     private lateinit var profileManager: ProfileManager
     private lateinit var packRepository: IPackRepository
     private lateinit var smrtPackClient: SmrtPackClient
+    private lateinit var smartyPlanner: SmartyModPlanner
 
     private val server = ServerProfile(
         name     = "TestSrv",
@@ -115,8 +117,14 @@ class LauncherControllerTest {
         // constructor without any stubbing.
         packRepository     = mockk(relaxed = true)
         smrtPackClient     = mockk(relaxed = true)
+        // No Smarty swap in SC-launch tests; the helper never resolves, so the
+        // plan injects nothing. The swap path has its own test.
+        smartyPlanner      = SmartyModPlanner(resolveHelper = { null }, manifestProcessor = manifestProcessor)
 
         every { manifestProcessor.calculateIgnoredFiles(any(), any()) } returns emptySet()
+        // Swap planning (enabled by default in SettingsData) flattens the manifest
+        // to find Smarty jars to strip; no Smarty in these SC-launch fixtures.
+        every { manifestProcessor.flattenManifest(any()) } returns emptyMap()
         coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/usr/bin/java")
     }
 
@@ -139,6 +147,7 @@ class LauncherControllerTest {
         packRepository     = packRepository,
         smrtPackClient     = smrtPackClient,
         smrtSyncService    = mockk(relaxed = true),
+        smartyPlanner      = smartyPlanner,
         dataDirectory      = sandbox,
         appScope           = scope,
     )
@@ -167,6 +176,9 @@ class LauncherControllerTest {
                 messageUI = any(),
                 progressUI = any(),
                 verifyUI = any(),
+                injectModJar = any(),
+                strictModCheck = any(),
+                helperKeepGlobs = any(),
             )
         }
 
@@ -222,7 +234,36 @@ class LauncherControllerTest {
         assertEquals(LaunchError.OfflineNoClient, state.reason)
 
         coVerify(exactly = 0) {
-            downloadService.processSession(any(), any(), any(), any(), any(), any(), any(), any())
+            downloadService.processSession(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `swap on with Smarty in manifest but no helper blocks the launch`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()  // useOpenSmrtHelper = true
+        // Manifest ships the proprietary Smarty jar; the planner's default glob
+        // matches it, and the resolver (newController stubs resolveHelper = null)
+        // yields no helper, with none on disk -> launch must be blocked.
+        every { manifestProcessor.flattenManifest(any()) } returns
+            mapOf("mods/Smarty-1.7.10.jar" to hivens.core.data.FileData("x", 1))
+
+        val session = SessionData(
+            playerName = "tester",
+            cachedPassword = "pw",
+            fileManifest = FileManifest(),
+        )
+        coEvery { authService.login("tester", "pw", "test") } returns
+            session.copy(fileManifest = FileManifest())
+
+        val controller = newController(this)
+        controller.launch(session, server, onSessionRefreshed = null)
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertIs<LaunchState.Error>(state)
+        assertEquals(LaunchError.HelperUnavailable("1.7.10"), state.reason)
+        coVerify(exactly = 0) {
+            downloadService.processSession(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -517,7 +558,7 @@ class LauncherControllerTest {
             fileManifest = FileManifest(),
         )
         coJustRun {
-            downloadService.processSession(any(), any(), any(), any(), any(), any(), any(), any())
+            downloadService.processSession(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
 
         val process = mockk<Process>()

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/ClientSyncCoordinatorTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/ClientSyncCoordinatorTest.kt
@@ -1,0 +1,60 @@
+package hivens.launcher.smrt
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientSyncCoordinatorTest {
+
+    @Test
+    fun `withClientLock serializes concurrent blocks on the same dir`() = runBlocking {
+        val dir = Path.of("/tmp/aura-sync-coord-test/clients/Industrial")
+        var active = 0
+        var maxActive = 0
+
+        val jobs = (1..12).map {
+            launch(Dispatchers.Default) {
+                ClientSyncCoordinator.withClientLock(dir) {
+                    // Under the mutex only one block runs at a time, so these
+                    // non-atomic reads/writes never observe overlap.
+                    active++
+                    maxActive = maxOf(maxActive, active)
+                    delay(5)
+                    active--
+                }
+            }
+        }
+        jobs.joinAll()
+
+        assertEquals(1, maxActive, "same-dir sync must never run concurrently")
+    }
+
+    @Test
+    fun `different dirs are allowed to run concurrently`() = runBlocking {
+        val a = Path.of("/tmp/aura-sync-coord-test/clients/A")
+        val b = Path.of("/tmp/aura-sync-coord-test/clients/B")
+        var active = 0
+        var maxActive = 0
+
+        val jobs = listOf(a, b, a, b).map { dir ->
+            launch(Dispatchers.Default) {
+                ClientSyncCoordinator.withClientLock(dir) {
+                    synchronized(this@ClientSyncCoordinatorTest) {
+                        active++
+                        maxActive = maxOf(maxActive, active)
+                    }
+                    delay(20)
+                    synchronized(this@ClientSyncCoordinatorTest) { active-- }
+                }
+            }
+        }
+        jobs.joinAll()
+
+        assertEquals(2, maxActive, "distinct dirs should not block each other")
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolverTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/OpenSmrtHelperResolverTest.kt
@@ -1,0 +1,77 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OpenSmrtHelperResolverTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var dir: Path
+
+    private val descriptorJson = """
+        {
+          "schema_version": 1,
+          "variants": [
+            { "mc_prefix": "1.12.2", "tag": "v0.1.0",
+              "asset": "open-smrt-network-forge-1.12.2-0.1.0.jar",
+              "sha256": "deadbeef", "size_bytes": 100 }
+          ]
+        }
+    """.trimIndent()
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("osmrt-resolver-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `descriptor falls back to last-good cache when the live fetch fails`() = runBlocking {
+        var calls = 0
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    calls++
+                    if (calls == 1) {
+                        respond(
+                            content = ByteReadChannel(descriptorJson.toByteArray()),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf("Content-Type", "application/json"),
+                        )
+                    } else {
+                        respond(ByteReadChannel.Empty, HttpStatusCode.InternalServerError)
+                    }
+                }
+            }
+        }
+        val resolver = OpenSmrtHelperResolver(HttpClientProvider { client }, json, dir)
+
+        val first = resolver.fetchDescriptor()
+        assertEquals("v0.1.0", first?.variantFor("1.12.2")?.tag, "live fetch parses + caches")
+
+        val second = resolver.fetchDescriptor()
+        assertEquals(
+            "v0.1.0", second?.variantFor("1.12.2")?.tag,
+            "a failed live fetch must serve the last-good descriptor cache, not null",
+        )
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmartyModPlannerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmartyModPlannerTest.kt
@@ -1,0 +1,81 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.model.ServerProfile
+import hivens.core.data.FileData
+import hivens.core.data.FileManifest
+import hivens.core.data.SettingsData
+import hivens.launcher.ManifestProcessorService
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SmartyModPlannerTest {
+
+    private val manifestProcessor = ManifestProcessorService(Json { ignoreUnknownKeys = true })
+    private val helperJar = Path.of("/tmp/open-smrt-network-1.12.jar")
+
+    private fun manifest() = FileManifest(
+        directories = mapOf(
+            "mods" to FileManifest(
+                files = mapOf(
+                    "Smarty-1.12.2.jar" to FileData(md5 = "a", size = 1),
+                    "JEI.jar" to FileData(md5 = "b", size = 2),
+                ),
+            ),
+        ),
+    )
+
+    private fun server() = ServerProfile(name = "Industrial", version = "1.12.2", assetDir = "Industrial")
+
+    private fun plannerResolving(resolved: OpenSmrtHelperResolver.Resolved?) =
+        SmartyModPlanner(resolveHelper = { resolved }, manifestProcessor = manifestProcessor)
+
+    @Test
+    fun `helper on and resolvable strips Smarty and injects helper`() = runTest {
+        val resolved = OpenSmrtHelperResolver.Resolved(helperJar, listOf("Smarty*.jar"))
+        val plan = plannerResolving(resolved).plan(
+            server(), manifest(),
+            SettingsData(useOpenSmrtHelper = true, strictModVerification = true),
+        )
+
+        assertEquals(setOf("Smarty-1.12.2.jar"), plan.ignoredAddon, "only the Smarty jar should be stripped")
+        assertEquals(helperJar, plan.injectJar)
+        assertTrue(plan.strict)
+        assertEquals(listOf("open-smrt-network-1.12.2.jar"), plan.helperKeepGlobs, "helper kept by exact filename")
+    }
+
+    @Test
+    fun `helper on but unresolvable still strips Smarty and protects the on-disk helper`() = runTest {
+        // The fix: a failed resolve must NOT re-admit the proprietary Smarty jar
+        // nor drop the helper-protection. Smarty is stripped via the default glob,
+        // injectJar is null (nothing fetched this launch), but helperKeepGlobs is
+        // still set so strict verification keeps a previously-injected helper.
+        val plan = plannerResolving(null).plan(
+            server(), manifest(),
+            SettingsData(useOpenSmrtHelper = true, strictModVerification = false),
+        )
+
+        assertEquals(setOf("Smarty-1.12.2.jar"), plan.ignoredAddon, "Smarty stays stripped even when the helper can't be fetched")
+        assertNull(plan.injectJar)
+        assertTrue(!plan.strict)
+        assertEquals(listOf("open-smrt-network-1.12.2.jar"), plan.helperKeepGlobs, "helper protection holds across resolver failures")
+    }
+
+    @Test
+    fun `helper off yields no swap and no helper protection`() = runTest {
+        val resolved = OpenSmrtHelperResolver.Resolved(helperJar, listOf("Smarty*.jar"))
+        val plan = plannerResolving(resolved).plan(
+            server(), manifest(),
+            SettingsData(useOpenSmrtHelper = false, strictModVerification = true),
+        )
+
+        assertTrue(plan.ignoredAddon.isEmpty())
+        assertNull(plan.injectJar)
+        assertTrue(plan.strict, "strict verification is independent of the helper swap")
+        assertTrue(plan.helperKeepGlobs.isEmpty(), "swap off lets a leftover helper be pruned so the upstream mod can return")
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -207,6 +207,7 @@ private fun localizeError(error: LaunchError, s: hivens.ui.i18n.AppStrings): Str
     is LaunchError.OfflineNoManifest    -> s.stateOfflineNoManifest
     is LaunchError.TwoFactorExpired     -> s.auth2faExpired
     is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.HelperUnavailable    -> s.stateHelperUnavailable(error.mcVersion)
     is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import hivens.launcher.launch.LaunchError
 import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.PrepareStage
 import hivens.ui.easter.LocalAprilFools
@@ -24,7 +23,6 @@ fun LaunchControlPanel(
     state: LaunchState,
     onLaunch: () -> Unit,
     onAbort: () -> Unit,
-    onClearError: () -> Unit,
 ) {
     val s = LocalStrings.current
     val af = LocalAprilFools.current
@@ -79,10 +77,13 @@ fun LaunchControlPanel(
                     }
                 }
 
+                // Error is rendered like Idle here: the failure is surfaced by
+                // the notification system, not by an in-panel banner. The panel
+                // just returns to a ready/playable state.
                 is LaunchState.Error -> Text(
-                    text  = localizeError(state.reason, s),
+                    s.launchReady,
                     style = MaterialTheme.typography.bodySmall,
-                    color = CelestiaTheme.colors.error,
+                    color = CelestiaTheme.colors.textSecondary,
                 )
 
                 is LaunchState.GameRunning -> Text(
@@ -136,10 +137,12 @@ fun LaunchControlPanel(
         Spacer(Modifier.height(16.dp))
 
         // -- Action button --------------------------------------------------
+        // Error maps to Play (not a "clear error" affordance): the next launch
+        // attempt overwrites the Error state, and the failure already went out as
+        // a notification. So Error behaves exactly like Idle in this panel.
         val btnText = when (state) {
             is LaunchState.Downloading, is LaunchState.Prepare -> s.launchAbort
             is LaunchState.GameRunning                         -> s.launchRunning
-            is LaunchState.Error                               -> s.launchResetError
             else                                               -> s.launchButton
         }
 
@@ -156,12 +159,12 @@ fun LaunchControlPanel(
             CelestiaButton(
                 text    = btnText,
                 enabled = state !is LaunchState.GameRunning,
-                // Pulse when ready to play
-                glowing = state is LaunchState.Idle,
+                // Pulse when ready to play (Idle, or after an error -- which the
+                // panel now treats as ready, with the failure shown via notification)
+                glowing = state is LaunchState.Idle || state is LaunchState.Error,
                 onClick = {
                     when (state) {
                         is LaunchState.Downloading, is LaunchState.Prepare -> onAbort()
-                        is LaunchState.Error                               -> onClearError()
                         else                                               -> onLaunch()
                     }
                 },
@@ -175,7 +178,6 @@ fun LaunchControlPanel(
         PuppetClick("dashboard.launch", enabled = state !is LaunchState.GameRunning) {
             when (state) {
                 is LaunchState.Downloading, is LaunchState.Prepare -> onAbort()
-                is LaunchState.Error                               -> onClearError()
                 else                                               -> onLaunch()
             }
         }
@@ -193,22 +195,6 @@ private fun localizeStage(stage: PrepareStage, s: hivens.ui.i18n.AppStrings): St
     PrepareStage.SYNC   -> s.stateSync
     PrepareStage.JVM    -> s.stateJvm
     PrepareStage.LAUNCH -> s.stateLaunching
-}
-
-/**
- * Maps a [LaunchError] to a localized error message. `Internal` is the
- * catch-all path; the rest are semantic codes from the controller's
- * known terminal states.
- */
-private fun localizeError(error: LaunchError, s: hivens.ui.i18n.AppStrings): String = when (error) {
-    is LaunchError.ExitCode             -> s.stateExitCode(error.code)
-    is LaunchError.Internal             -> s.stateError(error.message)
-    is LaunchError.OfflineNoClient      -> s.stateOfflineNoClient
-    is LaunchError.OfflineNoManifest    -> s.stateOfflineNoManifest
-    is LaunchError.TwoFactorExpired     -> s.auth2faExpired
-    is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
-    is LaunchError.HelperUnavailable    -> s.stateHelperUnavailable(error.mcVersion)
-    is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }
 
 /**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -33,7 +33,6 @@ interface AppStrings {
     val launchButton: String
     val launchAbort: String
     val launchRunning: String
-    val launchResetError: String
     val launchDownloading: String
 
     // --- Launcher States ---

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -47,6 +47,7 @@ interface AppStrings {
     fun stateExitCode(code: Int): String
     fun stateError(msg: String): String
     fun stateMissingAuthProvider(providerKey: String): String
+    fun stateHelperUnavailable(mcVersion: String): String
 
     // --- Auth Success ---
     fun authSuccess(uuid: String): String
@@ -393,6 +394,13 @@ interface AppStrings {
     val settingsForceProxyTitle: String
     val settingsForceProxyDesc: String
 
+    // --- Smarty server controls (Settings → Smarty) ---
+    val settingsSectionSmarty: String
+    val settingsOpenSmrtHelperTitle: String
+    val settingsOpenSmrtHelperDesc: String
+    val settingsStrictModCheckTitle: String
+    val settingsStrictModCheckDesc: String
+
     // --- Data directory (Settings → Data dir) ---
     val settingsSectionDataDir: String
     val settingsDataDirCurrent: String
@@ -546,6 +554,7 @@ interface AppStrings {
     // --- Settings two-column nav labels ---
     val settingsCategoryAppearance: String
     val settingsCategoryNetwork: String
+    val settingsCategorySmarty: String
     val settingsCategoryExperimental: String
     val settingsCategoryAdvanced: String
     val settingsCategoryDiagnostics: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -46,6 +46,8 @@ object EnglishStrings : AppStrings {
     override val stateLaunching   = "Starting process..."
     override fun stateExitCode(code: Int)  = "Game exited with code $code"
     override fun stateError(msg: String)   = "Error: $msg"
+    override fun stateHelperUnavailable(mcVersion: String) =
+        "No open-smrt helper for Minecraft $mcVersion. Launch blocked so the proprietary Smarty mod isn't run; disable the helper swap in Settings to play with it."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "This pack needs a SmartyCraft account. Sign in to play."
@@ -390,6 +392,12 @@ object EnglishStrings : AppStrings {
     override val settingsForceProxyTitle = "Force proxy mode"
     override val settingsForceProxyDesc  = "Skip the direct connection attempt and route every request through the SmartyCraft SOCKS proxy. Enable if you're in a region or network where direct access fails."
 
+    override val settingsSectionSmarty           = "Smarty servers"
+    override val settingsOpenSmrtHelperTitle      = "Use the alternative smrt network helper"
+    override val settingsOpenSmrtHelperDesc       = "Replace the upstream Smarty mod with our open-source helper on every Smarty server. Same network features, none of the surveillance. Falls back to the original mod if the replacement cannot be downloaded yet."
+    override val settingsStrictModCheckTitle      = "Exact mod verification"
+    override val settingsStrictModCheckDesc       = "After syncing, delete everything in the mods folder the server did not ask for. Keeps the install clean, but also removes any mods you added by hand."
+
     override val settingsSectionDataDir       = "Data directory"
     override val settingsDataDirCurrent       = "Current path:"
     override val settingsDataDirMove          = "Move..."
@@ -522,6 +530,7 @@ object EnglishStrings : AppStrings {
 
     override val settingsCategoryAppearance   = "Appearance"
     override val settingsCategoryNetwork      = "Network"
+    override val settingsCategorySmarty       = "Smarty"
     override val settingsCategoryExperimental = "Experimental"
     override val settingsCategoryAdvanced     = "Advanced"
     override val settingsCategoryDiagnostics  = "Diagnostics"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -33,7 +33,6 @@ object EnglishStrings : AppStrings {
     override val launchButton      = "Play"
     override val launchAbort       = "Cancel"
     override val launchRunning     = "Game running"
-    override val launchResetError  = "Clear error"
     override val launchDownloading = "Downloading:"
 
     // Launcher States
@@ -394,7 +393,7 @@ object EnglishStrings : AppStrings {
 
     override val settingsSectionSmarty           = "Smarty servers"
     override val settingsOpenSmrtHelperTitle      = "Use the alternative smrt network helper"
-    override val settingsOpenSmrtHelperDesc       = "Replace the upstream Smarty mod with our open-source helper on every Smarty server. Same network features, none of the surveillance. Falls back to the original mod if the replacement cannot be downloaded yet."
+    override val settingsOpenSmrtHelperDesc       = "Replace the upstream Smarty mod with our open-source helper on Smarty servers. Same network features, none of the surveillance. If no replacement exists for the game version, the launch is blocked rather than running the original mod."
     override val settingsStrictModCheckTitle      = "Exact mod verification"
     override val settingsStrictModCheckDesc       = "After syncing, delete everything in the mods folder the server did not ask for. Keeps the install clean, but also removes any mods you added by hand."
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -46,6 +46,8 @@ object GermanStrings : AppStrings {
     override val stateLaunching   = "Prozess starten..."
     override fun stateExitCode(code: Int)  = "Spiel mit Code $code beendet"
     override fun stateError(msg: String)   = "Fehler: $msg"
+    override fun stateHelperUnavailable(mcVersion: String) =
+        "Kein open-smrt-Helfer für Minecraft $mcVersion. Start blockiert, damit der proprietäre Smarty-Mod nicht läuft; deaktiviere den Helfer-Tausch in den Einstellungen, um damit zu spielen."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "Dieses Pack braucht ein SmartyCraft-Konto. Bitte anmelden, um zu spielen."
@@ -390,6 +392,12 @@ object GermanStrings : AppStrings {
     override val settingsForceProxyTitle = "Nur Proxy verwenden"
     override val settingsForceProxyDesc  = "Direktverbindung überspringen und alle Anfragen über den SmartyCraft-SOCKS-Proxy leiten. Aktivieren Sie dies, wenn in Ihrem Netzwerk Direktverbindungen blockiert werden."
 
+    override val settingsSectionSmarty           = "Smarty-Server"
+    override val settingsOpenSmrtHelperTitle      = "Alternativen smrt-Netzwerk-Helfer verwenden"
+    override val settingsOpenSmrtHelperDesc       = "Ersetzt den originalen Smarty-Mod auf jedem Smarty-Server durch unseren quelloffenen Helfer. Dieselben Netzwerkfunktionen, aber ohne Überwachung. Lässt sich der Ersatz noch nicht herunterladen, bleibt der Original-Mod."
+    override val settingsStrictModCheckTitle      = "Genaue Mod-Prüfung"
+    override val settingsStrictModCheckDesc       = "Löscht nach der Synchronisierung alles im Mods-Ordner, was der Server nicht angefordert hat. Hält die Installation sauber, entfernt aber auch von Hand hinzugefügte Mods."
+
     override val settingsSectionDataDir       = "Datenverzeichnis"
     override val settingsDataDirCurrent       = "Aktueller Pfad:"
     override val settingsDataDirMove          = "Verschieben..."
@@ -522,6 +530,7 @@ object GermanStrings : AppStrings {
 
     override val settingsCategoryAppearance   = "Erscheinungsbild"
     override val settingsCategoryNetwork      = "Netzwerk"
+    override val settingsCategorySmarty       = "Smarty"
     override val settingsCategoryExperimental = "Experimentell"
     override val settingsCategoryAdvanced     = "Erweitert"
     override val settingsCategoryDiagnostics  = "Diagnose"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -33,7 +33,6 @@ object GermanStrings : AppStrings {
     override val launchButton      = "Spielen"
     override val launchAbort       = "Abbrechen"
     override val launchRunning     = "Spiel läuft"
-    override val launchResetError  = "FEHLER ZURÜCKSETZEN"
     override val launchDownloading = "Herunterladen:"
 
     // Launcher States
@@ -394,7 +393,7 @@ object GermanStrings : AppStrings {
 
     override val settingsSectionSmarty           = "Smarty-Server"
     override val settingsOpenSmrtHelperTitle      = "Alternativen smrt-Netzwerk-Helfer verwenden"
-    override val settingsOpenSmrtHelperDesc       = "Ersetzt den originalen Smarty-Mod auf jedem Smarty-Server durch unseren quelloffenen Helfer. Dieselben Netzwerkfunktionen, aber ohne Überwachung. Lässt sich der Ersatz noch nicht herunterladen, bleibt der Original-Mod."
+    override val settingsOpenSmrtHelperDesc       = "Ersetzt den originalen Smarty-Mod auf Smarty-Servern durch unseren quelloffenen Helfer. Dieselben Netzwerkfunktionen, aber ohne Überwachung. Gibt es für die Spielversion keinen Ersatz, wird der Start blockiert statt den Original-Mod auszuführen."
     override val settingsStrictModCheckTitle      = "Genaue Mod-Prüfung"
     override val settingsStrictModCheckDesc       = "Löscht nach der Synchronisierung alles im Mods-Ordner, was der Server nicht angefordert hat. Hält die Installation sauber, entfernt aber auch von Hand hinzugefügte Mods."
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -33,7 +33,6 @@ object RussianStrings : AppStrings {
     override val launchButton      = "Играть"
     override val launchAbort       = "Отмена"
     override val launchRunning     = "Игра запущена"
-    override val launchResetError  = "Сбросить ошибку"
     override val launchDownloading = "Загрузка:"
 
     // Launcher States
@@ -396,7 +395,7 @@ object RussianStrings : AppStrings {
     override val settingsSectionSmarty           = "Серверы Smarty"
     override val settingsOpenSmrtHelperTitle      = "Использовать альтернативный хелпер для сети smrt"
     override val settingsStrictModCheckTitle      = "Точная проверка модификаций"
-    override val settingsOpenSmrtHelperDesc       = "Подменяет родной мод Smarty нашим открытым хелпером на каждом сервере Smarty. Те же сетевые функции, но без слежки. Если замену пока не удаётся скачать — остаётся родной мод."
+    override val settingsOpenSmrtHelperDesc       = "Подменяет родной мод Smarty нашим открытым хелпером на серверах Smarty. Те же сетевые функции, но без слежки. Если для версии игры замены нет, запуск блокируется, а не запускает родной мод."
     override val settingsStrictModCheckDesc       = "После синхронизации удаляет из папки mods всё, чего сервер не запрашивал. Держит сборку чистой, но заодно сносит и моды, которые ты добавил вручную."
 
     override val settingsSectionDataDir       = "Каталог данных"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -46,6 +46,8 @@ object RussianStrings : AppStrings {
     override val stateLaunching   = "Запуск процесса..."
     override fun stateExitCode(code: Int)  = "Игра закрылась с кодом $code"
     override fun stateError(msg: String)   = "Ошибка: $msg"
+    override fun stateHelperUnavailable(mcVersion: String) =
+        "Нет open-smrt хелпера для Minecraft $mcVersion. Запуск заблокирован, чтобы не запускать проприетарный мод Smarty; отключи подмену хелпера в настройках, чтобы играть с ним."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "Этой сборке нужен аккаунт SmartyCraft. Войдите, чтобы играть."
@@ -391,6 +393,12 @@ object RussianStrings : AppStrings {
     override val settingsForceProxyTitle = "Только через прокси"
     override val settingsForceProxyDesc  = "Не пытаться подключаться напрямую — все запросы пойдут через SOCKS-прокси SmartyCraft. Включи если в твоей сети прямое соединение блокируется."
 
+    override val settingsSectionSmarty           = "Серверы Smarty"
+    override val settingsOpenSmrtHelperTitle      = "Использовать альтернативный хелпер для сети smrt"
+    override val settingsStrictModCheckTitle      = "Точная проверка модификаций"
+    override val settingsOpenSmrtHelperDesc       = "Подменяет родной мод Smarty нашим открытым хелпером на каждом сервере Smarty. Те же сетевые функции, но без слежки. Если замену пока не удаётся скачать — остаётся родной мод."
+    override val settingsStrictModCheckDesc       = "После синхронизации удаляет из папки mods всё, чего сервер не запрашивал. Держит сборку чистой, но заодно сносит и моды, которые ты добавил вручную."
+
     override val settingsSectionDataDir       = "Каталог данных"
     override val settingsDataDirCurrent       = "Текущий путь:"
     override val settingsDataDirMove          = "Переместить..."
@@ -523,6 +531,7 @@ object RussianStrings : AppStrings {
 
     override val settingsCategoryAppearance   = "Внешний вид"
     override val settingsCategoryNetwork      = "Сеть"
+    override val settingsCategorySmarty       = "Smarty"
     override val settingsCategoryExperimental = "Эксперименты"
     override val settingsCategoryAdvanced     = "Расширенные"
     override val settingsCategoryDiagnostics  = "Диагностика"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
@@ -103,5 +103,6 @@ private fun localizeError(error: LaunchError, s: AppStrings): String = when (err
     is LaunchError.OfflineNoManifest    -> s.stateOfflineNoManifest
     is LaunchError.TwoFactorExpired     -> s.auth2faExpired
     is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
+    is LaunchError.HelperUnavailable    -> s.stateHelperUnavailable(error.mcVersion)
     is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
@@ -91,10 +91,9 @@ fun LaunchLogCollector(
 }
 
 /**
- * Mirrors `localizeError` in `LaunchControlPanel`. Kept as a private
- * helper rather than shared so the two consumers (status row + console
- * pane) can diverge independently. Strings are passed in (not read from
- * a global) so the caller controls which locale snapshot is used.
+ * Localizes a [LaunchError] for the console pane. Private (not shared) so the
+ * console copy can diverge from the notification driver's phrasing. Strings are
+ * passed in (not read from a global) so the caller controls the locale snapshot.
  */
 private fun localizeError(error: LaunchError, s: AppStrings): String = when (error) {
     is LaunchError.ExitCode             -> s.stateExitCode(error.code)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/LaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/LaunchDriver.kt
@@ -228,6 +228,7 @@ class LaunchDriver(
                                                 ?.let { s.notifReasonAuthFailDetail(it) }
                                                 ?: s.notifReasonAuthFail
         is LaunchError.MissingAuthProvider -> s.notifReasonMissingAuthProvider(reason.providerKey)
+        is LaunchError.HelperUnavailable   -> s.stateHelperUnavailable(reason.mcVersion)
         LaunchError.OfflineNoClient        -> s.notifReasonOfflineNoClient
         LaunchError.OfflineNoManifest      -> s.notifReasonOfflineNoManifest
         LaunchError.TwoFactorExpired       -> s.notifReasonTwoFactorExpired

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsCategory.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsCategory.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.graphics.vector.ImageVector
 import hivens.ui.i18n.AppStrings
@@ -24,6 +25,7 @@ internal enum class SettingsCategory(
 ) {
     Appearance(   Icons.Default.Palette,   { it.settingsCategoryAppearance }),
     Network(      Icons.Default.Wifi,      { it.settingsCategoryNetwork }),
+    Smarty(       Icons.Default.Shield,    { it.settingsCategorySmarty }),
     Experimental( Icons.Default.Science,   { it.settingsCategoryExperimental }),
     Advanced(     Icons.Default.Folder,    { it.settingsCategoryAdvanced }),
     Diagnostics(  Icons.Default.BugReport, { it.settingsCategoryDiagnostics }),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsFormState.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsFormState.kt
@@ -39,6 +39,8 @@ internal class SettingsFormState(initial: SettingsData) {
     var forceProxyMode         by mutableStateOf(initial.forceProxyMode)
     var mimicOverrideEnabled   by mutableStateOf(!initial.mimicVersionOverride.isNullOrBlank())
     var mimicVersionText       by mutableStateOf(initial.mimicVersionOverride ?: "")
+    var useOpenSmrtHelper      by mutableStateOf(initial.useOpenSmrtHelper)
+    var strictModVerification  by mutableStateOf(initial.strictModVerification)
 
     /**
      * Build a [SettingsData] suitable for persistence by overlaying this
@@ -63,6 +65,8 @@ internal class SettingsFormState(initial: SettingsData) {
             jvmBuilderEnabled           = jvmBuilderEnabled,
             forceProxyMode              = forceProxyMode,
             mimicVersionOverride        = normalisedMimic,
+            useOpenSmrtHelper           = useOpenSmrtHelper,
+            strictModVerification       = strictModVerification,
         )
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
@@ -127,6 +127,10 @@ fun SettingsScreen(
                             form = form,
                             save = ::save,
                         )
+                        SettingsCategory.Smarty -> SmartySection(
+                            form = form,
+                            save = ::save,
+                        )
                         SettingsCategory.Experimental -> ExperimentalSection(
                             form            = form,
                             save            = ::save,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SmartySection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SmartySection.kt
@@ -1,0 +1,65 @@
+package hivens.ui.screens.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Rule
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetToggle
+import hivens.ui.theme.CelestiaTheme
+
+/**
+ * Smarty server controls. Two switches that govern how a raw SmartyCraft
+ * server's mods are handled at sync:
+ *  - swap the upstream Smarty surveillance coremod for the open-smrt-network
+ *    helper, and
+ *  - strict verification that deletes any jar the server manifest does not
+ *    list (the description says outright that user-added mods go too).
+ * Both default on. The actual swap + prune live in the launcher
+ * (`SmartyModPlanner` / `FileDownloadService`); this screen only flips the
+ * persisted flags.
+ */
+@Composable
+internal fun SmartySection(
+    form: SettingsFormState,
+    save: () -> Unit,
+) {
+    val s = LocalStrings.current
+
+    SettingsSectionTitle(s.settingsSectionSmarty)
+
+    Column(
+        modifier = Modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        SettingsRowWithDescription(
+            title           = s.settingsOpenSmrtHelperTitle,
+            description     = s.settingsOpenSmrtHelperDesc,
+            icon            = Icons.Default.SwapHoriz,
+            iconTint        = CelestiaTheme.colors.primary,
+            checked         = form.useOpenSmrtHelper,
+            enabled         = true,
+            onCheckedChange = { form.useOpenSmrtHelper = it; save() },
+        )
+        PuppetToggle("settings.useOpenSmrtHelper", form.useOpenSmrtHelper) {
+            form.useOpenSmrtHelper = it; save()
+        }
+
+        SettingsRowWithDescription(
+            title           = s.settingsStrictModCheckTitle,
+            description     = s.settingsStrictModCheckDesc,
+            icon            = Icons.Default.Rule,
+            iconTint        = CelestiaTheme.colors.primary,
+            checked         = form.strictModVerification,
+            enabled         = true,
+            onCheckedChange = { form.strictModVerification = it; save() },
+        )
+        PuppetToggle("settings.strictModVerification", form.strictModVerification) {
+            form.strictModVerification = it; save()
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContent.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/home/classic/HomeClassicContent.kt
@@ -256,7 +256,6 @@ fun HomeClassicContent(instance: WidgetInstance) {
                     }
                 },
                 onAbort      = { controller.abort() },
-                onClearError = { controller.clearError() },
             )
         }
     }

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/screens/settings/SettingsFormStateTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/screens/settings/SettingsFormStateTest.kt
@@ -1,0 +1,33 @@
+package hivens.ui.screens.settings
+
+import hivens.core.data.SettingsData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsFormStateTest {
+
+    @Test
+    fun `Smarty toggles seed from settings and round-trip through mergeInto`() {
+        val form = SettingsFormState(
+            SettingsData(useOpenSmrtHelper = false, strictModVerification = true),
+        )
+        assertFalse(form.useOpenSmrtHelper, "seeded from SettingsData")
+        assertTrue(form.strictModVerification)
+
+        form.useOpenSmrtHelper = true
+        form.strictModVerification = false
+
+        val merged = form.mergeInto(SettingsData())
+        assertTrue(merged.useOpenSmrtHelper)
+        assertFalse(merged.strictModVerification)
+    }
+
+    @Test
+    fun `defaults are both on`() {
+        val form = SettingsFormState(SettingsData())
+        assertTrue(form.useOpenSmrtHelper)
+        assertTrue(form.strictModVerification)
+    }
+}


### PR DESCRIPTION
For raw SmartyCraft servers, optionally replace the proprietary Smarty surveillance coremod with the open-smrt-network helper, plus a strict "Exact Mod Verification" that prunes any `mods/` jar the server manifest does not list. New Settings -> Smarty section (two toggles, both default on).

## Behaviour
- **Swap ON is authoritative.** The Smarty jar is stripped from the sync set whether or not the helper resolves, so a transient resolver failure never re-admits the surveillance mod. The helper is resolved per MC version from open-smrt-network's GitHub releases (descriptor-pinned, sha256-verified, cached; last-good descriptor cached on disk).
- **Strict verification** keeps the helper by its exact per-version filename, so it survives a launch where the resolver could not refresh.
- **Block, don't half-strip.** If the swap is on, the manifest ships Smarty, and no helper is available for the MC version, the launch is blocked (`LaunchError.HelperUnavailable`) rather than joining with no network mod or running the surveillance mod.
- **`ClientSyncCoordinator`** serializes file-mutating sync per client dir so a foreground launch and background auto-sync cannot race destructive prune/inject on the same `mods/`.
- Launch failures now surface via the notification system; the in-panel error banner is gone.

## Cross-repo
Pairs with Kitty-Hivens/open-smrt-network: CI build matrix + release pipeline + `meta/smrt-helper.json` descriptor (verified per-version Smarty matchers: `SmartyClient-*` / `Smarty-*` / `smarty-*`, targeting only the `mods/` coremod). Dormant until that descriptor is populated on `main` (now done for v0.1.0).

## Tests
Planner, resolver descriptor cache, strict-prune/inject, launch block, sync coordinator. i18n in en/ru/de.

WIP / preview; a cohesion pass is in progress.