### PR TITLE
feat(profiler): detect ZGC/Shenandoah live set + flush metrics mid-session

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ libtray           = "0.1.0"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"
+junit             = "5.11.4"
+junitPlatform     = "1.11.4"
 
 [libraries]
 # Logging
@@ -100,6 +102,8 @@ libtray                          = { group = "dev.hivens", name = "libtray", ver
 
 # Test
 mockk                            = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+junit-jupiter                    = { group = "org.junit.jupiter",  name = "junit-jupiter",           version.ref = "junit" }
+junit-platform-launcher          = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatform" }
 
 # KSP processor API (used by :widget-processor to scan @Widget composables
 # and emit GeneratedWidgetRegistry at compile time).

--- a/profiler-agent/build.gradle.kts
+++ b/profiler-agent/build.gradle.kts
@@ -2,6 +2,18 @@ plugins {
     java
 }
 
+dependencies {
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+// JUnit 5 for the agent's own tests (the GC-classification table). Test compile
+// is still pinned to release 8 by the block below -- fine, JUnit 5 is Java 8
+// compatible; only the JVM that RUNS the tests is JDK 25.
+tasks.test {
+    useJUnitPlatform()
+}
+
 // This jar is a -javaagent that loads into the GAME JVM, not the launcher.
 // Legacy SmartyCraft packs (1.7.10 / 1.12.2) run on Java 8, so the agent must
 // be Java 8 bytecode (class major 52) or it throws UnsupportedClassVersionError

--- a/profiler-agent/src/main/java/hivens/profiler/agent/ProfilerAgent.java
+++ b/profiler-agent/src/main/java/hivens/profiler/agent/ProfilerAgent.java
@@ -19,6 +19,9 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -27,8 +30,8 @@ import javax.management.openmbean.CompositeData;
 
 /**
  * Nexira heap-profiler agent. Loads into the game JVM and only OBSERVES: it
- * sums post-GC heap usage (the live set) on major collections and accumulates
- * GC pause time, then writes a small JSON summary on shutdown. No bytecode
+ * sums post-GC heap usage (the live set) on whole-heap collections and
+ * accumulates GC pause time, then writes a small JSON summary. No bytecode
  * transform, no contact with mods -- the server's integrity checks see an
  * ordinary client.
  *
@@ -36,6 +39,10 @@ import javax.management.openmbean.CompositeData;
  * legacy 1.7.10 / 1.12.2 packs (Java 8) and modern packs (Java 17+). It writes
  * nothing to stdout/stderr (the launcher scrapes the game console) and swallows
  * every error -- a profiler must never take the game down.
+ *
+ * The summary is written periodically (every {@link #FLUSH_INTERVAL_SECONDS} s)
+ * as well as on shutdown, so a hard exit that skips the shutdown hook (Forge
+ * {@code Runtime.halt}, a native crash) still leaves a recent file behind.
  */
 public final class ProfilerAgent {
 
@@ -47,8 +54,15 @@ public final class ProfilerAgent {
     private static final AtomicLong gcCount = new AtomicLong(0L);
     private static final AtomicLong gcPauseTotalMs = new AtomicLong(0L);
     private static final AtomicBoolean liveSetReliable = new AtomicBoolean(false);
-    private static final AtomicBoolean written = new AtomicBoolean(false);
     private static final Set<String> heapPools = new HashSet<String>();
+
+    /** Serializes the periodic flush against the final shutdown write so the two
+     *  threads never race on the shared {@code <out>.tmp} staging file. */
+    private static final Object WRITE_LOCK = new Object();
+
+    /** Snapshot cadence. A halted JVM still leaves an at-most-this-old file even
+     *  when the shutdown hook never runs. */
+    private static final long FLUSH_INTERVAL_SECONDS = 30L;
 
     /** JVM agent entry point (Premain-Class in the jar manifest). */
     public static void premain(String agentArgs, Instrumentation inst) {
@@ -78,7 +92,18 @@ public final class ProfilerAgent {
                 }
             }
 
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> writeOnce(outPath), "nexira-profiler-writer"));
+            ScheduledExecutorService flusher = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "nexira-profiler-flush");
+                t.setDaemon(true); // a profiler thread must never hold the game JVM open
+                return t;
+            });
+            flusher.scheduleWithFixedDelay(
+                () -> writeSnapshot(outPath), FLUSH_INTERVAL_SECONDS, FLUSH_INTERVAL_SECONDS, TimeUnit.SECONDS);
+
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                flusher.shutdownNow();
+                writeSnapshot(outPath); // final, up-to-the-moment snapshot on a clean exit
+            }, "nexira-profiler-writer"));
         } catch (Throwable ignored) {
             // An agent must never take the game down. Stay silent.
         }
@@ -96,12 +121,11 @@ public final class ProfilerAgent {
             updateMax(peakHeapBytes, sumHeapUsed(before));
         }
 
