### PR TITLE
feat: three-tier memory model (Automatic baseline under Adaptive) + RAM mode UI

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/jvm/AutomaticHeap.kt
+++ b/client-core/src/main/kotlin/hivens/core/jvm/AutomaticHeap.kt
@@ -1,0 +1,34 @@
+package hivens.core.jvm
+
+/**
+ * The machine-aware baseline heap (`-Xmx`, MB) for an instance that is NOT pinned to
+ * an explicit value. Two roles:
+ *  - the static heap when the adaptive sizer is off (the "Automatic" tier), and
+ *  - the cold-start the adaptive sizer grows FROM before it has any session data.
+ *
+ * Pure: a function of host RAM only, no I/O -- unit-testable like [HeapDeriver]. There
+ * is no pack-declared RAM hint in the manifest today, so host RAM is the only input.
+ *
+ * [TARGET_FRACTION] aims generously (modded MC wants a comfortable heap), bounded by:
+ *  - [UPPER_BOUND_MB]: a 64 GB box gains nothing from a 40 GB heap -- only longer GC
+ *    pauses -- so cap what a modded client can actually use.
+ *  - [CEILING_FRACTION]: never claim more than 75% of host RAM (leave the OS and the
+ *    rest of the JVM room); the same ceiling [HeapDeriver] clamps to.
+ *  - [FLOOR_MB]: modded clients need at least ~1 GB. This floor can intentionally
+ *    exceed [CEILING_FRACTION] on a sub-1.4 GB host (which cannot really run modded MC
+ *    anyway) and also covers [SystemMemory]'s 16 GB fallback and a degenerate 0 read.
+ */
+object AutomaticHeap {
+
+    const val FLOOR_MB = 1024
+    const val CEILING_FRACTION = 0.75   // never starve the host; matches HeapDeriver's ceiling
+    const val TARGET_FRACTION = 0.60    // modded-generous baseline
+    const val UPPER_BOUND_MB = 10240    // 10 GB: a huge machine does not get a huge heap
+
+    /** Baseline heap (MB) derived from host RAM. Deterministic; clamped to a sane band. */
+    fun compute(systemRamMb: Int): Int =
+        (systemRamMb * TARGET_FRACTION).toInt()
+            .coerceAtMost(UPPER_BOUND_MB)
+            .coerceAtMost((systemRamMb * CEILING_FRACTION).toInt())
+            .coerceAtLeast(FLOOR_MB)
+}

