### PR TITLE
fix(release): de-dup "What's Changed" + backfill 2.3.4-beta2/beta3 changelog

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -560,12 +560,8 @@ jobs:
           body: ${{ steps.body.outputs.body }}
           files: dist/*
           draft: false
-          # Appends GitHub's auto-generated "What's Changed" section (PR list
-          # since the previous tag) BELOW our curated body. Additive, not
-          # replacement -- the CHANGELOG extraction in the body still wins
-          # for highlights. Fallback for when someone forgets the CHANGELOG
-          # entry and the extracted body falls back to the "No changelog
-          # entry for v${VERSION}" placeholder: at least the user gets the
-          # raw merged-PR list instead of an empty release page.
-          generate_release_notes: true
+          # generate_release_notes intentionally OFF: GitHub's auto section is also
+          # titled "What's Changed" and duplicated our curated CHANGELOG section of
+          # the same name on the release page (and the in-app updater parses the
+          # first "## What's Changed"). The composed body is the single source.
           prerelease: ${{ contains(needs.changelog.outputs.version, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ below are for the GitHub release page and CHANGELOG readers.
 
 ## [Unreleased]
 
+## [2.3.4-beta3] - 2026-06-04
+
+Matures the adaptive memory from 2.3.4-beta2 into a three-tier model
+(Fixed / Automatic / Adaptive) and cleans up the release notes.
+
+### Highlights
+- **Automatic memory baseline**. A non-pinned instance now sizes its heap from
+  your machine's RAM (a sane share, capped) instead of a fixed default, so it
+  stops over-allocating on a small machine. The adaptive sizer refines this
+  baseline over a few sessions.
+- **Adaptive governs every instance**. The global Adaptive memory toggle now
+  applies to every instance, not just freshly-created ones. Pin a specific RAM
+  value to opt one out; turn the toggle off to keep the automatic baseline
+  without learning.
+- **See and set the mode**. The RAM selector shows an "Auto" chip with the heap
+  it currently resolves to, and pack instances get their own Settings tab for RAM.
+
+### Changed
+- Adaptive heap derivation is peak-aware: it also covers churn-heavy packs and
+  collectors that never report a major GC.
+
+### Fixed
+- The experimental master toggle now actually disables adaptive memory at launch
+  (previously the launch path ignored it).
+- Release notes no longer carry a duplicated "What's Changed" section, and the
+  in-app update dialog no longer shows the download table as a changelog.
+
 ## [2.3.4-beta2] - 2026-06-03
 
 Adds the experimental adaptive memory sizer on top of 2.3.4-beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ below are for the GitHub release page and CHANGELOG readers.
 
 ## [Unreleased]
 
+## [2.3.4-beta2] - 2026-06-03
+
+Adds the experimental adaptive memory sizer on top of 2.3.4-beta.
+
+### Highlights
+- **Adaptive memory (experimental)**. New instances measure their real heap use
+  while you play and right-size `-Xmx` over the next few launches, so a pack runs
+  smoother without hand-tuning RAM. On by default under the experimental settings;
+  pick a specific RAM value to opt that instance out.
+
+### Added
+- Profiler agent: a small in-JVM measurement agent (GC / heap only, no mod contact)
+  that records each session's metrics; the launcher derives the next launch's heap
+  from them between runs.
+
 ## [2.3.4-beta] - 2026-06-03
 
 The customization release. The launcher's whole interface becomes

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
@@ -653,12 +653,15 @@ class UpdateService(
             .ifBlank { "No changelog available" }
     }
 
-    private fun extractWhatsChanged(body: String?): String {
+    internal fun extractWhatsChanged(body: String?): String {
         if (body == null) return ""
 
-        // Slice between "## What's Changed" and the next "---" or "##"
+        // The section between "## What's Changed" and the next heading / "---".
+        // No section -> empty, NOT a substringBefore("---") fallback: our release
+        // bodies carry no "---" rule, so that fallback returned the WHOLE body
+        // (NOTE + Downloads + checksums) as the changelog -- garbage in the dialog.
         val start = body.indexOf("## What's Changed")
-        if (start == -1) return body.substringBefore("---").trim()
+        if (start == -1) return ""
 
         val afterHeader = body.substring(start + "## What's Changed".length)
         return afterHeader

--- a/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
@@ -169,6 +169,32 @@ class UpdateServiceTest {
         assertEquals(0, svc.compareVersions("1.3.0", "1.3.0"))
     }
 
+    // ═══════════════════════════════════════════════════════════════════════════
+    // extractWhatsChanged
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun `extractWhatsChanged returns the section up to the next heading`() {
+        val svc = createService("{}")
+        val body = "## What's New\n\nfeatures\n\n## What's Changed\n\nthe details\n\n## Downloads\n\ntable"
+        assertEquals("the details", svc.extractWhatsChanged(body))
+    }
+
+    @Test
+    fun `extractWhatsChanged returns empty when there is no section`() {
+        val svc = createService("{}")
+        // A body with no "## What's Changed" (e.g. a manually-cut release) must NOT
+        // fall back to the whole body / download table.
+        val body = "> [!NOTE]\n> blah\n\n## Downloads\n\n| a | b |\n|---|---|"
+        assertEquals("", svc.extractWhatsChanged(body))
+    }
+
+    @Test
+    fun `extractWhatsChanged is empty for a null body`() {
+        val svc = createService("{}")
+        assertEquals("", svc.extractWhatsChanged(null))
+    }
+
     @Test
     fun `compareVersions handles patch level differences`() {
         val svc = createService("{}")

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -32,6 +32,15 @@ HIGHLIGHTS=$(printf '%s' "$CHANGELOG_NOTES" \
   | awk '/^### Highlights/ {flag=1; next} /^### / {flag=0} flag' \
   | sed '/^[[:space:]]*$/d')
 
+# The same notes WITHOUT the ### Highlights block -- highlights already render
+# above as "## What's New", so dumping the full section below would repeat them.
+CHANGELOG_DETAILS=$(printf '%s' "$CHANGELOG_NOTES" \
+  | awk '/^### Highlights/ {skip=1; next} /^### / {skip=0} !skip')
+# Degenerate entry (highlights only, no summary/details) -> keep the full notes.
+if [ -z "$(printf '%s' "$CHANGELOG_DETAILS" | tr -d '[:space:]')" ]; then
+  CHANGELOG_DETAILS="$CHANGELOG_NOTES"
+fi
+
 # Build the SHA256 checksum table by walking dist/SHA256SUMS.txt.
 CHECKSUMS=""
 while IFS= read -r line; do
@@ -71,5 +80,5 @@ done < "$CHECKSUMS_FILE"
   printf '\n</details>\n\n'
 
   printf "## What's Changed\n\n"
-  printf '%s\n' "$CHANGELOG_NOTES"
+  printf '%s\n' "$CHANGELOG_DETAILS"
 }


### PR DESCRIPTION
The 2.3.3 release page showed two `## What's Changed` sections, and the highlights twice. Two causes:

1. `compose-release-body.sh` printed the highlights as `## What's New` AND then dumped the **full** CHANGELOG section (which contains its own `### Highlights`) as `## What's Changed` -- highlights twice.
2. The release action set `generate_release_notes: true`, so GitHub appended its **own** `## What's Changed` (the merged-PR list) below ours -- a second heading of the same name.

## Fix
- **Drop `generate_release_notes`.** Our curated CHANGELOG section is the single `## What's Changed` -- and it's exactly what the in-app updater parses (`extractWhatsChanged`), so the update dialog keeps real changelog text instead of a raw PR list.
- **`compose-release-body.sh`:** the bottom `## What's Changed` now omits the `### Highlights` block (already shown above as `## What's New`). Highlights render once; the `### Added/Changed/Fixed` details stay.
- **Companion -- `extractWhatsChanged`:** when a body has no `## What's Changed`, return empty instead of `substringBefore("---")`. Our bodies have no `---` rule, so that fallback returned the whole body (NOTE + downloads table + checksums) as the "changelog" -- the garbage seen in the update dialog for the manually-cut 2.3.4-beta2.

## Verify
- Ran `compose-release-body.sh` with a sample CHANGELOG: one `## What's Changed`, highlights once, `### Added/Fixed` retained.
- `UpdateServiceTest`: extractWhatsChanged returns the section / empty when absent / empty for null. client-launcher green.