-        // Live set = heap retained after a MAJOR (old-gen) collection. Minor GCs
-        // leave old-gen garbage uncollected, so their after-usage over-counts.
-        // A collector that never reports a "major" action simply leaves the live
-        // set unreliable, and the launcher then keeps the current heap (safe).
-        String action = info.getGcAction();
-        if (action != null && action.toLowerCase(Locale.ROOT).contains("major")) {
+        // Live set = heap retained after a WHOLE-HEAP (old-gen-inclusive) collection.
+        // Minor GCs leave old-gen garbage uncollected, so their after-usage over-counts.
+        // A collector that never reports a whole-heap collection simply leaves the live
+        // set unreliable, and the launcher then leans on the peak term instead (safe).
+        if (isWholeHeapCollection(info.getGcAction(), info.getGcName())) {
             Map<String, MemoryUsage> after = gc.getMemoryUsageAfterGc();
             if (after != null) {
                 long live = sumHeapUsed(after);
@@ -111,6 +135,26 @@ public final class ProfilerAgent {
                 }
             }
         }
+    }
+
+    /**
+     * True when a GC notification ends a whole-heap (old-gen-inclusive) collection,
+     * where post-GC heap usage approximates the live set. The generational
+     * collectors say so in the action ("end of major GC"); the concurrent ones whose
+     * action never carries "major" are matched by name instead -- a ZGC *major* cycle
+     * or a single-generation Shenandoah cycle ends with "end of GC cycle", while a ZGC
+     * *minor* cycle (young only) carries "Minor" in its name and is excluded, as are
+     * the STW pause sub-events ("end of GC pause"). Verified against the
+     * G1 / Parallel / ZGC / Shenandoah notifications on JDK 25.
+     */
+    static boolean isWholeHeapCollection(String action, String name) {
+        if (action == null) return false;
+        String a = action.toLowerCase(Locale.ROOT);
+        if (a.contains("major")) return true;   // G1 / Parallel / CMS / Serial old gen
+        if (!a.contains("cycle")) return false;  // young GCs + STW pause sub-events
+        // A whole-heap concurrent cycle (ZGC Major Cycles, Shenandoah Cycles) -- but not
+        // a ZGC Minor cycle, whose after-usage is young-only.
+        return name == null || !name.toLowerCase(Locale.ROOT).contains("minor");
     }
 
     private static long sumHeapUsed(Map<String, MemoryUsage> usage) {
@@ -130,34 +174,41 @@ public final class ProfilerAgent {
         }
     }
 