--- a/client-core/src/test/kotlin/hivens/core/jvm/AutomaticHeapTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/jvm/AutomaticHeapTest.kt
@@ -1,0 +1,50 @@
+package hivens.core.jvm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AutomaticHeapTest {
+
+    @Test
+    fun `scales at 60 percent of RAM in the common range`() {
+        assertEquals(4915, AutomaticHeap.compute(8192))   // 0.6 * 8192
+        assertEquals(9830, AutomaticHeap.compute(16384))  // 0.6 * 16384
+    }
+
+    @Test
+    fun `caps at the upper bound on big machines`() {
+        assertEquals(10240, AutomaticHeap.compute(32768)) // 0.6*32768 = 19660 -> capped 10240
+        assertEquals(10240, AutomaticHeap.compute(65536)) // 64 GB -> still 10240
+    }
+
+    @Test
+    fun `never exceeds 75 percent of host RAM for machines that can honour it`() {
+        // The floor (1024) deliberately overrides the ceiling on sub-1.4 GB hosts, so
+        // this invariant is asserted only for >= 2 GB, where 0.6*RAM already clears 1024.
+        for (ram in listOf(2048, 3072, 4096, 6144, 8192, 12288, 16384, 32768)) {
+            assertTrue(
+                AutomaticHeap.compute(ram) <= (ram * 0.75).toInt(),
+                "compute($ram) must not exceed 75% of host RAM",
+            )
+        }
+    }
+
+    @Test
+    fun `floors at 1 GB on small machines`() {
+        assertEquals(1024, AutomaticHeap.compute(1024)) // 0.6*1024 = 614 -> floor 1024
+        assertEquals(1024, AutomaticHeap.compute(512))
+    }
+
+    @Test
+    fun `degenerate zero RAM yields the floor, not zero`() {
+        assertEquals(1024, AutomaticHeap.compute(0))
+    }
+
+    @Test
+    fun `the 4 GB machine gets a capped baseline, not the old static default`() {
+        // The bug this tier fixes: a 4 GB box must not get 6144. 0.6*4096 = 2457, under
+        // 0.75*4096 = 3072.
+        assertEquals(2457, AutomaticHeap.compute(4096))
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -10,6 +10,7 @@ import hivens.core.data.InstanceProfile
 import hivens.core.data.InstanceRuntime
 import hivens.core.data.LauncherLogType
 import hivens.core.data.SessionData
+import hivens.core.jvm.AutomaticHeap
 import hivens.core.jvm.HeapDeriver
 import hivens.core.jvm.SystemMemory
 import hivens.launcher.component.ClasspathProvider
@@ -64,11 +65,12 @@ internal class LauncherService(
         val profile: InstanceProfile = profileManager.getProfile(serverProfile.assetDir)
         val version = serverProfile.version
 
-        // 1. Memory allocation strategy (adaptive heap unless this instance is pinned)
+        // 1. Heap: pinned -> explicit value; else the machine-aware Automatic baseline,
+        // which the adaptive sizer refines from when it is on.
         val adaptive = resolveAdaptive(
             enabled = adaptiveApplies(adaptiveEnabled, profile.fixedMemory),
             instanceDir = clientRootPath,
-            baseMemoryMb = normalizeMemory(profile.memoryMb, allocatedMemoryMB),
+            baseMemoryMb = baselineMemory(profile.fixedMemory, profile.memoryMb, allocatedMemoryMB, SystemMemory.totalPhysicalMb()),
         )
         val memory = adaptive.memoryMb
 
@@ -127,13 +129,12 @@ internal class LauncherService(
     ): Process {
         val mcVersion = manifest.minecraftVersion
 
-        // 1. Memory allocation strategy -- same floor logic as the SC path; the
-        // InstanceRuntime value wins when positive, then adaptive may refine it
-        // unless the instance is pinned.
+        // 1. Heap: same tiering as the SC path -- pinned -> explicit value, else the
+        // machine-aware Automatic baseline that the adaptive sizer refines from.
         val adaptive = resolveAdaptive(
             enabled = adaptiveApplies(adaptiveEnabled, runtime.fixedMemory),
             instanceDir = clientRootPath,
-            baseMemoryMb = normalizeMemory(runtime.memoryMb, allocatedMemoryMB),
+            baseMemoryMb = baselineMemory(runtime.fixedMemory, runtime.memoryMb, allocatedMemoryMB, SystemMemory.totalPhysicalMb()),
         )
         val memory = adaptive.memoryMb
 
@@ -281,6 +282,21 @@ internal class LauncherService(
          */
         internal fun adaptiveApplies(adaptiveEnabled: Boolean, fixedMemory: Boolean): Boolean =
             adaptiveEnabled && !fixedMemory
+
+        /**
+         * The baseline heap before any adaptive refinement. A pinned instance
+         * ([fixedMemory]) keeps its explicit [profileMb] (respected as-is, even above
+         * the machine ceiling -- a deliberate value is the user's call); an unpinned
+         * instance uses the machine-aware [AutomaticHeap] baseline, which is also the
+         * cold-start the adaptive sizer grows from. Pure.
+         */
+        internal fun baselineMemory(
+            fixedMemory: Boolean,
+            profileMb: Int,
+            allocatedMb: Int,
+            systemRamMb: Int,
+        ): Int = if (fixedMemory) normalizeMemory(profileMb, allocatedMb)
+                 else AutomaticHeap.compute(systemRamMb)
 
         /**
          * Pack-centric Java path resolution. Mirrors [resolveJavaPath]'s

--- a/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
@@ -9,6 +9,7 @@ import hivens.core.data.LauncherLogType
 import hivens.core.data.SessionData
 import hivens.core.api.model.ServerProfile
 import hivens.launcher.LauncherService.Companion.adaptiveApplies
+import hivens.launcher.LauncherService.Companion.baselineMemory
 import hivens.launcher.LauncherService.Companion.normalizeMemory
 import hivens.launcher.LauncherService.Companion.resolveJavaPath
 import hivens.launcher.component.ClasspathProvider
@@ -81,6 +82,30 @@ class LauncherServiceTest {
         assertFalse(adaptiveApplies(adaptiveEnabled = true, fixedMemory = true))   // pinned -> off
         assertFalse(adaptiveApplies(adaptiveEnabled = false, fixedMemory = false)) // global off -> off
         assertFalse(adaptiveApplies(adaptiveEnabled = false, fixedMemory = true))  // both off
+    }
+
+    // ── baselineMemory (tier resolution) ─────────────────────────────────────
+
+    @Test
+    fun `baselineMemory honours an explicit pin, uncapped`() {
+        // Fixed: a deliberate value is respected even above 75% of a small machine.
+        assertEquals(6144, baselineMemory(fixedMemory = true, profileMb = 6144, allocatedMb = 4096, systemRamMb = 4096))
+    }
+
+    @Test
+    fun `baselineMemory still floors a tiny pin`() {
+        assertEquals(1024, baselineMemory(fixedMemory = true, profileMb = 256, allocatedMb = 0, systemRamMb = 16384))
+    }
+
+    @Test
+    fun `unpinned ignores the stored value and uses the Automatic baseline`() {
+        // The cold-start over-allocation regression: a 4 GB box no longer gets 6144.
+        assertEquals(2457, baselineMemory(fixedMemory = false, profileMb = 6144, allocatedMb = 6144, systemRamMb = 4096))
+    }
+
+    @Test
+    fun `unpinned scales the Automatic baseline with the machine`() {
+        assertEquals(9830, baselineMemory(fixedMemory = false, profileMb = 4096, allocatedMb = 4096, systemRamMb = 16384))
     }
 
     // ── resolveJavaPath ──────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
@@ -22,30 +22,33 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import hivens.core.jvm.SystemMemory
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 
 /**
- * Precise RAM selector with preset buttons and manual input.
- * Replaces the imprecise slider.
+ * RAM mode selector. Represents a MODE, not just a number:
+ *  - [isAuto] true  -> "Auto": the machine-aware Automatic baseline, refined by the
+ *    adaptive sizer when it is on. The chip shows [resolvedAutoMb] -- the heap the next
+ *    launch will actually use.
+ *  - [isAuto] false -> a pinned (Fixed) value: [currentMb], from a preset or typed.
+ *
+ * Stateless: the host owns the mode. Picking a preset/custom calls [onValueChanged]
+ * (pins the instance); the Auto chip calls [onAutoSelected] (un-pins it).
  */
 @Composable
 fun RamSelector(
+    isAuto: Boolean,
+    resolvedAutoMb: Int,
     currentMb: Int,
+    onAutoSelected: () -> Unit,
     onValueChanged: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val s = LocalStrings.current
 
-    val systemRamMb = remember {
-        val osBean = java.lang.management.ManagementFactory.getOperatingSystemMXBean()
-        try {
-            val method = osBean.javaClass.getMethod("getTotalPhysicalMemorySize")
-            method.isAccessible = true
-            ((method.invoke(osBean) as Long) / (1024 * 1024)).toInt()
-        } catch (_: Exception) { 16384 }
-    }
+    val systemRamMb = remember { SystemMemory.totalPhysicalMb() }
 
     val allPresets = listOf(1024, 2048, 3072, 4096, 6144, 8192, 12288, 16384)
     val presets = remember(systemRamMb) {
@@ -53,7 +56,7 @@ fun RamSelector(
     }
 
     var customInput by remember { mutableStateOf("") }
-    var isCustomMode by remember { mutableStateOf(!allPresets.contains(currentMb)) }
+    var isCustomMode by remember { mutableStateOf(!isAuto && !allPresets.contains(currentMb)) }
     val focusManager = LocalFocusManager.current
 
     Column(modifier = modifier.fillMaxWidth()) {
@@ -63,35 +66,37 @@ fun RamSelector(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(s.serverSettingsRam, style = MaterialTheme.typography.bodyMedium, color = CelestiaTheme.colors.textPrimary)
-            Text(formatRam(currentMb), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = CelestiaTheme.colors.primary)
+            Text(
+                formatRam(if (isAuto) resolvedAutoMb else currentMb),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = CelestiaTheme.colors.primary
+            )
         }
 
         Spacer(Modifier.height(10.dp))
 
-        // Preset buttons
-        val chunked = presets.chunked(4)
-        chunked.forEach { row ->
+        // Auto mode: full-width chip above the presets. Default for an unpinned instance;
+        // shows the heap Auto resolves to right now (Automatic baseline or adaptive-derived).
+        RamChip(
+            selected = isAuto,
+            label = s.ramAutoLabel(formatRam(resolvedAutoMb)),
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { isCustomMode = false; onAutoSelected() },
+        )
+
+        Spacer(Modifier.height(6.dp))
+
+        // Preset buttons -- picking one pins the instance (Fixed).
+        presets.chunked(4).forEach { row ->
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 row.forEach { preset ->
-                    val isSelected = currentMb == preset && !isCustomMode
-                    val bgColor by animateColorAsState(
-                        if (isSelected) CelestiaTheme.colors.primary else glassSurfaceAlpha(0.5f),
-                        tween(200)
+                    RamChip(
+                        selected = !isAuto && !isCustomMode && currentMb == preset,
+                        label = formatRam(preset),
+                        modifier = Modifier.weight(1f),
+                        onClick = { isCustomMode = false; onValueChanged(preset) },
                     )
-                    val textColor by animateColorAsState(
-                        if (isSelected) Color.White else CelestiaTheme.colors.textSecondary,
-                        tween(200)
-                    )
-                    Box(
-                        modifier = Modifier.weight(1f).height(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .border(1.dp, if (isSelected) CelestiaTheme.colors.primary.copy(alpha = 0.7f) else CelestiaTheme.colors.outline.copy(alpha = 0.2f), RoundedCornerShape(8.dp))
-                            .background(bgColor)
-                            .clickable { isCustomMode = false; onValueChanged(preset) },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(formatRam(preset), fontSize = 12.sp, fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium, color = textColor, textAlign = TextAlign.Center)
-                    }
                 }
                 repeat(4 - row.size) { Spacer(Modifier.weight(1f)) }
             }
@@ -100,7 +105,7 @@ fun RamSelector(
 
         Spacer(Modifier.height(8.dp))
 
-        // Custom input
+        // Custom input -- typing a value also pins the instance.
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(s.ramCustomInputLabel, style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary, modifier = Modifier.width(100.dp))
             OutlinedTextField(
@@ -111,10 +116,15 @@ fun RamSelector(
                     customInput.toIntOrNull()?.takeIf { it in 512..32768 }?.let(onValueChanged)
                 },
                 // No fixed height -- Material3 OutlinedTextField needs ~56 dp to lay out
-                // its placeholder; forcing 48 dp clipped it past the bottom border so
-                // the digit visually "fell through" the field.
+                // its placeholder; forcing 48 dp clipped it past the bottom border.
                 modifier = Modifier.weight(1f),
-                placeholder = { Text(if (isCustomMode) "" else currentMb.toString(), color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.4f), fontSize = 13.sp) },
+                placeholder = {
+                    Text(
+                        if (isCustomMode) "" else formatRam(if (isAuto) resolvedAutoMb else currentMb),
+                        color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.4f),
+                        fontSize = 13.sp,
+                    )
+                },
                 suffix = { Text("MB", color = CelestiaTheme.colors.textSecondary, fontSize = 12.sp) },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
@@ -135,6 +145,33 @@ fun RamSelector(
             style = MaterialTheme.typography.labelSmall,
             color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.5f)
         )
+    }
+}
+
+/** A pill used for both the Auto chip and each preset; [selected] drives the fill/text. */
+@Composable
+private fun RamChip(selected: Boolean, label: String, modifier: Modifier, onClick: () -> Unit) {
+    val bg by animateColorAsState(
+        if (selected) CelestiaTheme.colors.primary else glassSurfaceAlpha(0.5f),
+        tween(200),
+    )
+    val fg by animateColorAsState(
+        if (selected) Color.White else CelestiaTheme.colors.textSecondary,
+        tween(200),
+    )
+    Box(
+        modifier = modifier.height(36.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                1.dp,
+                if (selected) CelestiaTheme.colors.primary.copy(alpha = 0.7f) else CelestiaTheme.colors.outline.copy(alpha = 0.2f),
+                RoundedCornerShape(8.dp),
+            )
+            .background(bg)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(label, fontSize = 12.sp, fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium, color = fg, textAlign = TextAlign.Center)
     }
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
@@ -55,8 +55,13 @@ fun RamSelector(
         allPresets.filter { it <= (systemRamMb * 0.75).toInt() }.ifEmpty { listOf(1024, 2048) }
     }
 
-    var customInput by remember { mutableStateOf("") }
-    var isCustomMode by remember { mutableStateOf(!isAuto && !allPresets.contains(currentMb)) }
+    // Seed the custom field from a pinned non-preset value (against the machine-FILTERED
+    // presets, so a value pinned above the machine ceiling still shows in the field, not
+    // a missing chip). Keyed on the inputs so a profile load / instance switch re-seeds.
+    var customInput by remember(isAuto, currentMb) {
+        mutableStateOf(if (!isAuto && currentMb in 512..32768 && !presets.contains(currentMb)) currentMb.toString() else "")
+    }
+    var isCustomMode by remember(isAuto, currentMb) { mutableStateOf(!isAuto && !presets.contains(currentMb)) }
     val focusManager = LocalFocusManager.current
 
     Column(modifier = modifier.fillMaxWidth()) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -217,6 +217,8 @@ interface AppStrings {
     // =========================================================================
     val ramCustomInputLabel: String
     fun ramSystemHint(systemRam: String, recommended: String): String
+    /** Auto-mode chip label; [resolved] is the formatted heap Auto currently resolves to. */
+    fun ramAutoLabel(resolved: String): String
 
     // =========================================================================
     // Mod cards
@@ -691,6 +693,7 @@ interface AppStrings {
     val packDetailTabFiles: String
     val packDetailTabWorlds: String
     val packDetailTabLogs: String
+    val packDetailTabSettings: String
     val consoleSessionLive: String
     fun consoleSessionPickerLabel(current: String): String
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -220,6 +220,7 @@ object EnglishStrings : AppStrings {
     override val ramCustomInputLabel = "Custom value:"
     override fun ramSystemHint(systemRam: String, recommended: String) =
         "System: $systemRam • Recommended max: $recommended"
+    override fun ramAutoLabel(resolved: String) = "Auto · ~$resolved"
 
     // =========================================================================
     // Mod cards
@@ -331,8 +332,8 @@ object EnglishStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Quietly refresh every server pack you've already installed when the launcher starts. Costs background bandwidth — useful if you switch between many servers and want fresh state without clicking each one."
     override val settingsJvmBuilder             = "Visual JVM args builder"
     override val settingsJvmBuilderDesc         = "Reveals a 'Build args' button in the per-server constructor. Pick a GC algorithm, tune heap regions, enable AppCDS or JFR profiling — without memorizing flags. Curated presets cover Aikar's recipe, GTNH-class heavy modded, ZGC for huge heaps, and more."
-    override val settingsAdaptiveMemory         = "Adaptive memory (Auto)"
-    override val settingsAdaptiveMemoryDesc     = "Each instance sizes its own heap from how much memory the pack actually uses, refining it over a few sessions. Picking a specific RAM value opts that instance out; turn this off to give every instance the fixed default."
+    override val settingsAdaptiveMemory         = "Adaptive memory"
+    override val settingsAdaptiveMemoryDesc     = "Refines each instance's heap from real usage over a few sessions, on top of the automatic machine-based baseline. Pin a specific RAM value to opt an instance out; turn this off to keep the automatic baseline without learning."
     override val settingsMimicVersion           = "Mimic launcher version override"
     override val settingsMimicVersionDesc       = "Pin the version string sent to upstream in the handshake and User-Agent. Leave blank to use the shipped default — set this only when upstream has bumped its version pin faster than Nexira's release cycle. Takes effect on the next protocol call after save; no restart needed."
     override fun settingsMimicVersionPlaceholder(default: String) = "Default: $default"
@@ -665,6 +666,7 @@ object EnglishStrings : AppStrings {
     override val packDetailTabFiles             = "Files"
     override val packDetailTabWorlds            = "Worlds"
     override val packDetailTabLogs              = "Logs"
+    override val packDetailTabSettings          = "Settings"
     override val consoleSessionLive             = "General"
     override fun consoleSessionPickerLabel(current: String) = "Log: $current"
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -217,6 +217,7 @@ object GermanStrings : AppStrings {
     override val ramCustomInputLabel = "Eigener Wert:"
     override fun ramSystemHint(systemRam: String, recommended: String) =
         "System: $systemRam • Empfohlen max: $recommended"
+    override fun ramAutoLabel(resolved: String) = "Auto · ~$resolved"
 
     // =========================================================================
     // Mod cards
@@ -328,8 +329,8 @@ object GermanStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Aktualisiert beim Launcher-Start jedes bereits installierte Server-Pack im Hintergrund. Kostet Bandbreite — nützlich, wenn du zwischen mehreren Servern wechselst und frischen Stand ohne Klick auf jeden willst."
     override val settingsJvmBuilder             = "Visueller JVM-Argument-Builder"
     override val settingsJvmBuilderDesc         = "Zeigt einen „Argumente bauen“-Button in den Server-Einstellungen. Wähle Garbage Collector, justiere Heap-Regionen, aktiviere AppCDS oder JFR — ohne Flags auswendig zu lernen. Vorgaben: Aikar's Rezept, GTNH-Klasse, ZGC für große Heaps und mehr."
-    override val settingsAdaptiveMemory         = "Adaptiver Speicher (Auto)"
-    override val settingsAdaptiveMemoryDesc     = "Jede Instanz bestimmt ihren Heap selbst, anhand des tatsächlichen Verbrauchs des Packs, verfeinert über mehrere Sitzungen. Ein fester RAM-Wert deaktiviert Auto für diese Instanz; ausschalten gibt jeder Instanz den festen Standardwert."
+    override val settingsAdaptiveMemory         = "Adaptiver Speicher"
+    override val settingsAdaptiveMemoryDesc     = "Verfeinert den Heap jeder Instanz anhand des realen Verbrauchs über einige Sitzungen, aufbauend auf dem automatischen RAM-basierten Basiswert. Festen RAM-Wert setzen, um eine Instanz auszunehmen; ausschalten, um den automatischen Basiswert ohne Lernen zu behalten."
     override val settingsMimicVersion           = "Launcher-Version-Override"
     override val settingsMimicVersionDesc       = "Fixiert den Versions-String, der an den Upstream im Handshake und User-Agent gesendet wird. Leer lassen für den eingebauten Standard — nur setzen, wenn der Upstream seine Versions-Anforderung schneller anhebt als Nexiras Release-Zyklus. Wirkt beim nächsten Protokoll-Aufruf nach Speichern, kein Neustart nötig."
     override fun settingsMimicVersionPlaceholder(default: String) = "Standard: $default"
@@ -662,6 +663,7 @@ object GermanStrings : AppStrings {
     override val packDetailTabFiles             = "Dateien"
     override val packDetailTabWorlds            = "Welten"
     override val packDetailTabLogs              = "Logs"
+    override val packDetailTabSettings          = "Einstellungen"
     override val consoleSessionLive             = "Allgemein"
     override fun consoleSessionPickerLabel(current: String) = "Log: $current"
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -217,6 +217,7 @@ object RussianStrings : AppStrings {
     override val ramCustomInputLabel = "Своё значение:"
     override fun ramSystemHint(systemRam: String, recommended: String) =
         "Система: $systemRam • Рекомендуется не более $recommended"
+    override fun ramAutoLabel(resolved: String) = "Авто · ~$resolved"
 
     // =========================================================================
     // Mod cards
@@ -329,8 +330,8 @@ object RussianStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Тихо обновлять все уже установленные сборки в фоне при старте лаунчера. Тратит фоновый трафик — полезно если играешь на нескольких серверах и хочешь свежее состояние без клика по каждому."
     override val settingsJvmBuilder             = "Визуальный конструктор JVM-аргументов"
     override val settingsJvmBuilderDesc         = "Показывает кнопку «Собрать аргументы» в настройках сервера. Выбираешь сборщик мусора, настраиваешь регионы хипа, включаешь AppCDS или JFR — без необходимости помнить флаги. Готовые пресеты: Aikar's recipe, GTNH-класс, ZGC для больших хипов и другие."
-    override val settingsAdaptiveMemory         = "Адаптивная память (Авто)"
-    override val settingsAdaptiveMemoryDesc     = "Каждая сборка сама подбирает размер хипа по реальному потреблению пака, уточняя за несколько сессий. Выбор конкретного значения RAM отключает Авто для этой сборки; выключи, чтобы у всех был фиксированный дефолт."
+    override val settingsAdaptiveMemory         = "Адаптивная память"
+    override val settingsAdaptiveMemoryDesc     = "Уточняет размер хипа каждой сборки по реальному потреблению за несколько сессий, поверх автоматического базового значения от ОЗУ машины. Зафиксируй конкретное значение RAM, чтобы исключить сборку; выключи, чтобы оставить автоматическую базу без обучения."
     override val settingsMimicVersion           = "Подмена версии лаунчера"
     override val settingsMimicVersionDesc       = "Зафиксировать строку версии, которая отправляется в рукопожатии и User-Agent. Оставь пустым для стандартного значения — заполни только если апстрим успел поднять свою версию быстрее цикла релизов Nexira. Применяется на следующем запросе к протоколу после сохранения, перезапуск не требуется."
     override fun settingsMimicVersionPlaceholder(default: String) = "По умолчанию: $default"
@@ -663,6 +664,7 @@ object RussianStrings : AppStrings {
     override val packDetailTabFiles             = "Файлы"
     override val packDetailTabWorlds            = "Миры"
     override val packDetailTabLogs              = "Логи"
+    override val packDetailTabSettings          = "Настройки"
     override val consoleSessionLive             = "Общий"
     override fun consoleSessionPickerLabel(current: String) = "Лог: $current"
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
@@ -30,8 +30,11 @@ import hivens.core.api.interfaces.ISettingsService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.InstanceProfile
 import hivens.core.data.OptionalMod
+import hivens.core.jvm.AutomaticHeap
+import hivens.core.jvm.SystemMemory
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ProfileManager
+import hivens.launcher.ProfilerProfileStore
 import hivens.ui.components.CelestiaButton
 import hivens.ui.components.GlassCard
 import hivens.ui.components.JvmArgsBuilderDialog
@@ -79,6 +82,7 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
     val playerRepository: PlayerRepository           = koinInject()
     val credentialsManager: CredentialsManager       = koinInject()
     val settingsService: ISettingsService            = koinInject()
+    val profilerStore: ProfilerProfileStore          = koinInject()
     val s = LocalStrings.current
 
     val jvmBuilderEnabled = remember { settingsService.getSettings().jvmBuilderEnabled }
@@ -88,7 +92,8 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
     var profile    by remember { mutableStateOf<InstanceProfile?>(null) }
     var javaPath   by remember { mutableStateOf("") }
     var memory     by remember { mutableStateOf(4096) }
-    var ramTouched by remember { mutableStateOf(false) }
+    var isAutoMode by remember { mutableStateOf(true) }
+    var resolvedAutoMb by remember { mutableStateOf(AutomaticHeap.compute(SystemMemory.totalPhysicalMb())) }
     var jvmArgs    by remember { mutableStateOf("") }
     var winWidth   by remember { mutableStateOf("925") }
     var winHeight  by remember { mutableStateOf("530") }
@@ -113,6 +118,16 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
         autoConnect = p.autoConnect
         if (p.memoryMb > 0) memory = p.memoryMb
 
+        // RAM mode: Auto unless the user pinned a value. The Auto chip shows what the next
+        // launch will actually use -- the adaptive-derived heap when adaptive is on and has
+        // data, otherwise the machine-aware Automatic baseline (mirrors LauncherService).
+        isAutoMode = !p.fixedMemory
+        val settings = settingsService.getSettings()
+        val adaptiveOn = settings.experimentalFeaturesEnabled && settings.adaptiveMemoryEnabled
+        val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)
+        val derivedMb = if (adaptiveOn) withContext(Dispatchers.IO) { profilerStore.readProfile(clientDir)?.derivedHeapMb } else null
+        resolvedAutoMb = derivedMb ?: AutomaticHeap.compute(SystemMemory.totalPhysicalMb())
+
         val loadedMods = manifestProcessorService.getOptionalModsForClient(server)
         mods = loadedMods
         loadedMods.forEach { mod ->
@@ -136,7 +151,7 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
             val updated = p.copy(
                 javaPath     = javaPath.ifBlank { null },
                 memoryMb     = memory,
-                fixedMemory = if (ramTouched) true else p.fixedMemory,
+                fixedMemory = !isAutoMode,
                 jvmArgs      = jvmArgs.ifBlank { null },
                 windowWidth  = winWidth.toIntOrNull() ?: 925,
                 windowHeight = winHeight.toIntOrNull() ?: 530,
@@ -277,9 +292,12 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
 
                     // ── RAM -- RamSelector replaces old Slider ─────────────────
                     RamSelector(
+                        isAuto = isAutoMode,
+                        resolvedAutoMb = resolvedAutoMb,
                         currentMb = memory,
-                        // An explicit pick pins this server (fixedMemory = true), opting it out of the adaptive sizer.
-                        onValueChanged = { memory = it; ramTouched = true }
+                        // Auto un-pins (fixedMemory=false); picking a value pins (Fixed).
+                        onAutoSelected = { isAutoMode = true },
+                        onValueChanged = { memory = it; isAutoMode = false },
                     )
 
                     Spacer(Modifier.height(16.dp))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -310,8 +310,11 @@ private fun PackSettingsTab(
     val profilerStore: ProfilerProfileStore = koinInject()
     val settingsService: ISettingsService = koinInject()
 
-    var isAutoMode by remember(runtime) { mutableStateOf(!runtime.fixedMemory) }
-    var memory by remember(runtime) { mutableStateOf(if (runtime.memoryMb > 0) runtime.memoryMb else 4096) }
+    // Keyed on the stable instanceDir, not runtime: the tab's own edits mutate runtime,
+    // and re-seeding on those would fight an in-progress edit. Reset only when the
+    // displayed instance changes (which also remounts the screen via the nav Crossfade).
+    var isAutoMode by remember(instanceDir) { mutableStateOf(!runtime.fixedMemory) }
+    var memory by remember(instanceDir) { mutableStateOf(if (runtime.memoryMb > 0) runtime.memoryMb else 4096) }
     var resolvedAutoMb by remember { mutableStateOf(AutomaticHeap.compute(SystemMemory.totalPhysicalMb())) }
 
     LaunchedEffect(instanceDir) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -37,6 +38,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,11 +50,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import hivens.core.api.interfaces.IPackRepository
+import hivens.core.api.interfaces.ISettingsService
+import hivens.core.data.InstanceRuntime
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
+import hivens.core.jvm.AutomaticHeap
+import hivens.core.jvm.SystemMemory
+import hivens.launcher.ProfilerProfileStore
 import hivens.launcher.launch.LauncherController
 import hivens.launcher.platform.PlatformPaths
 import hivens.ui.AppState
+import hivens.ui.components.RamSelector
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.notifications.LaunchTarget
 import hivens.ui.notifications.drivers.LaunchDriver
@@ -71,6 +79,7 @@ import hivens.ui.utils.GameConsoleService
 import hivens.ui.utils.LogEntry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.koin.compose.koinInject
@@ -125,6 +134,7 @@ fun PackDetailScreen(
 
     var tabIndex by remember(pack.id) { mutableIntStateOf(0) }
     val s = LocalStrings.current
+    val scope = rememberCoroutineScope()
 
     Column(Modifier.fillMaxSize()) {
         Hero(pack = pack, onBack = onBack)
@@ -173,6 +183,11 @@ fun PackDetailScreen(
                 onClick  = { tabIndex = 3 },
                 text     = { Text(s.packDetailTabLogs, fontWeight = if (tabIndex == 3) FontWeight.Bold else FontWeight.Normal) },
             )
+            Tab(
+                selected = tabIndex == 4,
+                onClick  = { tabIndex = 4 },
+                text     = { Text(s.packDetailTabSettings, fontWeight = if (tabIndex == 4) FontWeight.Bold else FontWeight.Normal) },
+            )
         }
 
         Box(modifier = Modifier.fillMaxSize().padding(top = 4.dp)) {
@@ -181,6 +196,15 @@ fun PackDetailScreen(
                 1 -> FileBrowserPane(rootDir = instanceDir, modifier = Modifier.padding(16.dp))
                 2 -> WorldsTabPane(instanceDir = instanceDir)
                 3 -> PackLogsTab(packId = pack.id, instanceDir = instanceDir, dataDir = paths.dataDir)
+                4 -> PackSettingsTab(
+                    runtime = pack.runtime,
+                    instanceDir = instanceDir,
+                    onRuntimeChange = { rt ->
+                        val updated = pack.copy(runtime = rt)
+                        instance = updated
+                        scope.launch { repo.put(updated) }
+                    },
+                )
             }
         }
     }
@@ -268,6 +292,52 @@ private fun PackLogsTab(packId: String, instanceDir: Path, dataDir: Path) {
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Settings tab: per-instance runtime. RAM only for now -- Auto (the machine-aware
+ * Automatic baseline, refined by the adaptive sizer) vs a pinned value. Persists each
+ * change through [onRuntimeChange]; the Auto chip shows what the next launch will use.
+ */
+@Composable
+private fun PackSettingsTab(
+    runtime: InstanceRuntime,
+    instanceDir: Path,
+    onRuntimeChange: (InstanceRuntime) -> Unit,
+) {
+    val profilerStore: ProfilerProfileStore = koinInject()
+    val settingsService: ISettingsService = koinInject()
+
+    var isAutoMode by remember(runtime) { mutableStateOf(!runtime.fixedMemory) }
+    var memory by remember(runtime) { mutableStateOf(if (runtime.memoryMb > 0) runtime.memoryMb else 4096) }
+    var resolvedAutoMb by remember { mutableStateOf(AutomaticHeap.compute(SystemMemory.totalPhysicalMb())) }
+
+    LaunchedEffect(instanceDir) {
+        val settings = settingsService.getSettings()
+        val adaptiveOn = settings.experimentalFeaturesEnabled && settings.adaptiveMemoryEnabled
+        val derivedMb = if (adaptiveOn) withContext(Dispatchers.IO) { profilerStore.readProfile(instanceDir)?.derivedHeapMb } else null
+        resolvedAutoMb = derivedMb ?: AutomaticHeap.compute(SystemMemory.totalPhysicalMb())
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = glassSurfaceAlpha(0.85f)) {
+        Column(Modifier.fillMaxSize().padding(24.dp)) {
+            RamSelector(
+                isAuto = isAutoMode,
+                resolvedAutoMb = resolvedAutoMb,
+                currentMb = memory,
+                onAutoSelected = {
+                    isAutoMode = true
+                    onRuntimeChange(runtime.copy(fixedMemory = false))
+                },
+                onValueChanged = {
+                    memory = it
+                    isAutoMode = false
+                    onRuntimeChange(runtime.copy(memoryMb = it, fixedMemory = true))
+                },
+                modifier = Modifier.widthIn(max = 560.dp),
+            )
         }
     }
 }


### PR DESCRIPTION
## Three-tier memory model: Fixed / Automatic / Adaptive

Adds an **Automatic** tier between Fixed and Adaptive -- a machine-aware baseline heap that the adaptive sizer grows from, and that non-pinned instances use directly when adaptive is off.

### Why
The non-pinned cold-start used the raw static `memoryMb` constant (6144 SC / 4096 pack) with no system-RAM ceiling, so a 4 GB machine launched with `-Xmx6144M`. There was no machine-aware tier: adaptive cold-started from a dumb constant, and the only non-adaptive path was that same uncapped constant.

### The model
Per instance, the tier falls out of the existing flags -- no new per-instance field:

| State | Tier | Heap |
|---|---|---|
| `fixedMemory = true` | Fixed | the pinned value (respected as-is) |
| not pinned, adaptive on | Adaptive | `derive(samples) ?: Automatic` (cold-starts from Automatic) |
| not pinned, adaptive off | Automatic | machine-aware baseline |

### Automatic heuristic
`0.60 x RAM`, capped at 10 GB and 75% of RAM, floored 1 GB. So 8 GB -> ~4.8 GB, 16 GB -> ~9.6 GB, 32 GB+ -> 10 GB, 4 GB -> ~2.4 GB (the cold-start fix).

### UI
- `RamSelector` is now mode-aware: an **Auto** chip showing the resolved heap (adaptive-derived if available, else the Automatic baseline) vs pinned presets/custom. Deduped onto `SystemMemory`.
- `ServerSettingsScreen` hosts it (`fixedMemory = !auto`, which also fixes the old one-way `ramTouched` that could never un-pin).
- New **Settings** tab in PackDetail gives pack instances the same control, persisted via `IPackRepository`.
- i18n: `ramAutoLabel`, `packDetailTabSettings`; reworded the adaptive toggle now that Auto is a distinct tier.

### Tests
`AutomaticHeapTest` (scaling / cap / floor / degenerate / the 4 GB regression) and `LauncherServiceTest.baselineMemory` (the tier matrix). client-core + client-launcher green; client-ui compiles.

### Follow-ups (not in this PR)
- Pack Settings tab is RAM-only; `InstanceRuntime` also carries javaPath / jvmArgs / window / autoConnect with no pack UI yet -- a separate pack runtime-editor.
- The pack tab persists each change immediately (no save button); debouncing custom-input typing is a possible refinement.
- A pack-declared recommended-RAM hint in the manifest could feed Automatic later (ties to pack rich-metadata).