### PR TITLE
test: OS-portable launcher tests (unblock v2.3.4-beta release)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,73 @@
+name: Tests
+
+# Unit-test matrix on every code PR.
+#
+# build_release.yml runs these same three suites, but only on a release tag --
+# so OS-specific regressions stayed invisible until a tag was cut (that is how
+# a macOS native-classifier assumption and Windows path-separator asserts once
+# reached a release and blocked it). This workflow runs them at PR time instead.
+#
+# Full 3-OS matrix, deliberately NOT Linux-only: the failures that motivated
+# this were all green on Linux, so a Linux-only PR run would not have caught
+# them. The repo is public, so GitHub-hosted minutes are free on every OS.
+#
+# Docs-only PRs (CHANGELOG, *.md) do not touch the paths below, so they skip
+# the matrix entirely.
+
+on:
+  pull_request:
+    paths:
+      - '**.kt'
+      - '**.kts'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - '.github/workflows/tests.yml'
+  push:
+    branches: [stable]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '25'
+  JAVA_DISTRIBUTION: 'liberica'
+
+jobs:
+  test:
+    name: Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # fail-fast: false so one OS failing still reports the others -- we want
+    # every platform-specific failure in one run, not race-of-the-first.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    # shell: bash so the gradlew invocation is identical on Windows runners
+    # (PowerShell's default would mangle it).
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: 'gradle'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run unit tests
+        run: ./gradlew :client-config:test :client-core:test :client-launcher:test --continue
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: |
+            client-config/build/reports/tests/
+            client-core/build/reports/tests/
+            client-launcher/build/reports/tests/

--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
@@ -53,6 +53,7 @@ class RuntimeProvisioner(
     private val json: Json,
     private val loaderRegistry: LoaderRegistry = LoaderRegistry(emptyList()),
     osName: String = System.getProperty("os.name", ""),
+    osArch: String = System.getProperty("os.arch", ""),
     private val versionManifestUrl: String = VERSION_MANIFEST_URL,
     private val resourcesBaseUrl: String = RESOURCES_BASE,
 ) {
@@ -71,7 +72,7 @@ class RuntimeProvisioner(
      * x64 spellings.
      */
     private val acceptedNativeClassifiers: Set<String> = run {
-        val arch = System.getProperty("os.arch", "").lowercase()
+        val arch = osArch.lowercase()
         val arm64 = arch.contains("aarch64") || arch.contains("arm64")
         when (mojangOs) {
             "windows" -> if (arm64) setOf("natives-windows-arm64") else setOf("natives-windows")

--- a/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
@@ -548,7 +548,8 @@ class GameCommandBuilderTest {
         assertTrue(cmd.contains("-noverify"), "legacy launchwrapper runtime gets -noverify")
         assertTrue(cmd.contains("net.minecraft.launchwrapper.Launch"))
         assertEquals("1.12", cmd[cmd.indexOf("--assetIndex") + 1])
-        assertTrue(cmd[cmd.indexOf("--assetsDir") + 1].contains("shared/assets"), "assets from the shared root")
+        // Normalize separators -- the resolved path uses '\' on Windows.
+        assertTrue(cmd[cmd.indexOf("--assetsDir") + 1].replace('\\', '/').contains("shared/assets"), "assets from the shared root")
         assertEquals("net.minecraftforge.fml.common.launcher.FMLTweaker", cmd[cmd.indexOf("--tweakClass") + 1])
     }
 
@@ -651,11 +652,11 @@ class GameCommandBuilderTest {
         // Module path kept, with ${library_directory}/${classpath_separator} resolved.
         val pValue = cmd[cmd.indexOf("-p") + 1]
         assertTrue(pValue.contains("bootstraplauncher-2.0.2.jar"), "boot module on -p")
-        assertTrue(pValue.contains("/tmp/shared/libraries"), "library_directory substituted, got $pValue")
+        assertTrue(pValue.replace('\\', '/').contains("/tmp/shared/libraries"), "library_directory substituted, got $pValue")
         assertFalse(pValue.contains($$"${"), "no placeholder left in -p, got $pValue")
         assertTrue(pValue.contains(File.pathSeparator), "two boot jars joined by the path separator, got $pValue")
 
-        assertTrue(cmd.contains("-DlibraryDirectory=/tmp/shared/libraries"), "libraryDirectory substituted")
+        assertTrue(cmd.any { it.startsWith("-DlibraryDirectory=") && it.replace('\\', '/').contains("/tmp/shared/libraries") }, "libraryDirectory substituted")
         assertTrue(cmd.contains("--add-opens=java.base/java.lang=ALL-UNNAMED"), "kept add-opens")
         assertTrue(cmd.contains("--add-modules=jdk.incubator.vector"), "vector module added on the module path")
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
@@ -45,12 +45,20 @@ class RuntimeProvisionerTest {
 
     private fun sha1(s: String): String = sha1(s.toByteArray())
 
-    private fun provisioner(client: HttpClient, osName: String = "Linux") = RuntimeProvisioner(
+    // Pin the host arch: CI runners vary (macos-latest is arm64), and an
+    // un-pinned os.arch flips acceptedNativeClassifiers to the -arm64 variant,
+    // breaking tests that assert the x64 `natives-<os>` classifier.
+    private fun provisioner(
+        client: HttpClient,
+        osName: String = "Linux",
+        osArch: String = "amd64",
+    ) = RuntimeProvisioner(
         librariesDir = librariesDir,
         assetsDir = assetsDir,
         clientProvider = HttpClientProvider { client },
         json = json,
         osName = osName,
+        osArch = osArch,
         versionManifestUrl = MANIFEST_URL,
         resourcesBaseUrl = RES_BASE,
     )


### PR DESCRIPTION
The v2.3.4-beta release matrix failed on macOS + Windows (Ubuntu green), blocking publish. Both are test-only host assumptions; production code is correct on every OS.

- macOS (RuntimeProvisionerTest x3): os.arch was read directly, not injected like os.name. arm64 runners flipped the wanted native classifier to -arm64. Made osArch injectable, pinned x64 in the helper.
- Windows (GameCommandBuilderTest x2 + 1 latent): forward-slash path substrings vs backslash paths. Normalized separators.

Verified: client-launcher:test green on Linux. macOS/Windows verification is the release re-run (cannot run those locally).