-    private static void writeOnce(Path outPath) {
-        if (!written.compareAndSet(false, true)) return;
-        try {
-            long sessionMs = System.currentTimeMillis() - START_MS;
-            long ranXmxMb = Runtime.getRuntime().maxMemory() / (1024L * 1024L);
-            long liveMb = liveSetMaxBytes.get() / (1024L * 1024L);
-            long peakMb = peakHeapBytes.get() / (1024L * 1024L);
-            String json = "{\n"
-                + "  \"schema_version\": 1,\n"
-                + "  \"liveSetMb\": " + liveMb + ",\n"
-                + "  \"gcPauseTotalMs\": " + gcPauseTotalMs.get() + ",\n"
-                + "  \"gcCount\": " + gcCount.get() + ",\n"
-                + "  \"sessionMs\": " + sessionMs + ",\n"
-                + "  \"peakHeapMb\": " + peakMb + ",\n"
-                + "  \"ranXmxMb\": " + ranXmxMb + ",\n"
-                + "  \"liveSetReliable\": " + liveSetReliable.get() + "\n"
-                + "}\n";
-            Path parent = outPath.getParent();
-            if (parent != null) Files.createDirectories(parent);
-            Path tmp = outPath.resolveSibling(outPath.getFileName().toString() + ".tmp");
-            Files.write(tmp, json.getBytes(StandardCharsets.UTF_8));
+    /**
+     * Writes the current metrics to {@code outPath} atomically (tmp + ATOMIC_MOVE), so a
+     * reader never sees a partial file. Repeatable -- the periodic flusher and the
+     * shutdown hook both call it; {@link #WRITE_LOCK} serializes them against the shared
+     * tmp file.
+     */
+    private static void writeSnapshot(Path outPath) {
+        synchronized (WRITE_LOCK) {
             try {
-                Files.move(tmp, outPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-            } catch (AtomicMoveNotSupportedException e) {
-                Files.move(tmp, outPath, StandardCopyOption.REPLACE_EXISTING);
+                long sessionMs = System.currentTimeMillis() - START_MS;
+                long ranXmxMb = Runtime.getRuntime().maxMemory() / (1024L * 1024L);
+                long liveMb = liveSetMaxBytes.get() / (1024L * 1024L);
+                long peakMb = peakHeapBytes.get() / (1024L * 1024L);
+                String json = "{\n"
+                    + "  \"schema_version\": 1,\n"
+                    + "  \"liveSetMb\": " + liveMb + ",\n"
+                    + "  \"gcPauseTotalMs\": " + gcPauseTotalMs.get() + ",\n"
+                    + "  \"gcCount\": " + gcCount.get() + ",\n"
+                    + "  \"sessionMs\": " + sessionMs + ",\n"
+                    + "  \"peakHeapMb\": " + peakMb + ",\n"
+                    + "  \"ranXmxMb\": " + ranXmxMb + ",\n"
+                    + "  \"liveSetReliable\": " + liveSetReliable.get() + "\n"
+                    + "}\n";
+                Path parent = outPath.getParent();
+                if (parent != null) Files.createDirectories(parent);
+                Path tmp = outPath.resolveSibling(outPath.getFileName().toString() + ".tmp");
+                Files.write(tmp, json.getBytes(StandardCharsets.UTF_8));
+                try {
+                    Files.move(tmp, outPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(tmp, outPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (Throwable ignored) {
+                // best-effort: a failed metrics write must never surface to the user
             }
-        } catch (Throwable ignored) {
-            // best-effort: a failed metrics write must never surface to the user
         }
     }
 }

--- a/profiler-agent/src/test/java/hivens/profiler/agent/ProfilerAgentTest.java
+++ b/profiler-agent/src/test/java/hivens/profiler/agent/ProfilerAgentTest.java
@@ -1,0 +1,46 @@
+package hivens.profiler.agent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks {@link ProfilerAgent#isWholeHeapCollection} against the (gcName, gcAction)
+ * pairs observed from the real GC notifications on JDK 25. If a future JDK renames
+ * these, re-probe the collectors and update the classifier and this table together.
+ */
+class ProfilerAgentTest {
+
+    @Test
+    void generationalOldGenCounts() {
+        assertTrue(ProfilerAgent.isWholeHeapCollection("end of major GC", "G1 Old Generation"));
+        assertTrue(ProfilerAgent.isWholeHeapCollection("end of major GC", "PS MarkSweep"));
+    }
+
+    @Test
+    void concurrentWholeHeapCyclesCount() {
+        assertTrue(ProfilerAgent.isWholeHeapCollection("end of GC cycle", "ZGC Major Cycles"));
+        assertTrue(ProfilerAgent.isWholeHeapCollection("end of GC cycle", "Shenandoah Cycles"));
+    }
+
+    @Test
+    void youngAndMinorCollectionsDoNotCount() {
+        assertFalse(ProfilerAgent.isWholeHeapCollection("end of minor GC", "G1 Young Generation"));
+        assertFalse(ProfilerAgent.isWholeHeapCollection("end of minor GC", "PS Scavenge"));
+        assertFalse(ProfilerAgent.isWholeHeapCollection("end of GC cycle", "ZGC Minor Cycles"));
+    }
+
+    @Test
+    void stwPauseSubEventsDoNotCount() {
+        assertFalse(ProfilerAgent.isWholeHeapCollection("end of GC pause", "ZGC Major Pauses"));
+        assertFalse(ProfilerAgent.isWholeHeapCollection("Init Mark", "Shenandoah Pauses"));
+        assertFalse(ProfilerAgent.isWholeHeapCollection("end of concurrent GC pause", "G1 Concurrent GC"));
+    }
+
+    @Test
+    void nullActionIsSafeAndNullNameIsAllowed() {
+        assertFalse(ProfilerAgent.isWholeHeapCollection(null, "anything"));
+        assertTrue(ProfilerAgent.isWholeHeapCollection("end of major GC", null));
+    }
+}


### PR DESCRIPTION
## Problem
The profiler agent recorded a live set only on collectors whose GC action says "major" (G1, Parallel, CMS, Serial). ZGC and Shenandoah never do -- a ZGC major cycle and a Shenandoah cycle both report "end of GC cycle" -- so on a modern pack (or a Cleanroom-on-Java-25 legacy pack) `liveSetReliable` stayed false and the deriver had only the peak term. Separately, the metrics file was written only from the shutdown hook, so a hard exit that skips it (Forge `Runtime.halt`, a native crash) lost the whole session.

## Fix
- `isWholeHeapCollection` broadens whole-heap detection: "major" in the GC action, or an "end of GC cycle" whose gc name is not a ZGC *minor* cycle (young-only). The (name, action) pairs were read from the real GC notifications on JDK 25 and are locked in `ProfilerAgentTest`.
- A daemon flusher writes the metrics file every 30s, not only on the shutdown hook. Writes are serialized (one lock) and atomic (tmp + ATOMIC_MOVE), so a reader never sees a partial file.
- First tests in `:profiler-agent` (JUnit 5).

## Verification
Ran the agent end-to-end with `-javaagent` + a churn driver under each collector on JDK 25:

| collector | liveSetReliable | liveSetMb |
|---|---|---|
| G1 | true | 95 |
| Parallel | true | 95 |
| ZGC | true (was false) | 142 |
| Shenandoah | true (was false) | 112 |

- Periodic flush: a 120s session SIGKILLed at t=35s left a `sessionMs=30096` snapshot, written by the t=30s flush with no shutdown hook.
- `:profiler-agent:test` green; the agent class stays Java 8 bytecode (major 52).