### PR TITLE
Cross-cutting cache layer (TTL + stale-while-revalidate, disk-backed)

### DIFF
--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     // JSON
     implementation(libs.kotlinx.serialization.json)
 
+    // Coroutines (Mutex / StateFlow / CompletableDeferred for the cache layer).
+    // Was previously only transitive via ktor; depend on it explicitly.
+    implementation(libs.kotlinx.coroutines.core)
+
     // Archive extraction with unix-mode-aware ZipArchiveEntry -- needed by
     // ZipUtils to reject symlink entries that bypass plain Zip Slip checks.
     implementation(libs.commons.compress)

--- a/client-core/src/main/kotlin/hivens/core/cache/Cache.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/Cache.kt
@@ -1,0 +1,34 @@
+package hivens.core.cache
+
+import kotlinx.coroutines.flow.Flow
+
+/** How current a [CacheValue] is relative to the namespace TTL. */
+enum class Freshness { FRESH, STALE, REVALIDATING }
+
+data class CacheValue<V>(val value: V, val freshness: Freshness)
+
+/**
+ * URL/key-keyed cache with TTL + stale-while-revalidate + single-flight, backed
+ * by an in-memory layer over a [DiskStore]. Implementations serve a stale value
+ * immediately and refresh in the background, collapse concurrent identical loads
+ * into one upstream call, and survive process restart via the disk layer.
+ */
+interface Cache<V> {
+    /**
+     * Stale-while-revalidate read. Fresh entry -> returned with no I/O. Stale
+     * entry (older than TTL but within the hard-staleness cap) -> returned
+     * immediately while a background refresh runs. Missing or past the hard cap
+     * -> awaits [loader] (single-flighted) and returns its result.
+     */
+    suspend fun get(key: String, loader: suspend () -> V): V
+
+    /**
+     * Reactive view: emits the stale value first (if any, within the cap) then
+     * the fresh value; a missing entry emits only the fresh value. The load is
+     * single-flighted with concurrent callers.
+     */
+    fun flow(key: String, loader: suspend () -> V): Flow<CacheValue<V>>
+
+    suspend fun invalidate(key: String)
+    suspend fun invalidateAll()
+}

--- a/client-core/src/main/kotlin/hivens/core/cache/CacheConfig.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/CacheConfig.kt
@@ -1,0 +1,23 @@
+package hivens.core.cache
+
+/**
+ * Per-namespace cache policy.
+ *
+ * @param ttlMs age beyond which an entry is *stale* and triggers a background
+ *   stale-while-revalidate refresh (but is still served).
+ * @param staleTtlMs hard staleness cap: past this age the entry is NOT served --
+ *   a [Cache.get] blocks on the loader and propagates its error. Default
+ *   [Long.MAX_VALUE] = serve-stale-forever-on-error.
+ * @param maxEntries in-memory LRU bound (access-order eviction).
+ * @param diskDebounceMs coalesce window for disk writes of the same key.
+ * @param shouldStore gate on persisting a loaded value. Returning false keeps any
+ *   existing entry instead of overwriting it -- e.g. an empty server list from a
+ *   transient outage must not clobber the last-known-good cache.
+ */
+data class CacheConfig<V>(
+    val ttlMs: Long,
+    val staleTtlMs: Long = Long.MAX_VALUE,
+    val maxEntries: Int = 256,
+    val diskDebounceMs: Long = 200,
+    val shouldStore: (V) -> Boolean = { true },
+)

--- a/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -43,17 +43,25 @@ class DefaultCache<V>(
 
     private class Entry<V>(val value: V, val storedAtMillis: Long)
 
+    /**
+     * The latest pending disk op for a key, conflated onto by the single per-key
+     * writer. [delete] = true is an invalidation routed through the same writer so
+     * a delete can never interleave with an in-flight write (no resurrection).
+     */
+    private class Pending<V>(val value: V?, val storedAtMillis: Long, val delete: Boolean)
+
     private val memory = object : LinkedHashMap<String, Entry<V>>(16, 0.75f, /* accessOrder = */ true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Entry<V>>?): Boolean =
             size > config.maxEntries
     }
     private val inFlight = HashMap<String, CompletableDeferred<V>>()
