### PR TITLE
fix(profiler): detect host RAM on the packaged build

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/jvm/SystemMemory.kt
+++ b/client-core/src/main/kotlin/hivens/core/jvm/SystemMemory.kt
@@ -1,23 +1,40 @@
 package hivens.core.jvm
 
+import com.sun.management.OperatingSystemMXBean
 import java.lang.management.ManagementFactory
+import org.slf4j.LoggerFactory
 
 /**
- * Host physical RAM. The figure comes from the `com.sun.management`
- * OperatingSystemMXBean extension, reached reflectively because
- * `getTotalPhysicalMemorySize` is not on the public `OperatingSystemMXBean`
- * interface. Shared by the RAM selector UI and the adaptive heap sizer so both
- * read the same number. Falls back to 16 GB when the platform does not expose it.
+ * Host physical RAM, read from com.sun.management's [OperatingSystemMXBean]
+ * extension (the public, exported `getTotalMemorySize` accessor). Shared by the
+ * RAM selector UI and the adaptive heap sizer so both read the same number.
+ *
+ * That extension lives in the `jdk.management` module: on the jlinked
+ * distribution the module MUST be in the runtime image (see client-ui's
+ * `packaging.modules` + the `verifyRuntimeModules` guard) or the class fails to
+ * link and the read degrades to [FALLBACK_MB] -- which mis-sizes the Automatic
+ * heap. The fallback logs a warning so such a regression is visible, not silent.
  */
 object SystemMemory {
+
+    /** Used when the platform does not expose physical RAM (e.g. jdk.management absent). */
+    const val FALLBACK_MB = 16384
+
+    private val logger = LoggerFactory.getLogger("SystemMemory")
+
     fun totalPhysicalMb(): Int {
-        val bean = ManagementFactory.getOperatingSystemMXBean()
         return try {
-            val method = bean.javaClass.getMethod("getTotalPhysicalMemorySize")
-            method.isAccessible = true
-            ((method.invoke(bean) as Long) / (1024 * 1024)).toInt()
-        } catch (_: Exception) {
-            16384
+            val os = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
+            (os.totalMemorySize / (1024 * 1024)).toInt().takeIf { it > 0 } ?: FALLBACK_MB
+        } catch (_: LinkageError) {
+            // com.sun.management failed to link: jdk.management is absent from the runtime
+            // image. Degrade to a fallback rather than crash the launcher over a RAM read.
+            logger.warn(
+                "Could not read host RAM via com.sun.management OperatingSystemMXBean " +
+                    "(jdk.management missing from the runtime image?). Using {} MB fallback.",
+                FALLBACK_MB,
+            )
+            FALLBACK_MB
         }
     }
 }

--- a/client-core/src/main/kotlin/hivens/core/jvm/SystemMemory.kt
+++ b/client-core/src/main/kotlin/hivens/core/jvm/SystemMemory.kt
@@ -12,29 +12,39 @@ import org.slf4j.LoggerFactory
  * That extension lives in the `jdk.management` module: on the jlinked
  * distribution the module MUST be in the runtime image (see client-ui's
  * `packaging.modules` + the `verifyRuntimeModules` guard) or the class fails to
- * link and the read degrades to [FALLBACK_MB] -- which mis-sizes the Automatic
- * heap. The fallback logs a warning so such a regression is visible, not silent.
+ * link and the read is unavailable. [totalPhysicalMb] then substitutes
+ * [FALLBACK_MB] for sizing; [totalPhysicalMbOrNull] returns null so a caller
+ * that must not guess (a diagnostics display) can show "unknown" instead. The
+ * read is memoized -- host RAM is constant per process -- so the warning on a
+ * broken runtime fires once, not once per caller.
  */
 object SystemMemory {
 
-    /** Used when the platform does not expose physical RAM (e.g. jdk.management absent). */
+    /** Heap-sizing fallback used when the platform does not expose physical RAM. */
     const val FALLBACK_MB = 16384
 
     private val logger = LoggerFactory.getLogger("SystemMemory")
 
-    fun totalPhysicalMb(): Int {
+    private val cachedMb: Int? by lazy { readPhysicalMb() }
+
+    /** Host physical RAM (MB), or null if the platform does not expose it (e.g. jdk.management absent). */
+    fun totalPhysicalMbOrNull(): Int? = cachedMb
+
+    /** Host physical RAM (MB) for sizing; [FALLBACK_MB] when the platform does not expose it. */
+    fun totalPhysicalMb(): Int = cachedMb ?: FALLBACK_MB
+
+    private fun readPhysicalMb(): Int? {
         return try {
             val os = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
-            (os.totalMemorySize / (1024 * 1024)).toInt().takeIf { it > 0 } ?: FALLBACK_MB
+            (os.totalMemorySize / (1024 * 1024)).toInt().takeIf { it > 0 }
         } catch (_: LinkageError) {
             // com.sun.management failed to link: jdk.management is absent from the runtime
-            // image. Degrade to a fallback rather than crash the launcher over a RAM read.
+            // image. Degrade rather than crash the launcher over a RAM read.
             logger.warn(
                 "Could not read host RAM via com.sun.management OperatingSystemMXBean " +
-                    "(jdk.management missing from the runtime image?). Using {} MB fallback.",
-                FALLBACK_MB,
+                    "(jdk.management missing from the runtime image?).",
             )
-            FALLBACK_MB
+            null
         }
     }
 }

--- a/client-core/src/test/kotlin/hivens/core/jvm/SystemMemoryTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/jvm/SystemMemoryTest.kt
@@ -1,0 +1,25 @@
+package hivens.core.jvm
+
+import com.sun.management.OperatingSystemMXBean
+import java.lang.management.ManagementFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SystemMemoryTest {
+
+    /**
+     * On a normal JDK (jdk.management present) the read returns the real host RAM, not the
+     * [SystemMemory.FALLBACK_MB] fallback. Mirrors the production computation against the
+     * typed com.sun bean -- guards the MB conversion and the real-vs-fallback distinction.
+     * The missing-module case a unit test can't reach is covered by the build-time
+     * verifyRuntimeModules guard in client-ui.
+     */
+    @Test
+    fun `read matches the typed com_sun bean`() {
+        val bean = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
+        val expectedMb = (bean.totalMemorySize / (1024 * 1024)).toInt()
+        assertTrue(expectedMb > 0, "test precondition: a full JDK should report positive RAM")
+        assertEquals(expectedMb, SystemMemory.totalPhysicalMb())
+    }
+}

--- a/client-core/src/test/kotlin/hivens/core/jvm/SystemMemoryTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/jvm/SystemMemoryTest.kt
@@ -10,16 +10,18 @@ class SystemMemoryTest {
 
     /**
      * On a normal JDK (jdk.management present) the read returns the real host RAM, not the
-     * [SystemMemory.FALLBACK_MB] fallback. Mirrors the production computation against the
-     * typed com.sun bean -- guards the MB conversion and the real-vs-fallback distinction.
-     * The missing-module case a unit test can't reach is covered by the build-time
+     * [SystemMemory.FALLBACK_MB] fallback, and agrees with the typed com.sun bean. The range
+     * check is an independent sanity bound that catches a gross unit error in the production
+     * read; the missing-module case a unit test can't reach is covered by the build-time
      * verifyRuntimeModules guard in client-ui.
      */
     @Test
-    fun `read matches the typed com_sun bean`() {
+    fun `read returns real host RAM, not the fallback`() {
         val bean = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
         val expectedMb = (bean.totalMemorySize / (1024 * 1024)).toInt()
-        assertTrue(expectedMb > 0, "test precondition: a full JDK should report positive RAM")
-        assertEquals(expectedMb, SystemMemory.totalPhysicalMb())
+        val mb = SystemMemory.totalPhysicalMb()
+        assertTrue(mb in 256..(8 * 1024 * 1024), "implausible RAM read: $mb MB")
+        assertEquals(expectedMb, mb)
+        assertEquals(expectedMb, SystemMemory.totalPhysicalMbOrNull())
     }
 }

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -1,3 +1,4 @@
+import hivens.packaging.PackagingExtension
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -230,6 +231,12 @@ compose.desktop {
                 "java.desktop",
                 "java.logging",
                 "java.management",
+                // jdk.management carries com.sun.management.OperatingSystemMXBean, which
+                // SystemMemory reflects into for host RAM (Automatic heap sizing). Without it
+                // the bean lacks getTotalMemorySize/getTotalPhysicalMemorySize and RAM silently
+                // falls back to a wrong 16 GB -- unlike the loud NoClassDefFound a missing
+                // jdk.security.auth throws. Keep both module lists in sync.
+                "jdk.management",
                 "java.prefs",
                 "jdk.crypto.ec",
                 // jdk.security.auth: provides com.sun.security.auth.module.UnixSystem,
@@ -376,6 +383,10 @@ packaging {
         "java.desktop",
         "java.logging",
         "java.management",
+        // jdk.management: see the matching note in the compose block above. SystemMemory's
+        // RAM read needs com.sun.management's OperatingSystemMXBean; its absence is a silent
+        // 16 GB fallback (mis-sizing the Automatic heap), not a crash. verifyRuntimeModules guards it.
+        "jdk.management",
         "java.prefs",
         "jdk.crypto.ec",
         // See the matching note in the compose.desktop.application block
@@ -428,6 +439,30 @@ packaging {
         // PackagingPlugin's conventions -- omitted intentionally.
     }
 }
+
+// Guard the one jlink module whose omission fails SILENTLY. SystemMemory reads host
+// RAM via com.sun.management's OperatingSystemMXBean (the jdk.management module); drop
+// it from the runtime image and the read falls back to a wrong 16 GB, mis-sizing the
+// Automatic heap with no crash to flag it. A missing jdk.security.auth / jdk.crypto.ec
+// throws NoClassDefFound (loud), so those need no guard. This reads the configured list
+// only -- no jlink or release build -- and is wired into `check`.
+// the<PackagingExtension>() is resolved at Project scope; inside the task lambda `the`
+// would resolve against the Task's own extensions. The config-time .get() snapshot keeps
+// doLast configuration-cache safe -- it closes over a plain List, not the build script.
+val packagingExtension = the<PackagingExtension>()
+val verifyRuntimeModules by tasks.registering {
+    group = "verification"
+    description = "Fails if packaging.modules omits a module runtime reflection needs (jdk.management)."
+    val modules = packagingExtension.modules.get()
+    doLast {
+        require("jdk.management" in modules) {
+            "packaging.modules is missing \"jdk.management\": SystemMemory.totalPhysicalMb() will " +
+                "silently fall back to 16 GB on the packaged build, mis-sizing the Automatic heap."
+        }
+    }
+}
+
+tasks.named("check") { dependsOn(verifyRuntimeModules) }
 
 // Kotlin compiler options for every JVM compile task in client-ui.
 // freeCompilerArgs split into "always on" and "opt-in" groups.

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -452,7 +452,7 @@ packaging {
 val packagingExtension = the<PackagingExtension>()
 val verifyRuntimeModules by tasks.registering {
     group = "verification"
-    description = "Fails if packaging.modules omits a module runtime reflection needs (jdk.management)."
+    description = "Fails if packaging.modules omits a module the runtime read needs (jdk.management)."
     val modules = packagingExtension.modules.get()
     doLast {
         require("jdk.management" in modules) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSurface.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSurface.kt
@@ -68,7 +68,9 @@ fun AboutSurface(onBack: () -> Unit) {
     val updateState      = remember { mutableStateOf<UpdateCheckState>(UpdateCheckState.Idle) }
     val showUpdateDialog = remember { mutableStateOf(false) }
 
-    val systemRam = remember { SystemMemory.totalPhysicalMb() }
+    // OrNull (not the sizing fallback): the System-info card shows "Unknown" on a 0,
+    // so a broken runtime reads as unknown rather than a fabricated 16 GB.
+    val systemRam = remember { SystemMemory.totalPhysicalMbOrNull() ?: 0 }
 
     val displayRes = remember {
         runCatching {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSurface.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/widgets/about/AboutSurface.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import hivens.core.jvm.SystemMemory
 import hivens.launcher.update.UpdateService
 import hivens.ui.components.UpdateDialog
 import hivens.ui.i18n.LocalStrings
@@ -35,7 +36,6 @@ import hivens.widget.model.SlotId
 import hivens.widget.model.SurfaceId
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
-import java.lang.management.ManagementFactory
 
 private const val SURFACE = "about"
 
@@ -51,8 +51,8 @@ private const val SURFACE = "about"
 // UpdateDialog modal lives at the surface level so it survives even
 // if the user removes the update.panel widget via the editor.
 //
-// Pre-computed values (systemRam reflection lookup, displayRes AWT
-// toolkit call) happen once at surface mount and pass into the
+// Pre-computed values (systemRam lookup, displayRes AWT toolkit
+// call) happen once at surface mount and pass into the
 // context -- per-widget recomputation would re-read these on every
 // recomposition.
 //
@@ -68,14 +68,7 @@ fun AboutSurface(onBack: () -> Unit) {
     val updateState      = remember { mutableStateOf<UpdateCheckState>(UpdateCheckState.Idle) }
     val showUpdateDialog = remember { mutableStateOf(false) }
 
-    val systemRam = remember {
-        runCatching {
-            val osBean = ManagementFactory.getOperatingSystemMXBean()
-            val method = osBean.javaClass.getMethod("getTotalPhysicalMemorySize")
-            method.isAccessible = true
-            ((method.invoke(osBean) as Long) / (1024 * 1024)).toInt()
-        }.getOrDefault(0)
-    }
+    val systemRam = remember { SystemMemory.totalPhysicalMb() }
 
     val displayRes = remember {
         runCatching {


### PR DESCRIPTION
## Problem
`SystemMemory.totalPhysicalMb()` reads host RAM from com.sun.management's `OperatingSystemMXBean`, whose accessor lives in the `jdk.management` JDK module. That module was absent from both jlink module lists, so on the packaged (jlinked) runtime the read fell back to a 16 GB constant. The Automatic heap tier was then sized for a 16 GB machine regardless of the real host -- a 24 GB box got `0.6 * 16384` instead of detecting 24 GB. Dev builds (full JDK) worked, which is why it slipped through.

## Fix
- Add `jdk.management` to both module lists (the legacy compose `nativeDistributions` list and the authoritative `packaging.modules`).
- Read RAM through the typed `OperatingSystemMXBean.totalMemorySize` instead of impl-class reflection. The old reflection swallowed failure into a silent 16 GB; the typed read degrades to the fallback only on a `LinkageError` (module genuinely absent) and logs a warning, so it is no longer silent.
- `verifyRuntimeModules`: a `check`-wired Gradle task that fails the build if `packaging.modules` drops `jdk.management` -- the one runtime-reflection module whose absence is silent rather than a loud `NoClassDefFound`. Reads the configured list only, no jlink/release build.
- `AboutSurface` carried its own copy of the bean reflection (same latent bug); route it through `SystemMemory` so one hardened reader serves every caller.

## Verification
- `:client-core:test` green (incl. a `SystemMemory` read test).
- `verifyRuntimeModules` proven both ways: fails when `jdk.management` is removed, passes with it present.
- `:client-ui:compileKotlinDesktop` green.