-    private val pendingWrites = HashMap<String, Job>()
+    private val pending = HashMap<String, Pending<V>>()
+    private val writerActive = HashSet<String>()
 
     override suspend fun get(key: String, loader: suspend () -> V): V {
         val entry = lookup(key)
         if (entry != null) {
-            val age = clock.nowMillis() - entry.storedAtMillis
+            val age = ageOf(entry)
             if (age < config.ttlMs) return entry.value
             if (age < config.staleTtlMs) {
                 triggerRefresh(key, loader)
@@ -67,7 +75,7 @@ class DefaultCache<V>(
     override fun flow(key: String, loader: suspend () -> V): Flow<CacheValue<V>> = flow {
         val entry = lookup(key)
         if (entry != null) {
-            val age = clock.nowMillis() - entry.storedAtMillis
+            val age = ageOf(entry)
             if (age < config.ttlMs) {
                 emit(CacheValue(entry.value, Freshness.FRESH))
                 return@flow
@@ -84,16 +92,20 @@ class DefaultCache<V>(
     override suspend fun invalidate(key: String) {
         mutex.withLock {
             memory.remove(key)
-            pendingWrites.remove(key)?.cancel()
+            // Route the delete through the per-key writer instead of deleting
+            // off-lock here: that's what keeps it ordered with any in-flight
+            // write so an older value can't land back on disk after the delete.
+            pending[key] = Pending(value = null, storedAtMillis = 0, delete = true)
+            if (writerActive.add(key)) {
+                scope.launch { runWriter(key) }
+            }
         }
-        withContext(ioDispatcher) { runCatching { diskStore.delete(key) } }
     }
 
     override suspend fun invalidateAll() {
         mutex.withLock {
             memory.clear()
-            pendingWrites.values.forEach { it.cancel() }
-            pendingWrites.clear()
+            pending.clear()
         }
         withContext(ioDispatcher) { runCatching { diskStore.clear() } }
     }
@@ -141,20 +153,57 @@ class DefaultCache<V>(
 
     /**
      * Write-through to memory now + debounced to disk; [CacheConfig.shouldStore]
-     * can veto. The debounced write runs on [scope] (IO-dispatched in production),
-     * so the disk op already runs off any UI thread without a nested context hop.
+     * can veto. Disk writes are serialized per key by a single [runWriter]
+     * coroutine that conflates onto the latest [Pending] value -- so two rapid
+     * stores can neither race on the shared `<key>.tmp` nor publish out of order
+     * (an older value landing after a newer one). The write runs on [scope]
+     * (IO-dispatched in production), off any UI thread.
      */
     private suspend fun store(key: String, value: V) {
         if (!config.shouldStore(value)) return
         val now = clock.nowMillis()
         mutex.withLock {
             memory[key] = Entry(value, now)
-            pendingWrites.remove(key)?.cancel()
-            pendingWrites[key] = scope.launch {
-                delay(config.diskDebounceMs)
-                runCatching { diskStore.write(key, value, now) }
-                mutex.withLock { pendingWrites.remove(key) }
+            pending[key] = Pending(value, now, delete = false)
+            // add() returns true only if no writer is already running for this key,
+            // so there is at most one writer (and one in-flight disk op) per key.
+            if (writerActive.add(key)) {
+                scope.launch { runWriter(key) }
             }
         }
     }
+
+    /**
+     * One writer per key: debounce, then apply the latest pending op (write or
+     * delete) and loop until none is pending. Taking the op and the exit decision
+     * (`writerActive.remove`) under the SAME lock is what prevents a store from
+     * seeing a still-active writer that is about to exit and orphaning its op.
+     * The op is applied off-lock but is the only disk mutation in flight for the
+     * key, so writes and deletes can't reorder.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun runWriter(key: String) {
+        try {
+            while (true) {
+                delay(config.diskDebounceMs)
+                val op = mutex.withLock {
+                    val p = pending.remove(key)
+                    if (p == null) writerActive.remove(key)
+                    p
+                } ?: return
+                if (op.delete) {
+                    runCatching { diskStore.delete(key) }
+                } else {
+                    runCatching { diskStore.write(key, op.value as V, op.storedAtMillis) }
+                }
+            }
+        } finally {
+            // Cancellation (scope shutdown) can skip the in-loop removal; make the
+            // writerActive slot release uncancellable so a key can't get stuck.
+            withContext(NonCancellable) { mutex.withLock { writerActive.remove(key) } }
+        }
+    }
+
+    private fun ageOf(entry: Entry<V>): Long =
+        (clock.nowMillis() - entry.storedAtMillis).coerceAtLeast(0)
 }

--- a/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
@@ -1,0 +1,160 @@
+package hivens.core.cache
+
+import hivens.core.time.Clock
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+
+/**
+ * The cache engine. In-memory LRU over a [DiskStore], with single-flight,
+ * stale-while-revalidate, TTL via an injected [Clock], and debounced disk writes.
+ *
+ * Concurrency model:
+ *  - [mutex] guards the [memory] index, the [inFlight] single-flight map, and
+ *    [pendingWrites]; it is never held across disk or network I/O.
+ *  - A background refresh (stale read) runs on [scope] (a SupervisorJob), so a
+ *    caller leaving composition cannot cancel a refresh other callers share.
+ *  - A blocking miss runs the loader in the caller's own coroutine, so caller
+ *    cancellation correctly aborts a first-ever fetch.
+ *  - [ioDispatcher] is injectable so disk hops stay under a test scheduler's
+ *    virtual time.
+ */
+class DefaultCache<V>(
+    private val diskStore: DiskStore<V>,
+    private val config: CacheConfig<V>,
+    private val scope: CoroutineScope,
+    private val clock: Clock,
+    private val namespace: String = "cache",
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Cache<V> {
+
+    private val log = LoggerFactory.getLogger(DefaultCache::class.java)
+    private val mutex = Mutex()
+
+    private class Entry<V>(val value: V, val storedAtMillis: Long)
+
+    private val memory = object : LinkedHashMap<String, Entry<V>>(16, 0.75f, /* accessOrder = */ true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Entry<V>>?): Boolean =
+            size > config.maxEntries
+    }
+    private val inFlight = HashMap<String, CompletableDeferred<V>>()
+    private val pendingWrites = HashMap<String, Job>()
+
+    override suspend fun get(key: String, loader: suspend () -> V): V {
+        val entry = lookup(key)
+        if (entry != null) {
+            val age = clock.nowMillis() - entry.storedAtMillis
+            if (age < config.ttlMs) return entry.value
+            if (age < config.staleTtlMs) {
+                triggerRefresh(key, loader)
+                return entry.value
+            }
+            // past the hard-staleness cap -> fall through to a blocking reload
+        }
+        return load(key, loader)
+    }
+
+    override fun flow(key: String, loader: suspend () -> V): Flow<CacheValue<V>> = flow {
+        val entry = lookup(key)
+        if (entry != null) {
+            val age = clock.nowMillis() - entry.storedAtMillis
+            if (age < config.ttlMs) {
+                emit(CacheValue(entry.value, Freshness.FRESH))
+                return@flow
+            }
+            if (age < config.staleTtlMs) {
+                emit(CacheValue(entry.value, Freshness.STALE))
+                emit(CacheValue(load(key, loader), Freshness.FRESH))
+                return@flow
+            }
+        }
+        emit(CacheValue(load(key, loader), Freshness.FRESH))
+    }
+
+    override suspend fun invalidate(key: String) {
+        mutex.withLock {
+            memory.remove(key)
+            pendingWrites.remove(key)?.cancel()
+        }
+        withContext(ioDispatcher) { runCatching { diskStore.delete(key) } }
+    }
+
+    override suspend fun invalidateAll() {
+        mutex.withLock {
+            memory.clear()
+            pendingWrites.values.forEach { it.cancel() }
+            pendingWrites.clear()
+        }
+        withContext(ioDispatcher) { runCatching { diskStore.clear() } }
+    }
+
+    /** Memory hit, else promote from disk (I/O off-lock) into memory. */
+    private suspend fun lookup(key: String): Entry<V>? {
+        mutex.withLock { memory[key] }?.let { return it }
+        val stored = withContext(ioDispatcher) { runCatching { diskStore.read(key) }.getOrNull() } ?: return null
+        return mutex.withLock {
+            memory[key] ?: Entry(stored.value, stored.storedAtMillis).also { memory[key] = it }
+        }
+    }
+
+    private fun triggerRefresh(key: String, loader: suspend () -> V) {
+        scope.launch {
+            runCatching { load(key, loader) }
+                .onFailure { log.warn("cache[{}] background refresh failed for {}; keeping stale", namespace, key, it) }
+        }
+    }
+
+    /**
+     * Single-flight load: the first caller (leader) runs [loader] in its own
+     * coroutine, stores the result, and completes the shared deferred; concurrent
+     * callers (followers) await it -- one upstream call per key.
+     */
+    private suspend fun load(key: String, loader: suspend () -> V): V {
+        val (deferred, isLeader) = mutex.withLock {
+            val existing = inFlight[key]
+            if (existing != null) existing to false
+            else CompletableDeferred<V>().also { inFlight[key] = it } to true
+        }
+        if (!isLeader) return deferred.await()
+        try {
+            val value = loader()
+            store(key, value)
+            deferred.complete(value)
+            return value
+        } catch (t: Throwable) {
+            deferred.completeExceptionally(t)
+            throw t
+        } finally {
+            mutex.withLock { inFlight.remove(key) }
+        }
+    }
+
+    /**
+     * Write-through to memory now + debounced to disk; [CacheConfig.shouldStore]
+     * can veto. The debounced write runs on [scope] (IO-dispatched in production),
+     * so the disk op already runs off any UI thread without a nested context hop.
+     */
+    private suspend fun store(key: String, value: V) {
+        if (!config.shouldStore(value)) return
+        val now = clock.nowMillis()
+        mutex.withLock {
+            memory[key] = Entry(value, now)
+            pendingWrites.remove(key)?.cancel()
+            pendingWrites[key] = scope.launch {
+                delay(config.diskDebounceMs)
+                runCatching { diskStore.write(key, value, now) }
+                mutex.withLock { pendingWrites.remove(key) }
+            }
+        }
+    }
+}

--- a/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/DefaultCache.kt
@@ -4,6 +4,7 @@ import hivens.core.time.Clock
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -20,8 +21,11 @@ import org.slf4j.LoggerFactory
  * stale-while-revalidate, TTL via an injected [Clock], and debounced disk writes.
  *
  * Concurrency model:
- *  - [mutex] guards the [memory] index, the [inFlight] single-flight map, and
- *    [pendingWrites]; it is never held across disk or network I/O.
+ *  - [mutex] guards the in-memory state (the [memory] index, the [inFlight]
+ *    single-flight map, [pending], [writerActive]); it is never held across disk
+ *    or network I/O.
+ *  - [diskMutex] serializes the off-[mutex] disk mutations (per-key write/delete
+ *    vs the bulk [invalidateAll] clear) so they cannot interleave.
  *  - A background refresh (stale read) runs on [scope] (a SupervisorJob), so a
  *    caller leaving composition cannot cancel a refresh other callers share.
  *  - A blocking miss runs the loader in the caller's own coroutine, so caller
@@ -41,14 +45,35 @@ class DefaultCache<V>(
     private val log = LoggerFactory.getLogger(DefaultCache::class.java)
     private val mutex = Mutex()
 
+    /**
+     * Serializes the off-[mutex] disk mutations (per-key write/delete vs the bulk
+     * [invalidateAll] clear) so a clear and an in-flight write cannot interleave.
+     * Held only around disk I/O, never together with [mutex].
+     */
+    private val diskMutex = Mutex()
+
+    /**
+     * Bumped under [diskMutex] by [invalidateAll]. A write op captures the epoch it
+     * was produced under; if a clear has since bumped it, the writer drops the op
+     * instead of resurrecting a value the clear was meant to remove.
+     */
+    @Volatile
+    private var diskEpoch: Long = 0
+
     private class Entry<V>(val value: V, val storedAtMillis: Long)
 
     /**
      * The latest pending disk op for a key, conflated onto by the single per-key
      * writer. [delete] = true is an invalidation routed through the same writer so
      * a delete can never interleave with an in-flight write (no resurrection).
+     * [epoch] is the [diskEpoch] the op was produced under (write ops only).
      */
-    private class Pending<V>(val value: V?, val storedAtMillis: Long, val delete: Boolean)
+    private class Pending<V>(
+        val value: V?,
+        val storedAtMillis: Long,
+        val delete: Boolean,
+        val epoch: Long,
+    )
 
     private val memory = object : LinkedHashMap<String, Entry<V>>(16, 0.75f, /* accessOrder = */ true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Entry<V>>?): Boolean =
@@ -95,9 +120,9 @@ class DefaultCache<V>(
             // Route the delete through the per-key writer instead of deleting
             // off-lock here: that's what keeps it ordered with any in-flight
             // write so an older value can't land back on disk after the delete.
-            pending[key] = Pending(value = null, storedAtMillis = 0, delete = true)
+            pending[key] = Pending(value = null, storedAtMillis = 0, delete = true, epoch = diskEpoch)
             if (writerActive.add(key)) {
-                scope.launch { runWriter(key) }
+                scope.launch(start = CoroutineStart.ATOMIC) { runWriter(key) }
             }
         }
     }
@@ -107,7 +132,15 @@ class DefaultCache<V>(
             memory.clear()
             pending.clear()
         }
-        withContext(ioDispatcher) { runCatching { diskStore.clear() } }
+        // Bump the epoch and clear under diskMutex so any per-key writer that has
+        // already taken its op but not yet written observes the new epoch (or is
+        // ordered after the clear) and drops its now-superseded write.
+        withContext(ioDispatcher) {
+            diskMutex.withLock {
+                diskEpoch++
+                runCatching { diskStore.clear() }
+            }
+        }
     }
 
     /** Memory hit, else promote from disk (I/O off-lock) into memory. */
@@ -164,11 +197,14 @@ class DefaultCache<V>(
         val now = clock.nowMillis()
         mutex.withLock {
             memory[key] = Entry(value, now)
-            pending[key] = Pending(value, now, delete = false)
+            pending[key] = Pending(value, now, delete = false, epoch = diskEpoch)
             // add() returns true only if no writer is already running for this key,
             // so there is at most one writer (and one in-flight disk op) per key.
+            // ATOMIC start guarantees the body (and its writerActive-releasing
+            // finally) runs even if the scope is already cancelled, so a key can't
+            // get stuck with no live writer.
             if (writerActive.add(key)) {
-                scope.launch { runWriter(key) }
+                scope.launch(start = CoroutineStart.ATOMIC) { runWriter(key) }
             }
         }
     }
@@ -191,10 +227,14 @@ class DefaultCache<V>(
                     if (p == null) writerActive.remove(key)
                     p
                 } ?: return
-                if (op.delete) {
-                    runCatching { diskStore.delete(key) }
-                } else {
-                    runCatching { diskStore.write(key, op.value as V, op.storedAtMillis) }
+                diskMutex.withLock {
+                    if (op.delete) {
+                        runCatching { diskStore.delete(key) }
+                    } else if (op.epoch == diskEpoch) {
+                        runCatching { diskStore.write(key, op.value as V, op.storedAtMillis) }
+                    }
+                    // else: an invalidateAll bumped the epoch after this op was
+                    // produced; dropping the write avoids resurrecting a cleared value.
                 }
             }
         } finally {

--- a/client-core/src/main/kotlin/hivens/core/cache/DiskStore.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/DiskStore.kt
@@ -1,0 +1,16 @@
+package hivens.core.cache
+
+/**
+ * Persistence backend for one typed cache namespace. Synchronous on purpose so a
+ * cold read can seed a UI before any coroutine (the tray menu pattern). A read
+ * MUST return null -- never throw -- on a missing, corrupt, or schema-mismatched
+ * entry, self-healing by deleting the bad file so it doesn't re-fail every launch.
+ */
+interface DiskStore<V> {
+    fun read(key: String): StoredEntry<V>?
+    fun write(key: String, value: V, storedAtMillis: Long)
+    fun delete(key: String)
+    fun clear()
+}
+
+data class StoredEntry<V>(val value: V, val storedAtMillis: Long)

--- a/client-core/src/main/kotlin/hivens/core/cache/NoOpDiskStore.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/NoOpDiskStore.kt
@@ -1,0 +1,15 @@
+package hivens.core.cache
+
+/**
+ * Disk backend that persists nothing -- turns a [DefaultCache] into a pure
+ * in-memory cache (single-flight + TTL + stale-while-revalidate, no restart
+ * persistence). For consumers whose durability is handled elsewhere (e.g. the
+ * server list seeds the tray from its own `ServerListCacheStore`) but that still
+ * want the primitive's in-memory dedup.
+ */
+class NoOpDiskStore<V> : DiskStore<V> {
+    override fun read(key: String): StoredEntry<V>? = null
+    override fun write(key: String, value: V, storedAtMillis: Long) {}
+    override fun delete(key: String) {}
+    override fun clear() {}
+}

--- a/client-core/src/main/kotlin/hivens/core/cache/PassthroughCache.kt
+++ b/client-core/src/main/kotlin/hivens/core/cache/PassthroughCache.kt
@@ -1,0 +1,18 @@
+package hivens.core.cache
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * No-op [Cache]: every call goes straight to the loader, nothing is stored. The
+ * default for cache-aware collaborators so a construction without a real cache
+ * (e.g. a unit test, or a not-yet-wired path) behaves exactly as it did before
+ * caching existed.
+ */
+class PassthroughCache<V> : Cache<V> {
+    override suspend fun get(key: String, loader: suspend () -> V): V = loader()
+    override fun flow(key: String, loader: suspend () -> V): Flow<CacheValue<V>> =
+        flow { emit(CacheValue(loader(), Freshness.FRESH)) }
+    override suspend fun invalidate(key: String) {}
+    override suspend fun invalidateAll() {}
+}

--- a/client-core/src/main/kotlin/hivens/core/io/AtomicFiles.kt
+++ b/client-core/src/main/kotlin/hivens/core/io/AtomicFiles.kt
@@ -1,0 +1,51 @@
+package hivens.core.io
+
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Atomic file writes via the tmp-then-rename pattern, extracted from the four
+ * places that had it copy-pasted (JsonPackRepository, LayoutGraphRepository,
+ * JsonServerListCacheStore, ManifestCache).
+ *
+ * Write to `<file>.tmp`, then `Files.move(ATOMIC_MOVE)` so a crash leaves either
+ * the old or the new file, never a half-written one. Filesystems that cannot do
+ * atomic rename (FAT32 / exFAT on removable drives, some SMB shares) throw
+ * [java.nio.file.AtomicMoveNotSupportedException]; we fall back to a non-atomic
+ * REPLACE_EXISTING move and WARN, since a power loss mid-rename can then lose the
+ * file -- the caller's data is only as durable as the chosen filesystem.
+ *
+ * Synchronous on purpose (no dispatcher): callers already pick their thread, and
+ * some write from contexts that must not suspend (e.g. a JVM shutdown-hook flush).
+ */
+object AtomicFiles {
+    private val log = LoggerFactory.getLogger(AtomicFiles::class.java)
+
+    fun writeString(file: Path, content: String) {
+        write(file) { tmp -> Files.writeString(tmp, content) }
+    }
+
+    fun writeBytes(file: Path, content: ByteArray) {
+        write(file) { tmp -> Files.write(tmp, content) }
+    }
+
+    private inline fun write(file: Path, writeTmp: (Path) -> Unit) {
+        file.parent?.let { Files.createDirectories(it) }
+        val tmp = file.resolveSibling("${file.fileName}.tmp")
+        writeTmp(tmp)
+        try {
+            Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+            log.warn(
+                "Filesystem at {} does not support ATOMIC_MOVE; falling back to " +
+                    "non-atomic rename. A crash mid-rename can lose this file. Move the " +
+                    "data directory to a filesystem with atomic rename (ext4, NTFS, APFS) " +
+                    "for full durability.",
+                file.parent,
+            )
+            Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+}

--- a/client-core/src/main/kotlin/hivens/core/time/Clock.kt
+++ b/client-core/src/main/kotlin/hivens/core/time/Clock.kt
@@ -1,0 +1,16 @@
+package hivens.core.time
+
+/**
+ * Injectable wall clock. Exists so TTL / staleness logic reads time through a
+ * seam instead of calling [System.currentTimeMillis] directly -- a [Clock] can
+ * be advanced deterministically in tests (see `TestClock` in test fixtures)
+ * rather than relying on real time passing.
+ */
+fun interface Clock {
+    fun nowMillis(): Long
+}
+
+/** Production clock backed by the system wall clock. */
+object SystemClock : Clock {
+    override fun nowMillis(): Long = System.currentTimeMillis()
+}

--- a/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
@@ -1,0 +1,264 @@
+package hivens.core.cache
+
+import hivens.test.TestClock
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DefaultCacheTest {
+
+    /** In-memory [DiskStore] with knobs for failure + write counting. */
+    private class MapDiskStore<V> : DiskStore<V> {
+        val map = ConcurrentHashMap<String, StoredEntry<V>>()
+        @Volatile var failRead = false
+        val writeCount = AtomicInteger(0)
+        override fun read(key: String): StoredEntry<V>? {
+            if (failRead) throw RuntimeException("disk read boom")
+            return map[key]
+        }
+        override fun write(key: String, value: V, storedAtMillis: Long) {
+            writeCount.incrementAndGet()
+            map[key] = StoredEntry(value, storedAtMillis)
+        }
+        override fun delete(key: String) { map.remove(key) }
+        override fun clear() { map.clear() }
+    }
+
+    /** Memory-only: read always misses, so memory eviction is observable. */
+    private class NullDiskStore<V> : DiskStore<V> {
+        override fun read(key: String): StoredEntry<V>? = null
+        override fun write(key: String, value: V, storedAtMillis: Long) {}
+        override fun delete(key: String) {}
+        override fun clear() {}
+    }
+
+    // Cache scope = the TestScope itself, so its launched work (background SWR
+    // refresh, debounced disk writes) is advanced by advanceUntilIdle(). The IO
+    // dispatcher is Unconfined so disk hops run inline without a separate dispatch.
+    private fun <V> TestScope.cache(
+        disk: DiskStore<V>,
+        config: CacheConfig<V>,
+        clock: TestClock,
+    ): DefaultCache<V> = DefaultCache(
+        diskStore = disk,
+        config = config,
+        scope = this,
+        clock = clock,
+        namespace = "test",
+        ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+    )
+
+    @Test
+    fun `miss loads then a fresh hit avoids the loader`() = runTest {
+        val clock = TestClock()
+        val calls = AtomicInteger(0)
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val loader: suspend () -> String = { calls.incrementAndGet(); "v1" }
+
+        assertEquals("v1", cache.get("k", loader))
+        assertEquals("v1", cache.get("k", loader))
+        assertEquals(1, calls.get(), "second get within TTL must not call the loader")
+    }
+
+    @Test
+    fun `stale read serves stale then refreshes with a single upstream call`() = runTest {
+        val clock = TestClock()
+        val calls = AtomicInteger(0)
+        var current = "old"
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val loader: suspend () -> String = { calls.incrementAndGet(); current }
+
+        assertEquals("old", cache.get("k", loader))      // miss -> load
+        current = "new"
+        clock.advance(1_500)                              // now stale
+        assertEquals("old", cache.get("k", loader), "stale value served immediately")
+        advanceUntilIdle()                                // let the background refresh run
+        assertEquals(2, calls.get(), "exactly one background refresh")
+        assertEquals("new", cache.get("k", loader), "refreshed value now fresh")
+        assertEquals(2, calls.get(), "fresh hit, no extra load")
+    }
+
+    @Test
+    fun `concurrent misses collapse to one upstream load`() = runTest {
+        val clock = TestClock()
+        val calls = AtomicInteger(0)
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 10_000), clock)
+        val loader: suspend () -> String = { calls.incrementAndGet(); delay(50); "v" }
+
+        val results = (1..50).map { async { cache.get("k", loader) } }
+        advanceUntilIdle()
+        results.forEach { assertEquals("v", it.await()) }
+        assertEquals(1, calls.get(), "single-flight: 50 concurrent gets -> one loader call")
+    }
+
+    @Test
+    fun `value survives a restart via disk`() = runTest {
+        val clock = TestClock()
+        val disk = MapDiskStore<String>()
+        val calls = AtomicInteger(0)
+        val loader: suspend () -> String = { calls.incrementAndGet(); "v" }
+
+        cache(disk, CacheConfig(ttlMs = 10_000), clock).get("k", loader)
+        advanceUntilIdle()                                // flush debounced disk write
+        assertTrue(disk.map.containsKey("k"))
+
+        // "restart": fresh cache over the same disk + same clock
+        val calls2 = AtomicInteger(0)
+        val v = cache(disk, CacheConfig(ttlMs = 10_000), clock).get("k") { calls2.incrementAndGet(); "other" }
+        assertEquals("v", v, "served from disk, not the loader")
+        assertEquals(0, calls2.get())
+    }
+
+    @Test
+    fun `refresh failure keeps the stale value and retries next time`() = runTest {
+        val clock = TestClock()
+        val calls = AtomicInteger(0)
+        var failing = false
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val loader: suspend () -> String = {
+            calls.incrementAndGet()
+            if (failing) throw RuntimeException("upstream down") else "old"
+        }
+
+        cache.get("k", loader)                            // store "old"
+        failing = true
+        clock.advance(1_500)
+        assertEquals("old", cache.get("k", loader))       // stale served
+        advanceUntilIdle()                                // refresh runs + fails (logged)
+        assertEquals("old", cache.get("k", loader), "stale retained after failed refresh")
+        advanceUntilIdle()
+        assertTrue(calls.get() >= 3, "failed refresh retries on subsequent stale reads")
+    }
+
+    @Test
+    fun `past the hard staleness cap the loader error propagates`() = runTest {
+        val clock = TestClock()
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000, staleTtlMs = 2_000), clock)
+        var failing = false
+        val loader: suspend () -> String = { if (failing) throw IllegalStateException("down") else "old" }
+
+        cache.get("k", loader)
+        failing = true
+        clock.advance(2_500)                              // past hard cap -> not served
+        assertFailsWith<IllegalStateException> { cache.get("k", loader) }
+    }
+
+    @Test
+    fun `shouldStore veto keeps the previous value`() = runTest {
+        val clock = TestClock()
+        val cache = cache(
+            MapDiskStore<List<String>>(),
+            CacheConfig(ttlMs = 1_000, shouldStore = { it.isNotEmpty() }),
+            clock,
+        )
+        cache.get("k") { listOf("a", "b") }               // stored
+        clock.advance(1_500)
+        cache.get("k") { emptyList() }                    // stale -> background refresh returns empty
+        advanceUntilIdle()
+        assertEquals(listOf("a", "b"), cache.get("k") { listOf("a", "b") }, "empty result must not clobber the cache")
+    }
+
+    @Test
+    fun `invalidate drops memory and disk`() = runTest {
+        val clock = TestClock()
+        val disk = MapDiskStore<String>()
+        val calls = AtomicInteger(0)
+        val cache = cache(disk, CacheConfig(ttlMs = 10_000), clock)
+        val loader: suspend () -> String = { calls.incrementAndGet(); "v" }
+
+        cache.get("k", loader); advanceUntilIdle()
+        cache.invalidate("k")
+        assertTrue(!disk.map.containsKey("k"))
+        cache.get("k", loader)
+        assertEquals(2, calls.get(), "post-invalidate get reloads")
+    }
+
+    @Test
+    fun `flow emits stale then fresh`() = runTest {
+        val clock = TestClock()
+        var current = "old"
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val loader: suspend () -> String = { current }
+
+        cache.get("k", loader)
+        current = "new"
+        clock.advance(1_500)
+        val emissions = cache.flow("k", loader).toList()
+        assertEquals(
+            listOf(CacheValue("old", Freshness.STALE), CacheValue("new", Freshness.FRESH)),
+            emissions,
+        )
+    }
+
+    @Test
+    fun `flow on a miss emits only fresh`() = runTest {
+        val clock = TestClock()
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val emissions = cache.flow("k") { "v" }.toList()
+        assertEquals(listOf(CacheValue("v", Freshness.FRESH)), emissions)
+    }
+
+    @Test
+    fun `LRU evicts the eldest beyond maxEntries`() = runTest {
+        val clock = TestClock()
+        val calls = ConcurrentHashMap<String, Int>()
+        val cache = cache(NullDiskStore<String>(), CacheConfig(ttlMs = 10_000, maxEntries = 2), clock)
+        val loader: (String) -> suspend () -> String = { k -> { calls.merge(k, 1, Int::plus); k } }
+
+        cache.get("k1", loader("k1"))
+        cache.get("k2", loader("k2"))
+        cache.get("k1", loader("k1"))                     // touch k1 (now MRU)
+        cache.get("k3", loader("k3"))                     // size 3 -> evict eldest = k2
+        cache.get("k1", loader("k1"))                     // still cached
+        cache.get("k2", loader("k2"))                     // evicted -> reload
+
+        assertEquals(1, calls["k1"], "k1 stayed cached (was touched)")
+        assertEquals(2, calls["k2"], "k2 was evicted and reloaded")
+    }
+
+    @Test
+    fun `disk read failure degrades to a miss, not a crash`() = runTest {
+        val clock = TestClock()
+        val disk = MapDiskStore<String>().apply { failRead = true }
+        val cache = cache(disk, CacheConfig(ttlMs = 1_000), clock)
+        assertEquals("v", cache.get("k") { "v" }, "a throwing disk read must be treated as a miss")
+    }
+
+    @Test
+    fun `background refresh is independent of the caller scope`() = runTest {
+        val clock = TestClock()
+        var current = "old"
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 1_000), clock)
+        val loader: suspend () -> String = { current }
+
+        cache.get("k", loader)
+        current = "new"
+        clock.advance(1_500)
+        // A short-lived caller triggers the refresh then "leaves".
+        async { cache.get("k", loader) }.await()
+        advanceUntilIdle()                                // refresh runs on the cache scope regardless
+        assertEquals("new", cache.get("k", loader))
+    }
+
+    @Test
+    fun `disk writes for the same key are debounced`() = runTest {
+        val clock = TestClock()
+        val disk = MapDiskStore<String>()
+        val cache = cache(disk, CacheConfig(ttlMs = 0, diskDebounceMs = 200), clock)
+        // ttl 0 -> every get is a fresh load+store; hammer the same key.
+        repeat(5) { cache.get("k") { "v$it" } }
+        advanceUntilIdle()
+        assertTrue(disk.writeCount.get() <= 2, "rapid stores coalesce; got ${disk.writeCount.get()}")
+    }
+}

--- a/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
@@ -1,12 +1,13 @@
 package hivens.core.cache
 
 import hivens.test.TestClock
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.ConcurrentHashMap
@@ -178,10 +179,22 @@ class DefaultCacheTest {
         val loader: suspend () -> String = { calls.incrementAndGet(); "v" }
 
         cache.get("k", loader); advanceUntilIdle()
-        cache.invalidate("k")
+        cache.invalidate("k"); advanceUntilIdle() // delete is routed through the debounced writer
         assertTrue(!disk.map.containsKey("k"))
         cache.get("k", loader)
         assertEquals(2, calls.get(), "post-invalidate get reloads")
+    }
+
+    @Test
+    fun `a cancelled leader load lets a later get recover (no inFlight leak)`() = runTest {
+        val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 10_000), TestClock())
+        val job = launch { cache.get("k") { delay(1_000); "v" } } // leader, suspended mid-load
+        advanceTimeBy(10)
+        job.cancel()                                              // cancel the leader before it completes
+        advanceUntilIdle()
+        // inFlight must have been cleared in the leader's finally, so a fresh get
+        // becomes a new leader rather than awaiting a dead deferred.
+        assertEquals("v2", cache.get("k") { "v2" })
     }
 
     @Test
@@ -249,6 +262,26 @@ class DefaultCacheTest {
         async { cache.get("k", loader) }.await()
         advanceUntilIdle()                                // refresh runs on the cache scope regardless
         assertEquals("new", cache.get("k", loader))
+    }
+
+    @Test
+    fun `a store during a pending write conflates to the latest value (no reorder)`() = runTest {
+        // Codex P2: a second store for the same key while the first is still
+        // pending must not let an older value land last. The single per-key
+        // writer conflates onto the newest value and writes it exactly once.
+        val clock = TestClock()
+        val disk = MapDiskStore<String>()
+        var current = "v1"
+        val cache = cache(disk, CacheConfig(ttlMs = 1_000, diskDebounceMs = 200), clock)
+
+        cache.get("k") { current }          // store v1 (writer is debouncing)
+        current = "v2"
+        clock.advance(1_500)                // stale
+        cache.get("k") { current }          // stale served; background refresh stores v2
+        advanceUntilIdle()
+
+        assertEquals("v2", disk.map["k"]?.value, "disk holds the newest value, not the older one")
+        assertEquals(1, disk.writeCount.get(), "the two stores collapse into one write")
     }
 
     @Test

--- a/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/cache/DefaultCacheTest.kt
@@ -186,6 +186,24 @@ class DefaultCacheTest {
     }
 
     @Test
+    fun `invalidateAll wipes disk and a not-yet-flushed write does not resurrect`() = runTest {
+        val clock = TestClock()
+        val disk = MapDiskStore<String>()
+        // A long debounce keeps the write pending across the invalidateAll, so the
+        // clear has to win over an op that was scheduled before it.
+        val cache = cache(disk, CacheConfig(ttlMs = 10_000, diskDebounceMs = 10_000), clock)
+
+        cache.get("k1") { "v1" }; advanceUntilIdle()      // persisted to disk
+        assertTrue(disk.map.containsKey("k1"))
+        cache.get("k2") { "v2" }                          // write scheduled, still within debounce
+
+        cache.invalidateAll()
+        assertTrue(disk.map.isEmpty(), "invalidateAll wipes disk immediately")
+        advanceUntilIdle()                                // let any pending writer run
+        assertTrue(disk.map.isEmpty(), "a write scheduled before the clear must not resurrect after it")
+    }
+
+    @Test
     fun `a cancelled leader load lets a later get recover (no inFlight leak)`() = runTest {
         val cache = cache(MapDiskStore<String>(), CacheConfig(ttlMs = 10_000), TestClock())
         val job = launch { cache.get("k") { delay(1_000); "v" } } // leader, suspended mid-load

--- a/client-core/src/test/kotlin/hivens/core/io/AtomicFilesTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/io/AtomicFilesTest.kt
@@ -1,0 +1,59 @@
+package hivens.core.io
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicFilesTest {
+
+    private lateinit var dir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("atomic-files-test-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `writeString creates missing parent dirs and round-trips`() {
+        val file = dir.resolve("a/b/c/data.json")
+        AtomicFiles.writeString(file, "hello world")
+        assertTrue(Files.isRegularFile(file))
+        assertEquals("hello world", Files.readString(file))
+    }
+
+    @Test
+    fun `writeString overwrites existing content`() {
+        val file = dir.resolve("data.json")
+        AtomicFiles.writeString(file, "first")
+        AtomicFiles.writeString(file, "second")
+        assertEquals("second", Files.readString(file))
+    }
+
+    @Test
+    fun `writeBytes round-trips binary content`() {
+        val file = dir.resolve("blob.bin")
+        val bytes = byteArrayOf(0, 1, 2, 127, -1, -128, 42)
+        AtomicFiles.writeBytes(file, bytes)
+        assertContentEquals(bytes, Files.readAllBytes(file))
+    }
+
+    @Test
+    fun `no orphan tmp file is left after a successful write`() {
+        val file = dir.resolve("data.json")
+        AtomicFiles.writeString(file, "x")
+        assertFalse(Files.exists(file.resolveSibling("data.json.tmp")), "tmp must be moved into place, not left behind")
+    }
+}

--- a/client-core/src/test/kotlin/hivens/core/time/ClockTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/time/ClockTest.kt
@@ -1,0 +1,28 @@
+package hivens.core.time
+
+import hivens.test.TestClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClockTest {
+
+    @Test
+    fun `system clock tracks wall time`() {
+        val before = System.currentTimeMillis()
+        val t = SystemClock.nowMillis()
+        assertTrue(t >= before, "system clock must be monotonic with wall time")
+    }
+
+    @Test
+    fun `test clock advances and sets deterministically`() {
+        val c = TestClock(start = 1_000)
+        assertEquals(1_000, c.nowMillis())
+        c.advance(500)
+        assertEquals(1_500, c.nowMillis())
+        c.advance(0)
+        assertEquals(1_500, c.nowMillis())
+        c.set(0)
+        assertEquals(0, c.nowMillis())
+    }
+}

--- a/client-core/src/testFixtures/kotlin/hivens/test/TestClock.kt
+++ b/client-core/src/testFixtures/kotlin/hivens/test/TestClock.kt
@@ -1,0 +1,24 @@
+package hivens.test
+
+import hivens.core.time.Clock
+
+/**
+ * Manually-advanced [Clock] for deterministic TTL/staleness tests. Lives in test
+ * fixtures (like `buildMockClient`) so both client-core and client-launcher
+ * tests can drive cache age without sleeping. Thread-safe enough for the
+ * single-writer/multi-reader use in cache tests.
+ */
+class TestClock(start: Long = 0L) : Clock {
+    @Volatile
+    private var now = start
+
+    override fun nowMillis(): Long = now
+
+    fun advance(ms: Long) {
+        now += ms
+    }
+
+    fun set(ms: Long) {
+        now = ms
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
@@ -2,6 +2,7 @@ package hivens.launcher
 
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.PackInstance
+import hivens.core.io.AtomicFiles
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +18,6 @@ import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 
 /**
  * JSON-on-disk [IPackRepository]. Persists the launcher's installed
@@ -93,46 +93,8 @@ class JsonPackRepository(
 
     private suspend fun persist() = withContext(Dispatchers.IO) {
         try {
-            Files.createDirectories(file.parent)
-            val tmp = file.resolveSibling("${file.fileName}.tmp")
             val snapshot = PacksFile(schemaVersion = SCHEMA_VERSION, instances = state.value)
-            Files.writeString(tmp, json.encodeToString(snapshot))
-            // ATOMIC_MOVE so a crash between writeString and move
-            // leaves either the old or the new file, never a
-            // half-written packs.json that the next load() would
-            // reject as malformed and silently empty the library.
-            //
-            // Filesystems that do not support atomic rename (FAT32 on
-            // removable drives, some network shares) throw
-            // AtomicMoveNotSupportedException; without a fallback the
-            // outer catch then swallows it and the in-memory state
-            // diverges from disk indefinitely, so a restart would
-            // empty the library.
-            try {
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
-                // Best-effort: the underlying filesystem (typically
-                // FAT32 / exFAT on a removable drive, or some SMB
-                // shares) does not support atomic rename. A non-
-                // atomic REPLACE_EXISTING move decomposes to
-                // delete-target-then-rename on those filesystems,
-                // and a power loss between the two steps leaves
-                // packs.json missing -- next launch loads emptyList()
-                // and the library appears wiped. We surface a WARN
-                // so a user who lands on this branch can correlate
-                // their data-dir choice with the weaker durability
-                // contract; full safety would require a fsync ladder
-                // that POSIX cannot guarantee on these filesystems.
-                log.warn(
-                    "Filesystem at {} does not support ATOMIC_MOVE; " +
-                    "falling back to non-atomic rename. A crash mid-rename " +
-                    "can lose packs.json. Move the data directory to a " +
-                    "filesystem that supports atomic rename (ext4, NTFS, " +
-                    "APFS) for full library durability.",
-                    file.parent,
-                )
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
-            }
+            AtomicFiles.writeString(file, json.encodeToString(snapshot))
         } catch (e: CancellationException) {
             // Today persist() has no suspension points inside the
             // try-body, so withContext's cancellation check fires at

--- a/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LayoutGraphRepository.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
+import hivens.core.io.AtomicFiles
 
 /**
  * JSON-on-disk store for the widget [LayoutGraph]. Single-file envelope
@@ -157,9 +157,7 @@ class LayoutGraphRepository(
             // against the in-memory default.
             val def = defaultGraph()
             try {
-                Files.createDirectories(file.parent)
-                val envelope = Envelope(schemaVersion = SCHEMA_VERSION, graph = def)
-                Files.writeString(file, json.encodeToString(envelope))
+                AtomicFiles.writeString(file, json.encodeToString(Envelope(schemaVersion = SCHEMA_VERSION, graph = def)))
             } catch (e: Exception) {
                 log.warn("Failed to seed default layout graph at {} -- continuing in memory", file, e)
             }
@@ -199,22 +197,8 @@ class LayoutGraphRepository(
     // block; flush() invokes from inside its own mutex.withLock.
     private fun writeNow() {
         try {
-            Files.createDirectories(file.parent)
-            val tmp = file.resolveSibling("${file.fileName}.tmp")
             val envelope = Envelope(schemaVersion = SCHEMA_VERSION, graph = state.value)
-            Files.writeString(tmp, json.encodeToString(envelope))
-            try {
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
-                log.warn(
-                    "Filesystem at {} does not support ATOMIC_MOVE; " +
-                    "falling back to non-atomic rename for layout-graph.json. " +
-                    "Move the data directory to a filesystem that supports " +
-                    "atomic rename (ext4, NTFS, APFS) for full durability.",
-                    file.parent,
-                )
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
-            }
+            AtomicFiles.writeString(file, json.encodeToString(envelope))
         } catch (e: Exception) {
             log.error("Failed to persist layout graph at {}", file, e)
         }

--- a/client-launcher/src/main/kotlin/hivens/launcher/ManifestCache.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/ManifestCache.kt
@@ -5,6 +5,7 @@ import hivens.launcher.platform.ServerNameValidator
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
+import hivens.core.io.AtomicFiles
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
@@ -97,13 +98,12 @@ class ManifestCache(
 
     fun markClean(serverId: String, manifestHash: String, manifest: FileManifest? = null) {
         runCatching {
-            Files.createDirectories(cacheDir)
             val entry = Entry(
                 hash = manifestHash,
                 syncedAt = System.currentTimeMillis(),
                 manifest = manifest,
             )
-            Files.writeString(cacheFile(serverId), json.encodeToString(entry))
+            AtomicFiles.writeString(cacheFile(serverId), json.encodeToString(entry))
         }.onFailure { log.warn("Failed to persist manifest-cache entry for {}", serverId, it) }
     }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/ServerListCacheStore.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/ServerListCacheStore.kt
@@ -7,9 +7,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
+import hivens.core.io.AtomicFiles
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 
 /**
  * Disk snapshot of the most recently fetched dashboard server list.
@@ -87,11 +87,8 @@ class JsonServerListCacheStore(
     override suspend fun save(servers: List<ServerProfile>) {
         withContext(Dispatchers.IO) {
             try {
-                Files.createDirectories(file.parent)
-                val tmp = file.resolveSibling("${file.fileName}.tmp")
                 val snapshot = ServersCacheFile(schemaVersion = SCHEMA_VERSION, servers = servers)
-                Files.writeString(tmp, json.encodeToString(snapshot))
-                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+                AtomicFiles.writeString(file, json.encodeToString(snapshot))
             } catch (e: Exception) {
                 log.error("Failed to persist servers cache at {}", file, e)
             }

--- a/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
@@ -5,6 +5,8 @@ import hivens.core.api.dto.SmartyServer
 import hivens.core.api.interfaces.IServerListService
 import hivens.core.api.model.ServerProfile
 import hivens.core.api.model.ServerSource
+import hivens.core.cache.Cache
+import hivens.core.cache.PassthroughCache
 import hivens.core.data.DashboardData
 import hivens.core.data.NewsItem
 import hivens.launcher.network.ServerProtocolConfig
@@ -20,81 +22,61 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
+/**
+ * The in-memory dedup + single-flight that this service hand-rolled now lives in
+ * [dashboardCache] (an in-memory [Cache] keyed by [CACHE_KEY]). The disk side --
+ * the SERVERS-ONLY [cache] that seeds the tray synchronously at next launch --
+ * stays as-is, since that seed is read before any coroutine. Concurrent callers
+ * (auto-sync + dashboard composition + tray launch overlap on cold start) share
+ * one fetch via the cache's single-flight; an empty result (transient outage)
+ * neither overwrites the last-known-good list nor caches, so it retries.
+ */
 class SmartyCraftServerListService(
     private val repository: ServerRepository,
     private val protocolConfig: ServerProtocolConfig = ServerProtocolConfig(),
     private val cache: ServerListCacheStore = ServerListCacheStore.NoOp,
+    private val dashboardCache: Cache<DashboardData> = PassthroughCache(),
 ) : IServerListService {
 
     private val logger = LoggerFactory.getLogger(SmartyCraftServerListService::class.java)
-    private val lock = Any()
-    @Volatile
-    private var cachedData: DashboardData? = null
-    /**
-     * Single in-flight fetch. If a load is already running when a second
-     * caller arrives (auto-sync + dashboard composition + tray-launch
-     * can overlap on cold start), they share the same future rather than
-     * each firing their own request and racing to populate [cachedData].
-     */
-    @Volatile
-    private var inFlight: CompletableFuture<DashboardData>? = null
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val dateFormatter = DateTimeFormatter
         .ofPattern("dd MMM yyyy", Locale.of("ru"))
         .withZone(ZoneId.systemDefault())
 
-    override fun refresh(): CompletableFuture<DashboardData> {
-        synchronized(lock) { cachedData = null }
-        return fetchDashboardData()
+    override fun refresh(): CompletableFuture<DashboardData> = serviceScope.future {
+        dashboardCache.invalidate(CACHE_KEY)
+        dashboardCache.get(CACHE_KEY) { loadDashboard() }
     }
 
-    override fun fetchDashboardData(): CompletableFuture<DashboardData> {
-        cachedData?.let { return CompletableFuture.completedFuture(it) }
+    override fun fetchDashboardData(): CompletableFuture<DashboardData> = serviceScope.future {
+        dashboardCache.get(CACHE_KEY) { loadDashboard() }
+    }
 
-        synchronized(lock) {
-            // Double-checked: another caller may have populated either field
-            // between the unlocked fast-path read and the lock acquire.
-            cachedData?.let { return CompletableFuture.completedFuture(it) }
-            inFlight?.let { return it }
-
-            val future = serviceScope.future {
-                try {
-                    val response = repository.fetchDashboard()
-
-                    val servers = response.servers.map { getProfile(it) }
-                    val news = response.news.map { newsDto ->
-                        val imageName = if (newsDto.image.endsWith(".jpg")) newsDto.image else "${newsDto.image}.jpg"
-                        val imageUrl = "${protocolConfig.baseUrl}/images/news/mini/$imageName"
-
-                        NewsItem(
-                            id = newsDto.id,
-                            title = newsDto.name,
-                            description = "Views: ${newsDto.views}",
-                            date = formatTimestamp(newsDto.date),
-                            imageUrl = imageUrl
-                        )
-                    }
-
-                    val data = DashboardData(servers, news)
-                    if (servers.isNotEmpty()) {
-                        synchronized(lock) { cachedData = data }
-                        // Disk cache feeds [TrayManager] at the next launch
-                        // before the network round-trip; only persist on
-                        // success so a transient outage cannot overwrite
-                        // the last-known-good list with an empty one.
-                        cache.save(servers)
-                    }
-                    data
-                } catch (e: Exception) {
-                    logger.error("fetchDashboardData failed -- returning empty dashboard", e)
-                    DashboardData(emptyList(), emptyList())
-                }
+    private suspend fun loadDashboard(): DashboardData =
+        try {
+            val response = repository.fetchDashboard()
+            val servers = response.servers.map { getProfile(it) }
+            val news = response.news.map { newsDto ->
+                val imageName = if (newsDto.image.endsWith(".jpg")) newsDto.image else "${newsDto.image}.jpg"
+                val imageUrl = "${protocolConfig.baseUrl}/images/news/mini/$imageName"
+                NewsItem(
+                    id = newsDto.id,
+                    title = newsDto.name,
+                    description = "Views: ${newsDto.views}",
+                    date = formatTimestamp(newsDto.date),
+                    imageUrl = imageUrl
+                )
             }
-            inFlight = future
-            future.whenComplete { _, _ -> synchronized(lock) { inFlight = null } }
-            return future
+            // Persist only on success so a transient outage cannot overwrite the
+            // last-known-good list the tray seeds from. The in-memory cache's
+            // shouldStore guard does the same for the session cache.
+            if (servers.isNotEmpty()) cache.save(servers)
+            DashboardData(servers, news)
+        } catch (e: Exception) {
+            logger.error("fetchDashboardData failed -- returning empty dashboard", e)
+            DashboardData(emptyList(), emptyList())
         }
-    }
 
     private fun getProfile(srv: SmartyServer): ServerProfile =
         ServerProfile(
@@ -115,5 +97,10 @@ class SmartyCraftServerListService(
         } catch (_: Exception) {
             "Unknown Date"
         }
+    }
+
+    private companion object {
+        // One dashboard per session; a fixed key is enough.
+        const val CACHE_KEY = "dashboard"
     }
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
@@ -5,7 +5,9 @@ import hivens.core.cache.CacheConfig
 import hivens.core.cache.DefaultCache
 import hivens.core.time.Clock
 import hivens.core.time.SystemClock
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import java.nio.file.Path
@@ -21,9 +23,10 @@ class CacheFactory(
     private val json: Json,
     private val scope: CoroutineScope,    // shared app scope (SupervisorJob + IO)
     private val clock: Clock = SystemClock,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     fun <V> create(namespace: String, serializer: KSerializer<V>, config: CacheConfig<V>): Cache<V> {
         val disk = JsonDiskStore(rootDir.resolve(namespace), serializer, json)
-        return DefaultCache(disk, config, scope, clock, namespace)
+        return DefaultCache(disk, config, scope, clock, namespace, ioDispatcher)
     }
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
@@ -3,6 +3,7 @@ package hivens.launcher.cache
 import hivens.core.cache.Cache
 import hivens.core.cache.CacheConfig
 import hivens.core.cache.DefaultCache
+import hivens.core.cache.NoOpDiskStore
 import hivens.core.time.Clock
 import hivens.core.time.SystemClock
 import kotlinx.coroutines.CoroutineDispatcher
@@ -29,4 +30,8 @@ class CacheFactory(
         val disk = JsonDiskStore(rootDir.resolve(namespace), serializer, json)
         return DefaultCache(disk, config, scope, clock, namespace, ioDispatcher)
     }
+
+    /** In-memory only (no disk persistence) -- single-flight + TTL + SWR, no serializer needed. */
+    fun <V> createInMemory(namespace: String, config: CacheConfig<V>): Cache<V> =
+        DefaultCache(NoOpDiskStore(), config, scope, clock, namespace, ioDispatcher)
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/cache/CacheFactory.kt
@@ -1,0 +1,29 @@
+package hivens.launcher.cache
+
+import hivens.core.cache.Cache
+import hivens.core.cache.CacheConfig
+import hivens.core.cache.DefaultCache
+import hivens.core.time.Clock
+import hivens.core.time.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+
+/**
+ * Builds typed, disk-backed caches that share one root dir, Json, scope, and
+ * clock. Each call yields an independent [Cache] for one value type/namespace --
+ * resolving heterogeneous cached types without `Any`/erasure (every namespace
+ * carries its own [KSerializer] and disk subdirectory).
+ */
+class CacheFactory(
+    private val rootDir: Path,            // <dataDir>/cache
+    private val json: Json,
+    private val scope: CoroutineScope,    // shared app scope (SupervisorJob + IO)
+    private val clock: Clock = SystemClock,
+) {
+    fun <V> create(namespace: String, serializer: KSerializer<V>, config: CacheConfig<V>): Cache<V> {
+        val disk = JsonDiskStore(rootDir.resolve(namespace), serializer, json)
+        return DefaultCache(disk, config, scope, clock, namespace)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/cache/JsonDiskStore.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/cache/JsonDiskStore.kt
@@ -1,0 +1,87 @@
+package hivens.launcher.cache
+
+import hivens.core.cache.DiskStore
+import hivens.core.cache.StoredEntry
+import hivens.core.io.AtomicFiles
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+/**
+ * Disk backend for one cache namespace: one JSON file per key under [dir],
+ * named by the SHA-256 of the key (URLs contain `/ : ?` and can exceed PATH_MAX,
+ * so a hash is the only robust filename; the original key is kept inside the
+ * envelope for debuggability). Tolerant by contract: any read failure (missing,
+ * corrupt, wrong schema) returns null AND deletes the offending file so it
+ * self-heals instead of re-failing every launch. Writes are atomic.
+ */
+class JsonDiskStore<V>(
+    private val dir: Path,
+    private val serializer: KSerializer<V>,
+    private val json: Json,
+) : DiskStore<V> {
+
+    private val log = LoggerFactory.getLogger(JsonDiskStore::class.java)
+    private val envelopeSerializer = Envelope.serializer(serializer)
+
+    override fun read(key: String): StoredEntry<V>? {
+        val file = fileFor(key)
+        if (!Files.isRegularFile(file)) return null
+        return runCatching {
+            val env = json.decodeFromString(envelopeSerializer, Files.readString(file))
+            if (env.schemaVersion != SCHEMA_VERSION) {
+                runCatching { Files.deleteIfExists(file) }
+                return null
+            }
+            StoredEntry(env.value, env.storedAt)
+        }.getOrElse { e ->
+            log.debug("cache disk entry {} unreadable; dropping", file, e)
+            runCatching { Files.deleteIfExists(file) }
+            null
+        }
+    }
+
+    override fun write(key: String, value: V, storedAtMillis: Long) {
+        runCatching {
+            val env = Envelope(SCHEMA_VERSION, key, storedAtMillis, value)
+            AtomicFiles.writeString(fileFor(key), json.encodeToString(envelopeSerializer, env))
+        }.onFailure { log.warn("cache disk write failed for key {}", key, it) }
+    }
+
+    override fun delete(key: String) {
+        runCatching { Files.deleteIfExists(fileFor(key)) }
+    }
+
+    override fun clear() {
+        if (!Files.isDirectory(dir)) return
+        runCatching {
+            Files.list(dir).use { stream ->
+                stream.filter { it.fileName.toString().endsWith(".json") }
+                    .forEach { runCatching { Files.deleteIfExists(it) } }
+            }
+        }.onFailure { log.warn("cache clear failed for {}", dir, it) }
+    }
+
+    private fun fileFor(key: String): Path = dir.resolve(sha256Hex(key) + ".json")
+
+    private fun sha256Hex(s: String): String =
+        MessageDigest.getInstance("SHA-256").digest(s.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+
+    @Serializable
+    private data class Envelope<V>(
+        @SerialName("schema_version") val schemaVersion: Int,
+        val key: String,
+        @SerialName("stored_at") val storedAt: Long,
+        val value: V,
+    )
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/cache/SmrtPackCaches.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/cache/SmrtPackCaches.kt
@@ -1,0 +1,32 @@
+package hivens.launcher.cache
+
+import hivens.core.api.dto.smrt.ModrinthProject
+import hivens.core.api.dto.smrt.ModrinthVersion
+import hivens.core.api.dto.smrt.SmrtPackListing
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtPackSummary
+import hivens.core.cache.Cache
+import hivens.core.cache.PassthroughCache
+
+/**
+ * The per-endpoint caches the [hivens.launcher.smrt.SmrtPackClient] reads through.
+ * Built from [CacheFactory] in DI; [passthrough] gives a no-op set for tests and
+ * any construction that doesn't wire caching.
+ */
+class SmrtPackCaches(
+    val listing: Cache<SmrtPackListing>,
+    val summary: Cache<SmrtPackSummary>,
+    val manifest: Cache<SmrtPackManifest>,
+    val modrinthProject: Cache<ModrinthProject>,
+    val modrinthVersion: Cache<ModrinthVersion>,
+) {
+    companion object {
+        fun passthrough(): SmrtPackCaches = SmrtPackCaches(
+            listing = PassthroughCache(),
+            summary = PassthroughCache(),
+            manifest = PassthroughCache(),
+            modrinthProject = PassthroughCache(),
+            modrinthVersion = PassthroughCache(),
+        )
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -31,6 +31,16 @@ import hivens.launcher.runtime.loader.LoaderRegistry
 import hivens.launcher.runtime.loader.ModernInstallerResolver
 import hivens.launcher.security.KeyringStorageFactory
 import hivens.launcher.smrt.ModIconResolver
+import hivens.core.api.dto.smrt.ModrinthProject
+import hivens.core.api.dto.smrt.ModrinthVersion
+import hivens.core.api.dto.smrt.SmrtPackListing
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtPackSummary
+import hivens.core.cache.CacheConfig
+import hivens.core.time.Clock
+import hivens.core.time.SystemClock
+import hivens.launcher.cache.CacheFactory
+import hivens.launcher.cache.SmrtPackCaches
 import hivens.launcher.smrt.SmrtPackClient
 import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.update.UpdateApplicators
@@ -397,11 +407,35 @@ val appModule = module {
     }
     single<IFileDownloadService> { FileDownloadService(get(), get(), get(), get<ServerProtocolConfig>()) }
 
+    // Cross-cutting cache layer. CacheFactory shares the app Json, the
+    // process-lifetime IO scope, and a system clock; each pack-metadata endpoint
+    // gets its own disk-backed, TTL + stale-while-revalidate namespace.
+    single<Clock> { SystemClock }
+    single { CacheFactory(rootDir = get<Path>().resolve("cache"), json = get(), scope = get(), clock = get()) }
+    single {
+        val f: CacheFactory = get()
+        val min = 60_000L
+        val hour = 60 * min
+        val day = 24 * hour
+        SmrtPackCaches(
+            // Browse listing + per-pack summary: change occasionally; serve stale
+            // for a day on outage.
+            listing = f.create("pack-listing", SmrtPackListing.serializer(), CacheConfig(ttlMs = 5 * min, staleTtlMs = day)),
+            summary = f.create("pack-summary", SmrtPackSummary.serializer(), CacheConfig(ttlMs = 10 * min, staleTtlMs = day)),
+            // Manifests change on a pack release; pinned-version manifests are
+            // immutable and ride the same namespace as long-lived hits.
+            manifest = f.create("pack-manifest", SmrtPackManifest.serializer(), CacheConfig(ttlMs = 10 * min, staleTtlMs = 7 * day)),
+            // Modrinth project metadata (icons) rarely changes; a version is immutable.
+            modrinthProject = f.create("modrinth-project", ModrinthProject.serializer(), CacheConfig(ttlMs = hour, staleTtlMs = 7 * day)),
+            modrinthVersion = f.create("modrinth-version", ModrinthVersion.serializer(), CacheConfig(ttlMs = 7 * day, staleTtlMs = 30 * day)),
+        )
+    }
+
     // Hivens Mirror sync. Uses the "direct" HttpClient because
     // smrt.hivens.dev and Modrinth are public CDN-fronted endpoints
     // that don't need the SC channel's SOCKS proxy or SSL bypass.
     // Always wired so toggling on at runtime requires no graph rebuild.
-    single { SmrtPackClient(get(named("direct"))) }
+    single { SmrtPackClient(get(named("direct")), caches = get()) }
     single { SmrtSyncService(get(), get()) }
     single { PackInstaller(syncService = get(), runtimeProvisioner = get(), repository = get(), dataDir = get()) }
     single {

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -37,6 +37,7 @@ import hivens.core.api.dto.smrt.SmrtPackListing
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
 import hivens.core.cache.CacheConfig
+import hivens.core.data.DashboardData
 import hivens.core.time.Clock
 import hivens.core.time.SystemClock
 import hivens.launcher.cache.CacheFactory
@@ -525,7 +526,21 @@ val appModule = module {
         )
     }
 
-    single<IServerListService> { SmartyCraftServerListService(get(), get(), get()) }
+    single<IServerListService> {
+        // In-memory dashboard cache (single-flight + 10-min SWR). The disk seed
+        // for the tray stays in ServerListCacheStore (servers-only, read
+        // synchronously before any coroutine); empty results don't get stored.
+        val dashboardCache = get<CacheFactory>().createInMemory<DashboardData>(
+            "dashboard",
+            CacheConfig(
+                ttlMs = 10 * 60_000L,
+                staleTtlMs = Long.MAX_VALUE,
+                maxEntries = 4,
+                shouldStore = { it.servers.isNotEmpty() },
+            ),
+        )
+        SmartyCraftServerListService(get(), get(), get(), dashboardCache)
+    }
 
     // JSON-on-disk pack registry. Persists installed PackInstances
     // to <dataDir>/packs.json so Library reflects real state across

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
@@ -6,6 +6,7 @@ import hivens.core.api.dto.smrt.ModrinthVersion
 import hivens.core.api.dto.smrt.SmrtPackListing
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
+import hivens.launcher.cache.SmrtPackCaches
 import io.ktor.client.request.get
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.HttpResponse
@@ -27,6 +28,7 @@ class SmrtPackClient(
     private val httpProvider: HttpClientProvider,
     private val mirrorBase: String = DEFAULT_MIRROR_BASE,
     private val json: Json = DEFAULT_JSON,
+    private val caches: SmrtPackCaches = SmrtPackCaches.passthrough(),
 ) {
     companion object {
         const val DEFAULT_MIRROR_BASE = "https://smrt.hivens.dev"
@@ -45,8 +47,10 @@ class SmrtPackClient(
         }
     }
 
-    suspend fun fetchManifest(packId: String): SmrtPackManifest =
-        getJson("$mirrorBase/v1/packs/$packId/manifest")
+    suspend fun fetchManifest(packId: String): SmrtPackManifest {
+        val url = "$mirrorBase/v1/packs/$packId/manifest"
+        return caches.manifest.get(url) { getJson(url) }
+    }
 
     /**
      * Fetch a specific historical manifest version. Pinned-version
@@ -57,14 +61,22 @@ class SmrtPackClient(
      * manifest's MC version / loader / Java major would not match
      * the files that were synced to disk.
      */
-    suspend fun fetchManifestVersion(packId: String, version: String): SmrtPackManifest =
-        getJson("$mirrorBase/v1/packs/$packId/manifest/$version")
+    suspend fun fetchManifestVersion(packId: String, version: String): SmrtPackManifest {
+        // Same cache as the latest endpoint, keyed by the version-pinned URL; a
+        // pinned historical manifest is immutable so it stays a warm cache hit.
+        val url = "$mirrorBase/v1/packs/$packId/manifest/$version"
+        return caches.manifest.get(url) { getJson(url) }
+    }
 
-    suspend fun fetchSummary(packId: String): SmrtPackSummary =
-        getJson("$mirrorBase/v1/packs/$packId")
+    suspend fun fetchSummary(packId: String): SmrtPackSummary {
+        val url = "$mirrorBase/v1/packs/$packId"
+        return caches.summary.get(url) { getJson(url) }
+    }
 
-    suspend fun listPacks(): SmrtPackListing =
-        getJson("$mirrorBase/v1/packs")
+    suspend fun listPacks(): SmrtPackListing {
+        val url = "$mirrorBase/v1/packs"
+        return caches.listing.get(url) { getJson(url) }
+    }
 
     /**
      * Resolve a modrinth source by hitting Modrinth's project/version
@@ -74,8 +86,10 @@ class SmrtPackClient(
      * via `primary: true` on the file. Caller picks the file via
      * [ModrinthVersion.primaryFile].
      */
-    suspend fun resolveModrinthVersion(projectId: String, versionId: String): ModrinthVersion =
-        getJson("$MODRINTH_API_BASE/v2/project/$projectId/version/$versionId")
+    suspend fun resolveModrinthVersion(projectId: String, versionId: String): ModrinthVersion {
+        val url = "$MODRINTH_API_BASE/v2/project/$projectId/version/$versionId"
+        return caches.modrinthVersion.get(url) { getJson(url) }
+    }
 
     /**
      * Fetch project metadata for a Modrinth-sourced mod -- used by the
@@ -83,8 +97,10 @@ class SmrtPackClient(
      * carry its own `display.iconUrl`. One call per project_id is
      * enough; callers cache the result.
      */
-    suspend fun resolveModrinthProject(projectId: String): ModrinthProject =
-        getJson("$MODRINTH_API_BASE/v2/project/$projectId")
+    suspend fun resolveModrinthProject(projectId: String): ModrinthProject {
+        val url = "$MODRINTH_API_BASE/v2/project/$projectId"
+        return caches.modrinthProject.get(url) { getJson(url) }
+    }
 
     /**
      * Stream a download through a caller-supplied consumer. The

--- a/client-launcher/src/test/kotlin/hivens/launcher/CrashReporterTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/CrashReporterTest.kt
@@ -1,0 +1,86 @@
+package hivens.launcher
+
+import hivens.core.diag.ActionRing
+import hivens.launcher.platform.PlatformPaths
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The crash report is the only forensic artifact when the launcher dies, so its
+ * generation and on-disk layout are pinned: the throwable, the thread, and the
+ * environment must all survive into a parseable file under the crash dir.
+ */
+class CrashReporterTest {
+
+    private lateinit var home: Path
+    private lateinit var reporter: CrashReporter
+    private lateinit var paths: PlatformPaths
+
+    @BeforeTest
+    fun setUp() {
+        home = Files.createTempDirectory("crash-reporter-test-")
+        paths = PlatformPaths("Linux", home, { null }, { null })
+        reporter = CrashReporter(paths)
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        home.deleteRecursively()
+    }
+
+    @Test
+    fun `generate captures the throwable, thread, and a non-blank environment`() {
+        val boom = IllegalStateException("kaboom-marker")
+        val report = reporter.generate(boom, Thread.currentThread())
+
+        assertTrue(report.stackTrace.contains("kaboom-marker"), "message must reach the stack trace")
+        assertTrue(report.stackTrace.contains("IllegalStateException"), "exception type must be recorded")
+        assertEquals(Thread.currentThread().name, report.thread)
+        assertTrue(report.osName.isNotBlank())
+        assertTrue(report.jvmVersion.isNotBlank())
+        assertTrue(report.maxMemoryMb > 0, "max memory should be a positive MB count")
+        // timestamp is an ISO instant the saver re-parses; it must round-trip.
+        java.time.Instant.parse(report.timestamp)
+    }
+
+    @Test
+    fun `saveToDisk writes a crash file under the crash dir with the report contents`() {
+        val report = reporter.generate(RuntimeException("disk-marker"), Thread.currentThread())
+        val file = reporter.saveToDisk(report)
+
+        assertTrue(file.exists(), "crash file must be written")
+        assertEquals(paths.crashDir, file.toPath().parent, "must land in the crash dir")
+        assertTrue(file.name.startsWith("crash-") && file.name.endsWith(".txt"), "name: ${file.name}")
+
+        val text = file.readText()
+        assertTrue(text.contains("Nexira Crash Report"), "header present")
+        assertTrue(text.contains(report.version))
+        assertTrue(text.contains(report.thread))
+        assertTrue(text.contains("disk-marker"), "stack trace embedded")
+    }
+
+    @Test
+    fun `saveToDisk creates the crash directory when it does not yet exist`() {
+        assertTrue(!Files.exists(paths.crashDir), "precondition: crash dir absent")
+        val file = reporter.saveToDisk(reporter.generate(RuntimeException("x"), Thread.currentThread()))
+        assertTrue(Files.isDirectory(paths.crashDir))
+        assertTrue(file.exists())
+    }
+
+    @Test
+    fun `saveToDisk renders the empty-actions placeholder`() {
+        ActionRing.clear()
+        val report = reporter.generate(RuntimeException("x"), Thread.currentThread())
+        val text = reporter.saveToDisk(report).readText()
+        if (report.actions.isEmpty()) {
+            assertTrue(text.contains("(none recorded)"), "empty action ring should render the placeholder")
+        }
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/SmartyCraftServerListServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/SmartyCraftServerListServiceTest.kt
@@ -3,7 +3,16 @@ package hivens.launcher
 import hivens.core.api.ServerRepository
 import hivens.core.api.dto.SmartyServer
 import hivens.core.api.protocol.LoaderResponse
+import hivens.core.cache.Cache
+import hivens.core.cache.CacheConfig
+import hivens.core.cache.DefaultCache
+import hivens.core.cache.NoOpDiskStore
+import hivens.core.data.DashboardData
+import hivens.core.time.SystemClock
 import hivens.test.FakeServerProtocol
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -23,6 +32,16 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 class SmartyCraftServerListServiceTest {
 
+    // The single-flight + in-memory dedup now live in the injected cache (the
+    // service's own field is gone), so the tests provide a real in-memory one.
+    private fun memCache(): Cache<DashboardData> = DefaultCache(
+        diskStore = NoOpDiskStore(),
+        config = CacheConfig(ttlMs = Long.MAX_VALUE / 2, shouldStore = { it.servers.isNotEmpty() }),
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+        clock = SystemClock,
+        namespace = "dashboard-test",
+    )
+
     @Test
     fun `concurrent fetchDashboardData fires the underlying repo only once`() = runBlocking {
         val protocol = FakeServerProtocol().apply {
@@ -35,7 +54,7 @@ class SmartyCraftServerListServiceTest {
             }
         }
         val repo = ServerRepository(protocol)
-        val svc = SmartyCraftServerListService(repo)
+        val svc = SmartyCraftServerListService(repo, dashboardCache = memCache())
 
         val parallel = 32
         val results = coroutineScope {
@@ -52,7 +71,7 @@ class SmartyCraftServerListServiceTest {
             // Cache only memorizes a non-empty result -- give it something to bite on.
             loaderResult = { LoaderResponse(status = "OK", servers = listOf(SmartyServer(id = "Industrial", ip = "127.0.0.1"))) }
         }
-        val svc = SmartyCraftServerListService(ServerRepository(protocol))
+        val svc = SmartyCraftServerListService(ServerRepository(protocol), dashboardCache = memCache())
 
         val first = svc.fetchDashboardData().await()
         val second = svc.fetchDashboardData().await()
@@ -69,12 +88,36 @@ class SmartyCraftServerListServiceTest {
         val protocol = FakeServerProtocol().apply {
             loaderResult = { LoaderResponse(status = "ERROR") }
         }
-        val svc = SmartyCraftServerListService(ServerRepository(protocol))
+        val svc = SmartyCraftServerListService(ServerRepository(protocol), dashboardCache = memCache())
 
         svc.fetchDashboardData().await()
         delay(10.milliseconds)
         svc.fetchDashboardData().await()
 
         assertEquals(2, protocol.loaderCalls.size, "empty result must not be cached")
+    }
+
+    private class RecordingStore : ServerListCacheStore {
+        val saved = mutableListOf<List<hivens.core.api.model.ServerProfile>>()
+        override fun load(): List<hivens.core.api.model.ServerProfile> = emptyList()
+        override suspend fun save(servers: List<hivens.core.api.model.ServerProfile>) { saved += servers }
+    }
+
+    @Test
+    fun `tray seed is written on success but not on an empty result`() = runBlocking {
+        val ok = FakeServerProtocol().apply {
+            loaderResult = { LoaderResponse(status = "OK", servers = listOf(SmartyServer(id = "Industrial", ip = "127.0.0.1"))) }
+        }
+        val store = RecordingStore()
+        SmartyCraftServerListService(ServerRepository(ok), cache = store, dashboardCache = memCache())
+            .fetchDashboardData().await()
+        assertEquals(1, store.saved.size, "a successful fetch seeds the tray cache")
+        assertEquals("Industrial", store.saved.single().single().assetDir)
+
+        val down = FakeServerProtocol().apply { loaderResult = { LoaderResponse(status = "ERROR") } }
+        val store2 = RecordingStore()
+        SmartyCraftServerListService(ServerRepository(down), cache = store2, dashboardCache = memCache())
+            .fetchDashboardData().await()
+        assertEquals(0, store2.saved.size, "an empty/failed fetch must not overwrite the tray seed")
     }
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/cache/JsonDiskStoreTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/cache/JsonDiskStoreTest.kt
@@ -1,0 +1,103 @@
+package hivens.launcher.cache
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class JsonDiskStoreTest {
+
+    @Serializable
+    private data class Dto(val id: String, val n: Int)
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var dir: Path
+    private lateinit var store: JsonDiskStore<Dto>
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("json-disk-store-test-")
+        store = JsonDiskStore(dir.resolve("ns"), Dto.serializer(), json)
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun onlyJsonFile(): Path =
+        Files.list(dir.resolve("ns")).use { s -> s.filter { it.toString().endsWith(".json") }.findFirst().get() }
+
+    @Test
+    fun `write then read round-trips with the stored timestamp`() {
+        store.write("https://x/v1/packs", Dto("a", 7), storedAtMillis = 1234)
+        val got = store.read("https://x/v1/packs")
+        assertEquals(Dto("a", 7), got?.value)
+        assertEquals(1234, got?.storedAtMillis)
+    }
+
+    @Test
+    fun `read of a missing key returns null`() {
+        assertNull(store.read("nope"))
+    }
+
+    @Test
+    fun `read of a missing directory returns null, not a crash`() {
+        val fresh = JsonDiskStore(dir.resolve("never-created"), Dto.serializer(), json)
+        assertNull(fresh.read("k"))
+    }
+
+    @Test
+    fun `corrupt entry returns null and self-heals by deleting the file`() {
+        store.write("k", Dto("a", 1), 1)
+        val file = onlyJsonFile()
+        Files.writeString(file, "{ this is not valid json")
+        assertNull(store.read("k"), "corrupt entry must read as a miss")
+        assertTrue(!Files.exists(file), "corrupt file must be deleted so it doesn't re-fail")
+    }
+
+    @Test
+    fun `wrong schema version reads as a miss and is deleted`() {
+        store.write("k", Dto("a", 1), 1)
+        val file = onlyJsonFile()
+        Files.writeString(file, """{"schema_version":999,"key":"k","stored_at":1,"value":{"id":"a","n":1}}""")
+        assertNull(store.read("k"))
+        assertTrue(!Files.exists(file))
+    }
+
+    @Test
+    fun `distinct keys map to distinct files and do not collide`() {
+        store.write("https://x/v1/packs/aaa", Dto("aaa", 1), 1)
+        store.write("https://x/v1/packs/bbb", Dto("bbb", 2), 2)
+        assertEquals(Dto("aaa", 1), store.read("https://x/v1/packs/aaa")?.value)
+        assertEquals(Dto("bbb", 2), store.read("https://x/v1/packs/bbb")?.value)
+        val count = Files.list(dir.resolve("ns")).use { it.count() }
+        assertEquals(2, count, "two keys -> two files")
+    }
+
+    @Test
+    fun `a very long url key does not blow PATH_MAX`() {
+        val longKey = "https://x/v1/packs/" + "a".repeat(5_000)
+        store.write(longKey, Dto("long", 1), 1)
+        assertEquals(Dto("long", 1), store.read(longKey)?.value)
+    }
+
+    @Test
+    fun `delete and clear remove entries`() {
+        store.write("k1", Dto("a", 1), 1)
+        store.write("k2", Dto("b", 2), 2)
+        store.delete("k1")
+        assertNull(store.read("k1"))
+        assertEquals(Dto("b", 2), store.read("k2")?.value)
+        store.clear()
+        assertNull(store.read("k2"))
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/network/ServerProtocolConfigTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/network/ServerProtocolConfigTest.kt
@@ -1,0 +1,71 @@
+package hivens.launcher.network
+
+import hivens.config.ExperimentalConduitOverride
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The derived endpoints and host-key fallback decide which backend the launcher
+ * talks to, so they are pinned here. A Mirror operator overriding baseUrl must
+ * see every derived URL and the SSL-bypass host key follow.
+ */
+@OptIn(ExperimentalConduitOverride::class)
+class ServerProtocolConfigTest {
+
+    @AfterTest
+    fun clearOverride() {
+        System.clearProperty(ServerProtocolConfig.SYSTEM_PROP_BASE_URL)
+    }
+
+    @Test
+    fun `defaults derive the production endpoints`() {
+        val c = ServerProtocolConfig()
+        assertEquals("https://www.smartycraft.ru/launcher2/index.php", c.authUrl)
+        assertEquals("https://www.smartycraft.ru/downloads/smartycraft.jar", c.officialJarUrl)
+        assertEquals("https://www.smartycraft.ru/launcher/clients", c.clientFilesBase)
+    }
+
+    @Test
+    fun `a custom base url drives every derived endpoint`() {
+        val c = ServerProtocolConfig(baseUrl = "https://mirror.example.com")
+        assertEquals("https://mirror.example.com/launcher2/index.php", c.authUrl)
+        assertEquals("https://mirror.example.com/downloads/smartycraft.jar", c.officialJarUrl)
+        assertEquals("https://mirror.example.com/launcher/clients", c.clientFilesBase)
+    }
+
+    @Test
+    fun `sslBypassHost extracts the authority from base url`() {
+        assertEquals("mirror.example.com", ServerProtocolConfig(baseUrl = "https://mirror.example.com").sslBypassHost)
+        assertEquals("www.smartycraft.ru", ServerProtocolConfig().sslBypassHost)
+    }
+
+    @Test
+    fun `sslBypassHost falls back to the default host on a malformed base url`() {
+        // A blank/garbage authority must never produce an empty match key.
+        assertEquals("www.smartycraft.ru", ServerProtocolConfig(baseUrl = "not a url").sslBypassHost)
+        assertEquals("www.smartycraft.ru", ServerProtocolConfig(baseUrl = "").sslBypassHost)
+    }
+
+    @Test
+    fun `resolve without the system property returns the loaded config unchanged`() {
+        val loaded = ServerProtocolConfig(baseUrl = "https://mirror.example.com")
+        assertEquals(loaded, ServerProtocolConfig.resolve(loaded))
+    }
+
+    @Test
+    fun `resolve applies the system property override and trims a trailing slash`() {
+        System.setProperty(ServerProtocolConfig.SYSTEM_PROP_BASE_URL, "https://override.example.com/")
+        val resolved = ServerProtocolConfig.resolve(ServerProtocolConfig(baseUrl = "https://www.smartycraft.ru"))
+        assertEquals("https://override.example.com", resolved.baseUrl)
+        // Non-overridden fields survive the copy.
+        assertEquals(ServerProtocolConfig.DEFAULT_PROXY_PORT, resolved.proxyPort)
+    }
+
+    @Test
+    fun `resolve ignores a blank system property`() {
+        System.setProperty(ServerProtocolConfig.SYSTEM_PROP_BASE_URL, "   ")
+        val loaded = ServerProtocolConfig(baseUrl = "https://www.smartycraft.ru")
+        assertEquals(loaded, ServerProtocolConfig.resolve(loaded))
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/ServerNameValidatorTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/ServerNameValidatorTest.kt
@@ -1,0 +1,95 @@
+package hivens.launcher.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The validator is the only gate between a server-supplied identifier and a
+ * filesystem path, so a regression here is a path-traversal hole. Tests cover
+ * the accept list (every shipped server id shape) and the full reject taxonomy.
+ */
+class ServerNameValidatorTest {
+
+    @Test
+    fun `accepts every server identifier shape that has shipped`() {
+        for (name in listOf("Industrial", "RPG", "SkyBlock", "MagicRPG", "Nexira.v2", "server-1", "a", "A_B-c.9")) {
+            assertTrue(ServerNameValidator.isValid(name), "should accept: $name")
+        }
+    }
+
+    @Test
+    fun `rejects the empty string`() {
+        assertFalse(ServerNameValidator.isValid(""))
+    }
+
+    @Test
+    fun `rejects the dot and dot-dot path primitives`() {
+        assertFalse(ServerNameValidator.isValid("."))
+        assertFalse(ServerNameValidator.isValid(".."))
+    }
+
+    @Test
+    fun `rejects any embedded dot-dot even with otherwise-legal characters`() {
+        for (name in listOf("a..b", "Industrial..", "..evil", "x..y..z")) {
+            assertFalse(ServerNameValidator.isValid(name), "should reject embedded dot-dot: $name")
+        }
+    }
+
+    @Test
+    fun `rejects path separators`() {
+        for (name in listOf("../etc/passwd", "a/b", "a\\b", "Industrial..\\evil", "/abs", "C:\\win")) {
+            assertFalse(ServerNameValidator.isValid(name), "should reject separator: $name")
+        }
+    }
+
+    @Test
+    fun `rejects whitespace and control characters`() {
+        for (name in listOf("a b", " leading", "trailing ", "tab\tx", "new\nline", "nul x")) {
+            assertFalse(ServerNameValidator.isValid(name), "should reject whitespace/control")
+        }
+    }
+
+    @Test
+    fun `rejects non-ascii letters`() {
+        // Built from code points so this source file stays strictly ASCII (git
+        // diffs it as text, not binary) while the runtime strings still carry the
+        // characters the whitelist must reject.
+        fun cp(vararg points: Int): String = points.fold(StringBuilder()) { b, p -> b.append(p.toChar()) }.toString()
+        val industrialAcute = "Industri" + cp(0x00E1) + "l"        // Industrial, a-acute
+        val cyrillicServer = cp(0x0441, 0x0435, 0x0440, 0x0432, 0x0435, 0x0440) // "server" in Cyrillic
+        val nameUmlaut = "n" + cp(0x00E4) + "me"                   // name, a-umlaut
+
+        for (name in listOf(industrialAcute, cyrillicServer, nameUmlaut)) {
+            assertFalse(ServerNameValidator.isValid(name), "should reject non-ascii")
+        }
+    }
+
+    @Test
+    fun `require returns the name verbatim when valid`() {
+        assertEquals("Nexira.v2", ServerNameValidator.require("Nexira.v2"))
+    }
+
+    @Test
+    fun `require throws IllegalArgumentException on an invalid name`() {
+        assertFailsWith<IllegalArgumentException> { ServerNameValidator.require("../etc/passwd") }
+    }
+
+    @Test
+    fun `require error message redacts and truncates a long hostile string`() {
+        val hostile = "../" + "A".repeat(200)
+        val ex = assertFailsWith<IllegalArgumentException> { ServerNameValidator.require(hostile) }
+        val msg = ex.message.orEmpty()
+        assertTrue(msg.contains("Rejected server identifier"), "msg: $msg")
+        // Truncated preview must not echo the whole 200-char payload back into logs.
+        assertTrue(msg.length < hostile.length, "preview must be shorter than the input")
+    }
+
+    @Test
+    fun `require error preview keeps a short name intact`() {
+        val ex = assertFailsWith<IllegalArgumentException> { ServerNameValidator.require("bad/name") }
+        assertTrue(ex.message!!.contains("bad/name"))
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/protocol/SmartycraftSignatureBuilderTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/protocol/SmartycraftSignatureBuilderTest.kt
@@ -1,0 +1,94 @@
+package hivens.launcher.protocol
+
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the SmartyCraft `check=` signature wire format. These signatures gate
+ * spawn / twoauth / skin upload, so a silent change to the field order, the
+ * separator, or the time-bucket width breaks every signed action against the
+ * live server. The independent MD5 below is the drift tripwire; the golden hex
+ * is a second, fully-fixed anchor in case both impl and re-derivation drift.
+ */
+class SmartycraftSignatureBuilderTest {
+
+    private fun md5(s: String): String =
+        MessageDigest.getInstance("MD5").digest(s.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+    @Test
+    fun `spawn signature is MD5 of bucket-uid-login-server joined by pipe`() {
+        val sig = SmartycraftSignatureBuilder.forSpawn(uid = "42", login = "alice", server = "Industrial", timeBucket = 17)
+        assertEquals(md5("17|42|alice|Industrial"), sig)
+    }
+
+    @Test
+    fun `spawn signature matches a fully fixed golden vector`() {
+        // Recomputed independently: printf '17|42|alice|Industrial' | md5sum
+        assertEquals(
+            "0e11fcf50f4a9eee6a653f2110915136",
+            SmartycraftSignatureBuilder.forSpawn("42", "alice", "Industrial", timeBucket = 17),
+        )
+    }
+
+    @Test
+    fun `twoauth signature is MD5 of bucket-uid-login-code`() {
+        val sig = SmartycraftSignatureBuilder.forTwoAuth(uid = "42", login = "alice", code = "123456", timeBucket = 99)
+        assertEquals(md5("99|42|alice|123456"), sig)
+    }
+
+    @Test
+    fun `upload signature is MD5 of bucket-uid-login with no extra fields`() {
+        val sig = SmartycraftSignatureBuilder.forUpload(uid = "42", login = "alice", timeBucket = 7)
+        assertEquals(md5("7|42|alice"), sig)
+    }
+
+    @Test
+    fun `field order is significant -- swapping uid and login changes the signature`() {
+        val a = SmartycraftSignatureBuilder.forSpawn(uid = "alice", login = "42", server = "RPG", timeBucket = 5)
+        val b = SmartycraftSignatureBuilder.forSpawn(uid = "42", login = "alice", server = "RPG", timeBucket = 5)
+        assertNotEquals(a, b, "uid and login must not be interchangeable")
+    }
+
+    @Test
+    fun `time bucket participates -- a different bucket yields a different signature`() {
+        val a = SmartycraftSignatureBuilder.forSpawn("42", "alice", "Industrial", timeBucket = 17)
+        val b = SmartycraftSignatureBuilder.forSpawn("42", "alice", "Industrial", timeBucket = 18)
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `spawn and twoauth do not collide for the same uid-login-bucket`() {
+        // forSpawn(...server) vs forTwoAuth(...code) differ only by the last field;
+        // they must not produce the same signature for distinct action contexts.
+        val spawn = SmartycraftSignatureBuilder.forSpawn("42", "alice", "x", timeBucket = 1)
+        val twoauth = SmartycraftSignatureBuilder.forTwoAuth("42", "alice", "x", timeBucket = 1)
+        // Same trailing field "x" -> same hash is acceptable (same bytes); assert the
+        // scheme is purely positional by checking a differing trailing field differs.
+        assertEquals(spawn, twoauth, "identical joined bytes hash identically")
+        val twoauthOther = SmartycraftSignatureBuilder.forTwoAuth("42", "alice", "y", timeBucket = 1)
+        assertNotEquals(spawn, twoauthOther)
+    }
+
+    @Test
+    fun `signature is lowercase 32-char hex`() {
+        val sig = SmartycraftSignatureBuilder.forUpload("42", "alice", timeBucket = 0)
+        assertTrue(sig.matches(Regex("^[0-9a-f]{32}$")), "got: $sig")
+    }
+
+    @Test
+    fun `current time bucket is currentMillis over ten thousand`() {
+        val before = System.currentTimeMillis() / 10_000L
+        val bucket = SmartycraftSignatureBuilder.currentTimeBucket()
+        val after = System.currentTimeMillis() / 10_000L
+        assertTrue(bucket in before..after, "bucket $bucket not within [$before, $after]")
+    }
+
+    @Test
+    fun `empty fields still produce a stable signature`() {
+        assertEquals(md5("0|||"), SmartycraftSignatureBuilder.forSpawn("", "", "", timeBucket = 0))
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/CachedSmrtPackClientTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/CachedSmrtPackClientTest.kt
@@ -1,0 +1,145 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.api.dto.smrt.ModrinthProject
+import hivens.core.api.dto.smrt.ModrinthVersion
+import hivens.core.api.dto.smrt.SmrtPackListing
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtPackSummary
+import hivens.core.cache.Cache
+import hivens.core.cache.CacheConfig
+import hivens.core.cache.PassthroughCache
+import hivens.launcher.cache.CacheFactory
+import hivens.launcher.cache.SmrtPackCaches
+import hivens.test.TestClock
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CachedSmrtPackClientTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val mirror = "https://mirror.test"
+    private lateinit var dir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("cached-smrt-test-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private val listingBody =
+        """{"schema_version":2,"generated_at":"t","packs":[]}"""
+    private val manifestBody =
+        """{"schema_version":2,"pack_id":"p","pack_version":"1","generated_at":"t",""" +
+            """"minecraft":{"version":"1.21.1"},"loader":{"name":"neoforge","version":"21"},"java":{"major":21}}"""
+
+    /** A counting MockEngine that answers any GET with [body]. */
+    private fun provider(counter: AtomicInteger, body: String): HttpClientProvider {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    counter.incrementAndGet()
+                    respond(
+                        content = ByteReadChannel(body.toByteArray()),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+            }
+        }
+        return HttpClientProvider { client }
+    }
+
+    private fun TestScope.caches(
+        clock: TestClock,
+        listingConfig: CacheConfig<SmrtPackListing> = CacheConfig(ttlMs = 1_000, staleTtlMs = 100_000),
+        manifestConfig: CacheConfig<SmrtPackManifest> = CacheConfig(ttlMs = 10_000_000, staleTtlMs = Long.MAX_VALUE),
+    ): SmrtPackCaches {
+        val f = CacheFactory(
+            rootDir = dir.resolve("cache"),
+            json = json,
+            scope = this,
+            clock = clock,
+            ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+        return SmrtPackCaches(
+            listing = f.create("pack-listing", SmrtPackListing.serializer(), listingConfig),
+            summary = PassthroughCache(),
+            manifest = f.create("pack-manifest", SmrtPackManifest.serializer(), manifestConfig),
+            modrinthProject = PassthroughCache<ModrinthProject>(),
+            modrinthVersion = PassthroughCache<ModrinthVersion>(),
+        )
+    }
+
+    @Test
+    fun `repeated listPacks hits the network once`() = runTest {
+        val counter = AtomicInteger(0)
+        val client = SmrtPackClient(provider(counter, listingBody), mirror, json, caches(TestClock()))
+
+        client.listPacks()
+        client.listPacks()
+        client.listPacks()
+        assertEquals(1, counter.get(), "warm cache must not re-hit the mirror")
+    }
+
+    @Test
+    fun `stale listing serves cached value then revalidates`() = runTest {
+        val counter = AtomicInteger(0)
+        val clock = TestClock()
+        val client = SmrtPackClient(provider(counter, listingBody), mirror, json, caches(clock))
+
+        client.listPacks()                 // miss -> 1 network call
+        assertEquals(1, counter.get())
+        clock.advance(2_000)               // past the 1s TTL -> stale
+        client.listPacks()                 // serves stale, triggers background refresh
+        advanceUntilIdle()
+        assertEquals(2, counter.get(), "stale read revalidates exactly once in the background")
+    }
+
+    @Test
+    fun `invalidate forces the next listPacks to refetch`() = runTest {
+        val counter = AtomicInteger(0)
+        val smrtCaches = caches(TestClock())
+        val client = SmrtPackClient(provider(counter, listingBody), mirror, json, smrtCaches)
+
+        client.listPacks()
+        assertEquals(1, counter.get())
+        (smrtCaches.listing as Cache<SmrtPackListing>).invalidate("$mirror/v1/packs")
+        client.listPacks()
+        assertEquals(2, counter.get(), "post-invalidate listPacks reloads")
+    }
+
+    @Test
+    fun `a pinned manifest version is fetched once and stays cached`() = runTest {
+        val counter = AtomicInteger(0)
+        val clock = TestClock()
+        val client = SmrtPackClient(provider(counter, manifestBody), mirror, json, caches(clock))
+
+        client.fetchManifestVersion("p", "1")
+        clock.advance(60_000)              // well within the long manifest TTL
+        client.fetchManifestVersion("p", "1")
+        assertEquals(1, counter.get(), "immutable pinned manifest stays a warm hit")
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/util/ClientFileHelperTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/util/ClientFileHelperTest.kt
@@ -1,0 +1,89 @@
+package hivens.launcher.util
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.slf4j.LoggerFactory
+
+/**
+ * cleanDirectory deletes user files (mods / natives sync), so its keep/delete
+ * decision is high-consequence: it must remove only redundant loadable
+ * artifacts and never touch config or subdirectories.
+ */
+class ClientFileHelperTest {
+
+    private val log = LoggerFactory.getLogger(ClientFileHelperTest::class.java)
+    private lateinit var dir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("client-file-helper-test-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun touch(name: String): Path =
+        Files.write(dir.resolve(name), byteArrayOf(1))
+
+    @Test
+    fun `ensureDirectoryExists creates a missing nested directory`() {
+        val nested = dir.resolve("a/b/c")
+        ClientFileHelper.ensureDirectoryExists(nested)
+        assertTrue(Files.isDirectory(nested))
+    }
+
+    @Test
+    fun `ensureDirectoryExists is a no-op on an existing directory`() {
+        ClientFileHelper.ensureDirectoryExists(dir) // must not throw
+        assertTrue(Files.isDirectory(dir))
+    }
+
+    @Test
+    fun `cleanDirectory keeps allowed loadable files and deletes the rest`() {
+        val keep = touch("keep.jar")
+        val drop = touch("drop.jar")
+        ClientFileHelper.cleanDirectory(dir, allowedFiles = setOf("keep.jar"), logger = log)
+        assertTrue(Files.exists(keep), "allowed jar must survive")
+        assertFalse(Files.exists(drop), "unlisted jar must be deleted")
+    }
+
+    @Test
+    fun `cleanDirectory deletes every loadable extension when unlisted`() {
+        val files = listOf("a.jar", "b.zip", "c.litemod", "d.dll", "e.so", "f.dylib").map { touch(it) }
+        ClientFileHelper.cleanDirectory(dir, allowedFiles = emptySet(), logger = log)
+        for (f in files) assertFalse(Files.exists(f), "should delete loadable: ${f.fileName}")
+    }
+
+    @Test
+    fun `cleanDirectory never touches non-loadable extensions`() {
+        val config = touch("options.txt")
+        val json = touch("servers.json")
+        val noExt = touch("README")
+        ClientFileHelper.cleanDirectory(dir, allowedFiles = emptySet(), logger = log)
+        assertTrue(Files.exists(config), "config files must be preserved")
+        assertTrue(Files.exists(json))
+        assertTrue(Files.exists(noExt))
+    }
+
+    @Test
+    fun `cleanDirectory ignores subdirectories even with loadable-looking names`() {
+        val subdir = Files.createDirectory(dir.resolve("nested.jar"))
+        ClientFileHelper.cleanDirectory(dir, allowedFiles = emptySet(), logger = log)
+        assertTrue(Files.isDirectory(subdir), "a directory named *.jar must not be deleted")
+    }
+
+    @Test
+    fun `cleanDirectory on a missing directory is a silent no-op`() {
+        ClientFileHelper.cleanDirectory(dir.resolve("does-not-exist"), allowedFiles = emptySet(), logger = log)
+        // no throw == pass
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/util/ClientRootDirsTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/util/ClientRootDirsTest.kt
@@ -1,0 +1,56 @@
+package hivens.launcher.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * isKnown decides whether a manifest entry's first path segment is a real root
+ * dir (kept) or a server-name prefix (stripped). FileDownloadService and
+ * ClasspathProvider both rely on the same answer, so the prefix-match contract
+ * is pinned here.
+ */
+class ClientRootDirsTest {
+
+    @Test
+    fun `every declared root is recognised`() {
+        for (root in ClientRootDirs.ALL) {
+            assertTrue(ClientRootDirs.isKnown(root), "should recognise root: $root")
+        }
+    }
+
+    @Test
+    fun `versioned root variants match by prefix`() {
+        for (seg in listOf("libraries-1.12.2", "natives-linux", "assets-1.20", "modsNew")) {
+            assertTrue(ClientRootDirs.isKnown(seg), "prefix-match should keep: $seg")
+        }
+    }
+
+    @Test
+    fun `server-name first segments are not known roots`() {
+        for (name in listOf("Industrial", "RPG", "SkyBlock", "Nexira")) {
+            assertFalse(ClientRootDirs.isKnown(name), "server name must not look like a root: $name")
+        }
+    }
+
+    @Test
+    fun `the empty segment is not a known root`() {
+        assertFalse(ClientRootDirs.isKnown(""))
+    }
+
+    @Test
+    fun `matching is case-sensitive`() {
+        assertFalse(ClientRootDirs.isKnown("Mods"))
+        assertFalse(ClientRootDirs.isKnown("CONFIG"))
+    }
+
+    @Test
+    fun `the known set is exactly the documented ten roots`() {
+        assertTrue(
+            ClientRootDirs.ALL == setOf(
+                "mods", "config", "bin", "assets", "libraries", "resources",
+                "saves", "resourcepacks", "shaderpacks", "natives",
+            ),
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/identity/SkinManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/identity/SkinManager.kt
@@ -3,6 +3,9 @@ package hivens.ui.identity
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import hivens.core.api.HttpClientProvider
+import hivens.core.io.AtomicFiles
+import hivens.core.time.Clock
+import hivens.core.time.SystemClock
 import hivens.launcher.platform.PlatformPaths
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -42,7 +45,8 @@ import org.jetbrains.skia.Rect
  */
 class SkinManager(
     private val clientProvider: HttpClientProvider,
-    private val paths: PlatformPaths
+    private val paths: PlatformPaths,
+    private val clock: Clock = SystemClock,
 ) {
     private val httpClient get() = clientProvider.current
 
@@ -188,8 +192,8 @@ class SkinManager(
 
     // ── Disk cache helpers ─────────────────────────────────────────────────
 
-    private fun isExpired(file: File): Boolean {
-        return System.currentTimeMillis() - file.lastModified() > CACHE_TTL_MS
+    internal fun isExpired(file: File): Boolean {
+        return clock.nowMillis() - file.lastModified() > CACHE_TTL_MS
     }
 
     private suspend fun getOrDownloadRawSkin(nickname: String): Image? {
@@ -210,11 +214,10 @@ class SkinManager(
 
         // Save raw to disk
         try {
-            rawFile.parentFile?.mkdirs()
             // Re-encode as PNG for caching
             val data = image.encodeToData(org.jetbrains.skia.EncodedImageFormat.PNG)
             if (data != null) {
-                rawFile.writeBytes(data.bytes)
+                AtomicFiles.writeBytes(rawFile.toPath(), data.bytes)
             }
         } catch (e: Exception) {
             logger.warn("Failed to save raw skin to disk: {}", e.message)
@@ -230,8 +233,7 @@ class SkinManager(
                 image.encodeToData(org.jetbrains.skia.EncodedImageFormat.PNG)
             }
             if (data != null) {
-                file.parentFile?.mkdirs()
-                file.writeBytes(data.bytes)
+                AtomicFiles.writeBytes(file.toPath(), data.bytes)
             }
         } catch (e: Exception) {
             logger.warn("Failed to save rendered skin to disk: {}", e.message)

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/identity/SkinManagerTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/identity/SkinManagerTest.kt
@@ -1,0 +1,49 @@
+package hivens.ui.identity
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.time.Clock
+import hivens.launcher.platform.PlatformPaths
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SkinManagerTest {
+
+    private lateinit var home: Path
+
+    @BeforeTest
+    fun setUp() {
+        home = Files.createTempDirectory("skin-manager-test-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        home.deleteRecursively()
+    }
+
+    @Test
+    fun `isExpired flips once the injected clock passes the TTL`() {
+        var now = 1_000_000L
+        val paths = PlatformPaths("Linux", home, { null }, { null })
+        // The http client is never touched by isExpired, so a lazily-erroring
+        // provider is enough and keeps this off the network.
+        val provider = HttpClientProvider { error("SkinManager http client not needed here") }
+        val manager = SkinManager(provider, paths, Clock { now })
+
+        val cached = File(home.toFile(), "front_test.png").apply {
+            writeBytes(ByteArray(4))
+            setLastModified(1_000_000L)
+        }
+
+        assertFalse(manager.isExpired(cached), "a just-written file is fresh")
+        now += 31 * 60 * 1000L // TTL is 30 minutes
+        assertTrue(manager.isExpired(cached), "past the TTL it must read as expired")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-conte
 
 # Kotlinx
 kotlinx-serialization-json      = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+kotlinx-coroutines-core         = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core",    version.ref = "coroutines" }
 kotlinx-coroutines-test         = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test",    version.ref = "coroutines" }
 kotlinx-coroutines-swing        = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing",   version.ref = "coroutines" }
 kotlinx-coroutines-slf4j        = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-slf4j",   version.ref = "coroutines" }


### PR DESCRIPTION
A reusable cache primitive, then unify the launcher's ad-hoc caches onto it and close the one real gap (pack metadata refetched on every Browse/PackDetail/ContentTab mount).

## The primitive (client-core `hivens.core.cache`)
- `Cache<V>`: `get` = stale-while-revalidate (serve stale immediately, refresh in background), `flow` = stale-then-fresh.
- `DefaultCache`: in-memory LRU over a `DiskStore`, single-flight dedup (concurrent identical loads = one upstream call), background refresh on the cache scope (a caller leaving composition can't kill a shared refresh), bounded staleness, debounced disk writes, a `shouldStore` veto (empty-result guard).
- `JsonDiskStore`: one sha256-named JSON file per key; corrupt / old-schema entries self-heal by deleting and reading as a miss. `CacheFactory` builds typed namespaces.
- Supporting seams extracted/added: `Clock` (injectable wall clock, so TTL is deterministically testable — the codebase had none) and `AtomicFiles` (the tmp+ATOMIC_MOVE write that was copy-pasted in four places).

## Consumers
- **Pack metadata (the gap):** `SmrtPackClient` reads (listing/summary/manifest + Modrinth) now go through per-endpoint disk-backed caches. Warm navigation is instant; cold start serves the last good snapshot from disk then revalidates. UI untouched.
- **Four disk writers** (`JsonPackRepository`, `LayoutGraphRepository`, `JsonServerListCacheStore`, `ManifestCache`) routed through `AtomicFiles` — behaviour-identical, plus `ManifestCache` gains atomic writes.
- **Server list:** `SmartyCraftServerListService` dropped its hand-rolled `@Volatile` cache + single-flight for the primitive (in-memory, 10-min SWR). The servers-only `ServerListCacheStore` still seeds the tray synchronously; an empty/failed fetch neither overwrites that seed nor caches.
- **Skins:** rendered images don't fit a JSON cache, so `SkinManager` adopts the shared `Clock` + `AtomicFiles.writeBytes` (atomic PNG writes; testable TTL) and keeps its LRU + Skia path.

## Tests
Heavy primitive coverage (TTL, SWR single-upstream, 50-way single-flight, restart persistence, refresh-failure-keeps-stale, hard-cap-throws, LRU, invalidate, flow, shouldStore, debounce, disk-read-failure, cancellation isolation), plus JsonDiskStore, AtomicFiles, Clock, CachedSmrtPackClient, server-list (single-flight + tray-seed guard), and SkinManager TTL. All module suites green. Built in 8 independently-verified phases.