### PR TITLE
feat(launcher): join SmartyCraft-bound packs (SC-patched authlib + open-smrt)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,15 @@ fun getGitVersion(providerFactory: ProviderFactory): String {
     return try {
         val version = providerFactory.exec {
             commandLine("git", "describe", "--tags", "--always", "--dirty")
-        }.standardOutput.asText.get().trim()
+        }.standardOutput.asText.get().trim().removePrefix("v")
 
-        version.removePrefix("v")
+        // `--always` falls back to a bare commit SHA when no tag is reachable
+        // (the test CI does a shallow, no-tags checkout). A SHA carries no dotted
+        // version component, and an all-numeric short SHA would otherwise parse as
+        // a single huge version number and invert every version comparison. Treat
+        // "no reachable tag" as an unknown 0.0.0 build (no prerelease suffix, so
+        // it stays a clean lower bound for comparisons).
+        if (version.contains('.')) version else "0.0.0"
     } catch (e: Exception) {
         println("Git version lookup failed: ${e.message}")
         "0.0.0-dev"

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -8,6 +8,7 @@ import hivens.core.data.FileManifest
 import hivens.core.data.SessionData
 import hivens.core.util.ZipUtils
 import hivens.core.util.retryWithBackoff
+import hivens.launcher.smrt.ModInjector
 import hivens.launcher.util.ClientRootDirs
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -113,7 +114,7 @@ class FileDownloadService(
             strictPruneMods(targetDir, strictAllowed, injectName, helperKeepGlobs)
         }
         if (injectModJar != null) {
-            injectHelperJar(targetDir, injectModJar)
+            ModInjector.injectHelperJar(targetDir, injectModJar)
         }
 
         // ── Manifest cache short-circuit ─────────────────────────────────
@@ -235,7 +236,7 @@ class FileDownloadService(
         val modsDir = baseDir.resolve("mods")
         if (!Files.isDirectory(modsDir)) return
 
-        val keepPatterns = helperKeepGlobs.map { globToRegex(it) }
+        val keepPatterns = helperKeepGlobs.map { ModInjector.globToRegex(it) }
         val baseNorm = baseDir.normalize()
 
         var removed = 0
@@ -262,39 +263,6 @@ class FileDownloadService(
             logger.error("Strict mod check: error walking mods folder", e)
         }
         if (removed > 0) logger.info("Strict mod check: pruned {} foreign jar(s) from mods/", removed)
-    }
-
-    private fun globToRegex(glob: String): Regex {
-        val sb = StringBuilder()
-        for (c in glob) {
-            when (c) {
-                '*' -> sb.append(".*")
-                '?' -> sb.append('.')
-                else -> sb.append(Regex.escape(c.toString()))
-            }
-        }
-        return Regex(sb.toString(), RegexOption.IGNORE_CASE)
-    }
-
-    /**
-     * Copies the open-smrt-network helper into `mods/`, replacing the upstream
-     * Smarty coremod the caller stripped via `ignoredFiles`. Always overwrites:
-     * the source bytes were already SHA-256 verified by `OpenSmrtHelperResolver`,
-     * and a size-only skip would miss a same-size helper rebuild. The jar is tiny
-     * (single-digit KB), so an unconditional copy per sync is negligible.
-     */
-    private fun injectHelperJar(baseDir: Path, jar: Path) {
-        if (!Files.isRegularFile(jar)) {
-            logger.warn("open-smrt helper: jar {} missing at inject time; skipping", jar)
-            return
-        }
-        runCatching {
-            val modsDir = baseDir.resolve("mods")
-            Files.createDirectories(modsDir)
-            val dest = modsDir.resolve(jar.fileName.toString())
-            Files.copy(jar, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
-            logger.info("open-smrt helper: injected {}", dest.fileName)
-        }.onFailure { logger.warn("open-smrt helper: failed to inject {}", jar, it) }
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -9,6 +9,7 @@ import hivens.core.data.HeapProfile
 import hivens.core.data.InstanceProfile
 import hivens.core.data.InstanceRuntime
 import hivens.core.data.LauncherLogType
+import hivens.core.data.PackAuthRequirement
 import hivens.core.data.SessionData
 import hivens.core.jvm.AutomaticHeap
 import hivens.core.jvm.HeapDeriver
@@ -17,7 +18,14 @@ import hivens.launcher.component.ClasspathProvider
 import hivens.launcher.component.EnvironmentPreparer
 import hivens.launcher.component.GameCommandBuilder
 import hivens.launcher.component.ProcessLogHandler
+import hivens.launcher.launch.LaunchError
+import hivens.launcher.launch.PackPrepBlocked
 import hivens.launcher.runtime.RuntimeProvisioner
+import hivens.launcher.runtime.loader.ResolvedLibrary
+import hivens.launcher.runtime.loader.ResolvedRuntime
+import hivens.launcher.smrt.ModInjector
+import hivens.launcher.smrt.OpenSmrtHelperResolver
+import hivens.launcher.smrt.SmrtAuthlibSwapper
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.nio.file.Files
@@ -41,6 +49,8 @@ internal class LauncherService(
     private val runtimeProvisioner: RuntimeProvisioner,
     private val profilerStore: ProfilerProfileStore,
     private val agentExtractor: AgentExtractor,
+    private val authlibSwapper: SmrtAuthlibSwapper,
+    private val openSmrtResolver: OpenSmrtHelperResolver,
     private val sharedAssetsDir: Path,
     private val sharedLibrariesDir: Path,
 ) : ILauncherService {
@@ -145,11 +155,16 @@ internal class LauncherService(
         // Java major can drive JDK provisioning -- same MC version on a different
         // loader needs a different JDK (Cleanroom-1.12.2 wants 25, not 8).
         val nativesDir = commandBuilder.packNativesDir(mcVersion)
-        val resolved = runtimeProvisioner.ensureRuntime(
+        val baseRuntime = runtimeProvisioner.ensureRuntime(
             mcVersion = mcVersion,
             loaderName = manifest.loaderName,
             loaderVersion = manifest.loaderVersion,
         ) { current, total, file -> onLog("Runtime $current/$total: $file", LauncherLogType.INFO) }
+
+        // 2b. SC binding: an SC-bound pack provisions the VANILLA authlib (sends the
+        // join to Mojang -> 403 for an SC token), so swap in SC's patched authlib
+        // and inject the open-smrt interop helper. No-op for Hivens-native packs.
+        val resolved = applySmrtBinding(manifest, sessionData, clientRootPath, mcVersion, baseRuntime, onLog)
 
         // 3. Java. Major precedence: loader-resolved override -> the pack manifest's
         // own declaration (authoritative for the pack) -> Mojang's per-version field
@@ -195,6 +210,64 @@ internal class LauncherService(
         )
 
         return spawnProcess(command, clientRootPath, onLog)
+    }
+
+    /**
+     * Applies SC-binding to a freshly provisioned pack [runtime]: returns it
+     * unchanged for non-SC packs; for an SC-bound pack swaps the vanilla authlib
+     * classpath entry to SC's patched jar and injects the open-smrt-network
+     * helper into the instance mods. Throws [PackPrepBlocked] (mapped to a
+     * [LaunchError] by the controller) ONLY when the patched authlib cannot be
+     * sourced -- without it the join is a guaranteed rejection. The open-smrt
+     * helper is best-effort interop (a miss only degrades connection stability),
+     * so it never blocks the launch.
+     *
+     * The patched authlib comes from the SC session's own file manifest
+     * ([SessionData.fileManifest], populated by the pre-spawn re-auth), so it is
+     * pulled from the same distribution the `clients/` cache already uses -- nothing of
+     * SC's is rehosted. Only the resolved classpath entry is rewritten; the
+     * shared `libraries/` root stays vanilla (a patched jar there would hit every
+     * pack of that MC version and be reverted by the provisioner's size check).
+     */
+    private suspend fun applySmrtBinding(
+        manifest: CachedManifestSnapshot,
+        sessionData: SessionData,
+        clientRootPath: Path,
+        mcVersion: String,
+        runtime: ResolvedRuntime,
+        onLog: (String, LauncherLogType) -> Unit,
+    ): ResolvedRuntime {
+        val requirement = manifest.authRequirement
+        if (requirement !is PackAuthRequirement.SmartyCraft) return runtime
+
+        // authlib swap: intrinsic to SC-bound packs (no toggle -- vanilla authlib
+        // is a guaranteed 403, there is no "original works" alternative).
+        val authlib = findAuthlibLibrary(runtime)
+            ?: throw PackPrepBlocked(LaunchError.AuthlibUnavailable(mcVersion))
+        val patched = authlibSwapper.ensurePatchedAuthlib(requirement.serverId, sessionData.fileManifest)
+            ?: throw PackPrepBlocked(LaunchError.AuthlibUnavailable(mcVersion))
+        onLog("Using SmartyCraft authlib for ${requirement.serverId}", LauncherLogType.INFO)
+        val bound = swapAuthlibPath(runtime, authlib, patched)
+
+        // open-smrt-network helper: always attempted for an SC-bound pack (no toggle --
+        // a pack ships no proprietary Smarty, so the server-list useOpenSmrtHelper
+        // choice of "keep the original" is meaningless here). But this is interop
+        // infrastructure, NOT an auth gate: without it the SC connection may be less
+        // stable, the join itself is not rejected. So a resolve miss is best-effort
+        // (log + continue), never a block -- the authlib swap above is the only hard
+        // requirement.
+        val helper = openSmrtResolver.resolve(mcVersion)
+        if (helper != null) {
+            ModInjector.stripByGlobs(clientRootPath, helper.smartyNames)
+            ModInjector.injectHelperJar(clientRootPath, helper.jar)
+            onLog("Injected open-smrt-network helper", LauncherLogType.INFO)
+        } else {
+            onLog(
+                "open-smrt-network helper unavailable for $mcVersion; joining without it (connection may be less stable)",
+                LauncherLogType.WARN,
+            )
+        }
+        return bound
     }
 
     /**
@@ -265,6 +338,14 @@ internal class LauncherService(
     }
 
     internal companion object {
+        /** The vanilla `com.mojang:authlib` classpath entry in [runtime], or null if absent. */
+        internal fun findAuthlibLibrary(runtime: ResolvedRuntime): ResolvedLibrary? =
+            runtime.libraries.firstOrNull { it.coord.group == "com.mojang" && it.coord.artifact == "authlib" }
+
+        /** [runtime] with [target]'s path repointed to [newPath]; every other entry left as-is. */
+        internal fun swapAuthlibPath(runtime: ResolvedRuntime, target: ResolvedLibrary, newPath: Path): ResolvedRuntime =
+            runtime.copy(libraries = runtime.libraries.map { if (it === target) it.copy(path = newPath) else it })
+
         /**
          * Memory allocation rule: profile's per-instance value wins when positive,
          * otherwise the launcher's globally allocated value is used. Anything below

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -46,6 +46,7 @@ import hivens.launcher.cache.CacheFactory
 import hivens.launcher.cache.SmrtPackCaches
 import hivens.launcher.smrt.OpenSmrtHelperResolver
 import hivens.launcher.smrt.SmartyModPlanner
+import hivens.launcher.smrt.SmrtAuthlibSwapper
 import hivens.launcher.smrt.SmrtPackClient
 import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.update.UpdateApplicators
@@ -448,6 +449,9 @@ val appModule = module {
     // both sync paths (LauncherController, AutoSyncService) consult.
     single { OpenSmrtHelperResolver(get(named("direct")), get(), get()) }
     single { SmartyModPlanner(get<OpenSmrtHelperResolver>()::resolve, get()) }
+    // SC-bound pack authlib swap. Default (smartycraft) channel: the patched jar
+    // is pulled from the SC client distribution, same source as the server-list sync.
+    single { SmrtAuthlibSwapper(get(), get<ServerProtocolConfig>(), get()) }
     single { PackInstaller(syncService = get(), runtimeProvisioner = get(), repository = get(), dataDir = get()) }
     single {
         MrpackInstaller(
@@ -626,6 +630,8 @@ val appModule = module {
             runtimeProvisioner = get(),
             profilerStore      = get(),
             agentExtractor     = get(),
+            authlibSwapper     = get(),
+            openSmrtResolver   = get(),
             sharedAssetsDir    = get<PlatformPaths>().assetsDir,
             sharedLibrariesDir = get<PlatformPaths>().librariesDir,
         )

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LaunchError.kt
@@ -38,6 +38,15 @@ sealed class LaunchError {
     data class HelperUnavailable(val mcVersion: String) : LaunchError()
 
     /**
+     * An SC-bound pack needs SmartyCraft's patched authlib (the vanilla one
+     * provisioned from official CDNs sends the join to Mojang and is rejected),
+     * but it could not be sourced from the SC client distribution for
+     * [mcVersion] (no manifest entry / network error / hash mismatch). The
+     * launch is blocked rather than spawning a guaranteed join rejection.
+     */
+    data class AuthlibUnavailable(val mcVersion: String) : LaunchError()
+
+    /**
      * Pack declares an auth requirement the user has no live session
      * for. The UI renders a "sign in with <provider> to play this
      * pack" hint -- distinct from [AuthFail] (where the user IS

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -505,7 +505,11 @@ class LauncherController(
 
                 val process = launcherService.launchPackClient(
                     sessionData          = session,
-                    manifest             = manifestSnapshot,
+                    // Carry the EFFECTIVE requirement (manifest value or the
+                    // name-based fallback) so the service's SC-binding step sees it;
+                    // the raw snapshot's authRequirement is null for packs whose
+                    // mirror manifest has no auth block yet (e.g. Industrial).
+                    manifest             = manifestSnapshot.copy(authRequirement = authRequirement),
                     runtime              = refreshedInstance.runtime,
                     clientRootPath       = clientDir,
                     javaPathOverride     = javaOverride,
@@ -540,6 +544,12 @@ class LauncherController(
                     _state.value = LaunchState.Idle
                 }
 
+            } catch (e: PackPrepBlocked) {
+                // SC-binding step could not complete (patched authlib / open-smrt
+                // helper unavailable). Surface the semantic reason, not Internal.
+                runningProcess = null
+                logger.warn("Pack launch blocked for {}: {}", packInstance.displayName, e.error)
+                fail(e.error)
             } catch (e: Exception) {
                 runningProcess = null
                 if (e !is CancellationException) {

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/PackPrepBlocked.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/PackPrepBlocked.kt
@@ -1,0 +1,9 @@
+package hivens.launcher.launch
+
+/**
+ * Thrown from the pack launch service when an SC-bound preparation step cannot
+ * complete (patched authlib or open-smrt helper unavailable). Carries the
+ * semantic [error] so the controller maps it to the right [LaunchError] surface
+ * instead of the generic [LaunchError.Internal].
+ */
+class PackPrepBlocked(val error: LaunchError) : Exception()

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/ModInjector.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/ModInjector.kt
@@ -1,0 +1,85 @@
+package hivens.launcher.smrt
+
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Shared `mods/` mutation behind the Smarty -> open-smrt swap. Both call sites --
+ * the server-list sync ([hivens.launcher.FileDownloadService]) and the SC-bound
+ * pack launch ([hivens.launcher.LauncherService]) -- inject the helper jar and
+ * strip the surveillance Smarty jar through one implementation, so the two paths
+ * can never drift on "what counts as a Smarty jar" or "where the helper lands".
+ */
+object ModInjector {
+    private val logger = LoggerFactory.getLogger(ModInjector::class.java)
+
+    /**
+     * Copies the open-smrt-network helper into `<baseDir>/mods/`, replacing any
+     * prior copy. Always overwrites: the source bytes were already hash-verified
+     * by the resolver, and a size-only skip would miss a same-size helper rebuild.
+     * The jar is tiny, so an unconditional copy per launch is negligible. No-op
+     * when the source is missing.
+     */
+    fun injectHelperJar(baseDir: Path, jar: Path) {
+        if (!Files.isRegularFile(jar)) {
+            logger.warn("open-smrt helper: jar {} missing at inject time; skipping", jar)
+            return
+        }
+        runCatching {
+            val modsDir = baseDir.resolve("mods")
+            Files.createDirectories(modsDir)
+            val dest = modsDir.resolve(jar.fileName.toString())
+            Files.copy(jar, dest, StandardCopyOption.REPLACE_EXISTING)
+            logger.info("open-smrt helper: injected {}", dest.fileName)
+        }.onFailure { logger.warn("open-smrt helper: failed to inject {}", jar, it) }
+    }
+
+    /**
+     * Deletes every jar under `<baseDir>/mods/` whose basename matches one of
+     * [globs] (e.g. `Smarty*.jar`). Used to strip the upstream surveillance jar
+     * before injecting the helper, on paths that do NOT run exact manifest
+     * verification (the pack path, whose mods are pack-managed and must not be
+     * blanket-pruned). The recursive walk covers top-level `mods/` and version
+     * subdirs. Returns the number removed.
+     */
+    fun stripByGlobs(baseDir: Path, globs: List<String>): Int {
+        val modsDir = baseDir.resolve("mods")
+        if (globs.isEmpty() || !Files.isDirectory(modsDir)) return 0
+        val patterns = globs.map { globToRegex(it) }
+        var removed = 0
+        try {
+            Files.walk(modsDir).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".jar") }
+                    .forEach { jar ->
+                        if (patterns.any { it.matches(jar.fileName.toString()) }) {
+                            runCatching {
+                                Files.delete(jar)
+                                removed++
+                                logger.debug("Smarty strip: removed {}", jar)
+                            }.onFailure { logger.warn("Smarty strip: failed to remove {}", jar, it) }
+                        }
+                    }
+            }
+        } catch (e: Exception) {
+            logger.error("Smarty strip: error walking mods folder", e)
+        }
+        if (removed > 0) logger.info("Smarty strip: removed {} upstream jar(s) from mods/", removed)
+        return removed
+    }
+
+    /** Converts a `*`/`?` filename glob to a case-insensitive [Regex]. */
+    fun globToRegex(glob: String): Regex {
+        val sb = StringBuilder()
+        for (c in glob) {
+            when (c) {
+                '*' -> sb.append(".*")
+                '?' -> sb.append('.')
+                else -> sb.append(Regex.escape(c.toString()))
+            }
+        }
+        return Regex(sb.toString(), RegexOption.IGNORE_CASE)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapper.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapper.kt
@@ -1,0 +1,187 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.data.FileData
+import hivens.core.data.FileManifest
+import hivens.core.util.retryWithBackoff
+import hivens.launcher.network.ServerProtocolConfig
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.URLEncoder
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+
+/**
+ * Supplies the SmartyCraft-patched `authlib` jar for an SC-bound pack launch.
+ *
+ * A pack runtime is provisioned from official CDNs, so it ships the VANILLA
+ * authlib, which sends the in-game join to `sessionserver.mojang.com` and is
+ * rejected (403) for an SC session token. SC's own client ships a patched authlib
+ * (same Maven artifact, different bytes) that redirects the join to SC's
+ * `auth_joinserver.php`. That patched jar is part of the SC client file set the
+ * server distributes -- the exact source the server-list path already pulls into
+ * the `clients/` cache. We fetch it for the bound serverId straight from that
+ * distribution and cache it per server, so nothing of SC's is rehosted.
+ *
+ * The caller swaps the resolved classpath entry to the returned jar; the shared
+ * `libraries` root is never touched (a patched jar there would hit every pack of
+ * that MC version and be re-downloaded back to vanilla by the runtime
+ * provisioner's size check).
+ *
+ * Every failure path returns null: no manifest, no matching entry, network error,
+ * or md5 mismatch all mean "no patched authlib" -- the caller then blocks the
+ * launch rather than spawning a guaranteed 403.
+ */
+class SmrtAuthlibSwapper(
+    private val clientProvider: HttpClientProvider,
+    private val config: ServerProtocolConfig,
+    dataDirectory: Path,
+) {
+    private val log = LoggerFactory.getLogger(SmrtAuthlibSwapper::class.java)
+    private val cacheRoot = dataDirectory.resolve("smrt-authlib")
+    private val client get() = clientProvider.current
+
+    /**
+     * Returns the local path to the SC-patched authlib for [serverId], downloading
+     * + md5-verifying it from the SC client distribution on a cold cache, or null
+     * when it cannot be located or verified. Idempotent: a warm cache costs one md5.
+     *
+     * The authlib is matched by ARTIFACT, not by an expected filename: SC freezes
+     * its own authlib version per MC release, which can differ from the
+     * vanilla-provisioned one (e.g. `authlib-1.5.21.jar` vs `authlib-1.5.25.jar`).
+     * The patched jar is cached + returned under its own SC filename; the caller
+     * points the classpath entry at it regardless of the vanilla entry's name.
+     */
+    suspend fun ensurePatchedAuthlib(
+        serverId: String,
+        fileManifest: FileManifest?,
+    ): Path? = withContext(Dispatchers.IO) {
+        val manifest = fileManifest ?: run {
+            log.warn("authlib swap: no file manifest for '{}'; cannot source patched authlib", serverId)
+            return@withContext null
+        }
+        val entry = findAuthlibEntry(manifest) ?: run {
+            log.warn("authlib swap: no authlib jar under libraries in SC manifest for '{}'", serverId)
+            return@withContext null
+        }
+        val (rawPath, data) = entry
+        val fileName = rawPath.substringAfterLast('/')
+        val dest = cacheRoot.resolve(sanitize(serverId)).resolve(fileName)
+
+        if (verifies(dest, data.md5)) return@withContext dest
+
+        return@withContext try {
+            Files.createDirectories(dest.parent)
+            val url = "${config.clientFilesBase}/" +
+                rawPath.split("/").joinToString("/") { URLEncoder.encode(it, "UTF-8").replace("+", "%20") }
+            log.info("authlib swap: downloading {} <- {}", fileName, url)
+            // The SC SOCKS channel drops mid-stream periodically; this jar is
+            // mandatory (a miss blocks the launch), so retry transient failures.
+            retryWithBackoff(
+                operation = "authlib $fileName",
+                shouldRetry = { it !is CancellationException },
+            ) {
+                downloadToFile(url, dest)
+            }
+            if (verifies(dest, data.md5)) {
+                dest
+            } else {
+                log.warn(
+                    "authlib swap: md5 mismatch for {} (expected {}, got {}); discarding",
+                    fileName, data.md5, md5Of(dest),
+                )
+                Files.deleteIfExists(dest)
+                null
+            }
+        } catch (e: Exception) {
+            log.warn("authlib swap: download failed for {}", fileName, e)
+            runCatching { Files.deleteIfExists(dest) }
+            null
+        }
+    }
+
+    /**
+     * Finds the manifest entry for the authlib jar (basename `authlib-<ver>.jar`)
+     * that sits under a `libraries`-rooted path (the SC client keeps authlib at
+     * `libraries-<mc>/authlib-<ver>.jar`), returning its raw manifest path +
+     * [FileData]. Restricting to a libraries path avoids matching an unrelated mod
+     * that happens to share the prefix.
+     */
+    private fun findAuthlibEntry(manifest: FileManifest): Pair<String, FileData>? {
+        val flat = LinkedHashMap<String, FileData>()
+        fun walk(m: FileManifest, prefix: String) {
+            m.files.forEach { (name, data) ->
+                flat[if (prefix.isEmpty()) name else "$prefix/$name"] = data
+            }
+            m.directories.forEach { (name, sub) ->
+                walk(sub, if (prefix.isEmpty()) name else "$prefix/$name")
+            }
+        }
+        walk(manifest, "")
+        return flat.entries.firstOrNull { (path, _) ->
+            val segments = path.split("/")
+            val base = segments.lastOrNull() ?: return@firstOrNull false
+            AUTHLIB_JAR.matches(base) && segments.any { it.startsWith("libraries") }
+        }?.toPair()
+    }
+
+    /** True when [p] satisfies [expectedMd5], honouring the SC "any" skip-check sentinel. */
+    private fun verifies(p: Path, expectedMd5: String): Boolean = when {
+        expectedMd5 == "any" -> Files.isRegularFile(p) && Files.size(p) > 0
+        expectedMd5.isBlank() -> false
+        else -> md5Of(p)?.equals(expectedMd5, ignoreCase = true) == true
+    }
+
+    private suspend fun downloadToFile(url: String, dest: Path) {
+        val tmp = dest.resolveSibling("${dest.fileName}.tmp")
+        try {
+            client.prepareGet(url).execute { response ->
+                if (response.status.value != 200) throw IOException("HTTP ${response.status} for $url")
+                val channel = response.bodyAsChannel()
+                FileOutputStream(tmp.toFile()).use { out ->
+                    val buf = ByteArray(64 * 1024)
+                    while (!channel.isClosedForRead) {
+                        val n = channel.readAvailable(buf, 0, buf.size)
+                        if (n <= 0) break
+                        out.write(buf, 0, n)
+                    }
+                }
+            }
+            Files.move(tmp, dest, StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            runCatching { Files.deleteIfExists(tmp) }
+        }
+    }
+
+    private fun md5Of(p: Path): String? {
+        if (!Files.isRegularFile(p)) return null
+        return runCatching {
+            val md = MessageDigest.getInstance("MD5")
+            Files.newInputStream(p).use { input ->
+                val buf = ByteArray(64 * 1024)
+                while (true) {
+                    val n = input.read(buf)
+                    if (n <= 0) break
+                    md.update(buf, 0, n)
+                }
+            }
+            md.digest().joinToString("") { "%02x".format(it) }
+        }.getOrNull()
+    }
+
+    private fun sanitize(id: String): String =
+        id.map { if (it.isLetterOrDigit() || it == '.' || it == '-' || it == '_') it else '_' }.joinToString("")
+
+    private companion object {
+        private val AUTHLIB_JAR = Regex("^authlib-.*\\.jar$", RegexOption.IGNORE_CASE)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapper.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapper.kt
@@ -102,6 +102,11 @@ class SmrtAuthlibSwapper(
                 Files.deleteIfExists(dest)
                 null
             }
+        } catch (e: CancellationException) {
+            // An aborted launch must cancel cleanly, not surface as AuthlibUnavailable
+            // (which would overwrite the abort's Idle state with an error).
+            runCatching { Files.deleteIfExists(dest) }
+            throw e
         } catch (e: Exception) {
             log.warn("authlib swap: download failed for {}", fileName, e)
             runCatching { Files.deleteIfExists(dest) }

--- a/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/LauncherServiceTest.kt
@@ -10,13 +10,21 @@ import hivens.core.data.SessionData
 import hivens.core.api.model.ServerProfile
 import hivens.launcher.LauncherService.Companion.adaptiveApplies
 import hivens.launcher.LauncherService.Companion.baselineMemory
+import hivens.launcher.LauncherService.Companion.findAuthlibLibrary
 import hivens.launcher.LauncherService.Companion.normalizeMemory
 import hivens.launcher.LauncherService.Companion.resolveJavaPath
+import hivens.launcher.LauncherService.Companion.swapAuthlibPath
+import hivens.launcher.runtime.MavenCoord
+import hivens.launcher.runtime.loader.ResolvedLibrary
+import hivens.launcher.runtime.loader.ResolvedRuntime
 import hivens.launcher.component.ClasspathProvider
 import hivens.launcher.component.EnvironmentPreparer
 import hivens.launcher.component.GameCommandBuilder
 import hivens.launcher.component.ProcessLogHandler
+import hivens.launcher.network.ServerProtocolConfig
 import hivens.launcher.runtime.RuntimeProvisioner
+import hivens.launcher.smrt.OpenSmrtHelperResolver
+import hivens.launcher.smrt.SmrtAuthlibSwapper
 import hivens.test.buildMockClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -261,6 +269,9 @@ class LauncherServiceTest {
             ),
             profilerStore = ProfilerProfileStore(json),
             agentExtractor = AgentExtractor(workDir),
+            // SC server path never reaches the SC-binding step; dead deps satisfy the ctor.
+            authlibSwapper = SmrtAuthlibSwapper(deadHttpClientProvider(), ServerProtocolConfig(), workDir),
+            openSmrtResolver = OpenSmrtHelperResolver(deadHttpClientProvider(), json, workDir),
             sharedAssetsDir = workDir / "assets",
             sharedLibrariesDir = workDir / "libraries",
         )
@@ -335,4 +346,36 @@ class LauncherServiceTest {
     }
 
     private fun makeTempDir(): Path = Files.createTempDirectory("launcher-test-").also { it.createDirectories() }
+
+    // ── SC-bound authlib swap (the pure half of applySmrtBinding) ─────────────
+
+    private fun runtimeOf(libs: List<ResolvedLibrary>) = ResolvedRuntime(
+        libraries = libs,
+        clientJar = Path.of("/libs/client.jar"),
+        mainClass = "Main",
+        assetIndexId = "1.12",
+    )
+
+    private val lwjgl = ResolvedLibrary(MavenCoord("org.lwjgl", "lwjgl", "3.3.1"), Path.of("/libs/lwjgl.jar"))
+    private val authlib = ResolvedLibrary(MavenCoord("com.mojang", "authlib", "1.5.25"), Path.of("/libs/authlib-1.5.25.jar"))
+
+    @Test
+    fun `findAuthlibLibrary picks the com_mojang authlib entry`() {
+        assertEquals(authlib, findAuthlibLibrary(runtimeOf(listOf(lwjgl, authlib))))
+    }
+
+    @Test
+    fun `findAuthlibLibrary returns null when no authlib is present`() {
+        assertEquals(null, findAuthlibLibrary(runtimeOf(listOf(lwjgl))))
+    }
+
+    @Test
+    fun `swapAuthlibPath repoints only the authlib entry`() {
+        val patched = Path.of("/cache/smrt-authlib/Industrial/authlib-1.5.25.jar")
+        val out = swapAuthlibPath(runtimeOf(listOf(lwjgl, authlib)), authlib, patched)
+
+        assertEquals(patched, out.libraries.first { it.coord.artifact == "authlib" }.path, "authlib path is swapped")
+        assertEquals(lwjgl.path, out.libraries.first { it.coord.artifact == "lwjgl" }.path, "other libraries untouched")
+        assertEquals(2, out.libraries.size, "no entry added or dropped")
+    }
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -461,6 +461,40 @@ class LauncherControllerTest {
     }
 
     @Test
+    fun `pack blocked by PackPrepBlocked surfaces the carried LaunchError, not Internal`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+        coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/opt/jdk8/bin/java")
+        credentialsManager.save(
+            SessionData(playerName = "tester", uuid = "u", accessToken = "stale", cachedPassword = "pw"),
+        )
+        coEvery { authService.login("tester", "pw", "Industrial") } returns
+            SessionData(playerName = "tester", uuid = "u", accessToken = "fresh")
+
+        // The SC-binding step inside the service could not source the patched
+        // authlib; it throws PackPrepBlocked carrying the semantic reason.
+        coEvery {
+            launcherService.launchPackClient(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } throws PackPrepBlocked(LaunchError.AuthlibUnavailable("1.12.2"))
+
+        val instance = scBoundPackInstance()
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "stale"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        val state = controller.state.value
+        assertIs<LaunchState.Error>(state)
+        assertEquals(
+            LaunchError.AuthlibUnavailable("1.12.2"), state.reason,
+            "controller must map PackPrepBlocked.error, not wrap it in Internal",
+        )
+    }
+
+    @Test
     fun `pack with SC requirement and no cached password fails with MissingAuthProvider`() = runTest {
         every { settingsService.getSettings() } returns SettingsData()
 
@@ -513,6 +547,45 @@ class LauncherControllerTest {
             LaunchError.MissingAuthProvider(PackAuthRequirement.SmartyCraft.PROVIDER_KEY),
             state.reason,
             "Industrial fallback must drive the same precondition surface as an explicit requirement",
+        )
+    }
+
+    @Test
+    fun `fallback SC requirement is forwarded to launchPackClient, not dropped`() = runTest {
+        // Guards the snapshot-forwarding bug: when the requirement comes from the
+        // name-based fallback (manifest authRequirement = null), the service must
+        // still receive it, or the SC-binding step (authlib swap) never runs.
+        every { settingsService.getSettings() } returns SettingsData()
+        coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/opt/jdk8/bin/java")
+        credentialsManager.save(
+            SessionData(playerName = "tester", uuid = "u", accessToken = "stale", cachedPassword = "pw"),
+        )
+        coEvery { authService.login("tester", "pw", "Industrial") } returns
+            SessionData(playerName = "tester", uuid = "u", accessToken = "fresh")
+
+        val process = mockk<Process>()
+        every { process.waitFor() } returns 0
+        val manifestPassed = slot<hivens.core.data.CachedManifestSnapshot>()
+        coEvery {
+            launcherService.launchPackClient(
+                sessionData = any(), manifest = capture(manifestPassed), runtime = any(),
+                clientRootPath = any(), javaPathOverride = any(), allocatedMemoryMB = any(),
+                adaptiveEnabled = any(), displayName = any(), onLog = any(),
+            )
+        } returns process
+        coJustRun { packRepository.put(any()) }
+
+        val instance = scBoundPackInstance(packId = "Industrial", displayName = "Industrial", authRequirement = null)
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "stale"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            PackAuthRequirement.SmartyCraft("Industrial"), manifestPassed.captured.authRequirement,
+            "the effective (fallback) requirement must reach the service so SC-binding runs",
         )
     }
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/ModInjectorTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/ModInjectorTest.kt
@@ -1,0 +1,72 @@
+package hivens.launcher.smrt
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ModInjectorTest {
+
+    private lateinit var dir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("modinjector-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun touch(rel: String) {
+        val p = dir.resolve(rel)
+        Files.createDirectories(p.parent)
+        Files.writeString(p, "x")
+    }
+
+    @Test
+    fun `injectHelperJar copies the helper into mods, overwriting`() {
+        val helper = dir.resolve("helpers").resolve("open-smrt-network-1.12.2.jar")
+        Files.createDirectories(helper.parent)
+        Files.writeString(helper, "helper-v2")
+        // a stale prior copy must be replaced
+        touch("mods/open-smrt-network-1.12.2.jar")
+
+        ModInjector.injectHelperJar(dir, helper)
+
+        val dest = dir.resolve("mods").resolve("open-smrt-network-1.12.2.jar")
+        assertTrue(Files.isRegularFile(dest))
+        assertEquals("helper-v2", Files.readString(dest), "inject must overwrite the stale jar")
+    }
+
+    @Test
+    fun `stripByGlobs removes matching jars in top-level and version subdirs, keeps others`() {
+        touch("mods/Smarty.jar")
+        touch("mods/1.12.2/SmartyClient.jar")
+        touch("mods/JEI.jar")
+        touch("mods/1.12.2/Mixinbooter.jar")
+
+        val removed = ModInjector.stripByGlobs(dir, listOf("Smarty*.jar"))
+
+        assertEquals(2, removed, "both Smarty jars should be stripped across dirs")
+        assertFalse(Files.exists(dir.resolve("mods/Smarty.jar")))
+        assertFalse(Files.exists(dir.resolve("mods/1.12.2/SmartyClient.jar")))
+        assertTrue(Files.exists(dir.resolve("mods/JEI.jar")), "unrelated mods must be kept")
+        assertTrue(Files.exists(dir.resolve("mods/1.12.2/Mixinbooter.jar")), "unrelated mods must be kept")
+    }
+
+    @Test
+    fun `stripByGlobs is a no-op with empty globs or no mods dir`() {
+        assertEquals(0, ModInjector.stripByGlobs(dir, emptyList()))
+        touch("mods/JEI.jar")
+        assertEquals(0, ModInjector.stripByGlobs(dir, emptyList()))
+        assertTrue(Files.exists(dir.resolve("mods/JEI.jar")))
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapperTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapperTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -65,10 +66,9 @@ class SmrtAuthlibSwapperTest {
         assertNotNull(out, "patched authlib should resolve")
         assertTrue(Files.isRegularFile(out), "cached jar must exist on disk")
         assertContentEquals(bytes, Files.readAllBytes(out), "cached bytes must be the downloaded payload")
-        assertTrue(
-            out.toString().contains("smrt-authlib") && out.toString().endsWith("Industrial/authlib-1.5.25.jar"),
-            "cache path is per-server: got $out",
-        )
+        assertEquals("authlib-1.5.25.jar", out.fileName.toString(), "cached under the SC filename")
+        assertEquals("Industrial", out.parent.fileName.toString(), "cache is per-server")
+        assertEquals("smrt-authlib", out.parent.parent.fileName.toString(), "under the smrt-authlib cache root")
     }
 
     @Test
@@ -77,7 +77,7 @@ class SmrtAuthlibSwapperTest {
         // expected filename, so a differing version still resolves (the BLOCKER).
         val out = swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("libraries-1.12.2", "authlib-1.5.21.jar", goodMd5))
         assertNotNull(out, "a differing SC authlib version must still resolve")
-        assertTrue(out.toString().endsWith("Industrial/authlib-1.5.21.jar"), "cached under SC's own filename: got $out")
+        assertEquals("authlib-1.5.21.jar", out.fileName.toString(), "cached under SC's own filename")
     }
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapperTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtAuthlibSwapperTest.kt
@@ -1,0 +1,119 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.data.FileData
+import hivens.core.data.FileManifest
+import hivens.launcher.network.ServerProtocolConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SmrtAuthlibSwapperTest {
+
+    private lateinit var dir: Path
+    private val bytes = "patched-smartycraft-authlib".toByteArray()
+    private val goodMd5 = md5Hex(bytes)
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("authlib-swap-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    /** `Industrial/<dir>/<fileName>` with the given md5. */
+    private fun manifest(dir: String, fileName: String, md5: String): FileManifest = FileManifest(
+        directories = mapOf(
+            "Industrial" to FileManifest(
+                directories = mapOf(
+                    dir to FileManifest(
+                        files = mapOf(fileName to FileData(md5 = md5, size = bytes.size.toLong())),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun swapper(handlerBytes: ByteArray): SmrtAuthlibSwapper {
+        val client = HttpClient(MockEngine) {
+            engine { addHandler { respond(ByteReadChannel(handlerBytes), HttpStatusCode.OK) } }
+        }
+        return SmrtAuthlibSwapper(HttpClientProvider { client }, ServerProtocolConfig(), dir)
+    }
+
+    @Test
+    fun `downloads + md5-verifies the patched authlib and caches it per server`() = runBlocking {
+        val out = swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("libraries-1.12.2", "authlib-1.5.25.jar", goodMd5))
+        assertNotNull(out, "patched authlib should resolve")
+        assertTrue(Files.isRegularFile(out), "cached jar must exist on disk")
+        assertContentEquals(bytes, Files.readAllBytes(out), "cached bytes must be the downloaded payload")
+        assertTrue(
+            out.toString().contains("smrt-authlib") && out.toString().endsWith("Industrial/authlib-1.5.25.jar"),
+            "cache path is per-server: got $out",
+        )
+    }
+
+    @Test
+    fun `matches authlib by artifact even when the SC version differs from vanilla`() = runBlocking {
+        // SC freezes its own authlib version; the matcher is by artifact, not an
+        // expected filename, so a differing version still resolves (the BLOCKER).
+        val out = swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("libraries-1.12.2", "authlib-1.5.21.jar", goodMd5))
+        assertNotNull(out, "a differing SC authlib version must still resolve")
+        assertTrue(out.toString().endsWith("Industrial/authlib-1.5.21.jar"), "cached under SC's own filename: got $out")
+    }
+
+    @Test
+    fun `ignores an authlib jar that is not under a libraries path`() = runBlocking {
+        // A mod basenamed authlib-*.jar outside libraries/ must not be mistaken for it.
+        assertNull(swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("mods", "authlib-1.5.25.jar", goodMd5)))
+    }
+
+    @Test
+    fun `accepts the download without hashing when the manifest md5 is the any sentinel`() = runBlocking {
+        val out = swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("libraries-1.12.2", "authlib-1.5.25.jar", "any"))
+        assertNotNull(out, "the SC 'any' md5 sentinel means skip-verify, not fail-closed")
+        assertContentEquals(bytes, Files.readAllBytes(out))
+    }
+
+    @Test
+    fun `returns null when the authlib is not in the manifest`() = runBlocking {
+        val empty = FileManifest(directories = mapOf("Industrial" to FileManifest()))
+        assertNull(swapper(bytes).ensurePatchedAuthlib("Industrial", empty))
+    }
+
+    @Test
+    fun `returns null and discards the file on md5 mismatch`() = runBlocking {
+        val out = swapper(bytes).ensurePatchedAuthlib("Industrial", manifest("libraries-1.12.2", "authlib-1.5.25.jar", "00deadbeef"))
+        assertNull(out, "a manifest md5 that the payload does not match must fail closed")
+        val dest = dir.resolve("smrt-authlib").resolve("Industrial").resolve("authlib-1.5.25.jar")
+        assertTrue(!Files.exists(dest), "the unverified download must be discarded, not cached")
+    }
+
+    @Test
+    fun `returns null when the session has no file manifest`() = runBlocking {
+        assertNull(swapper(bytes).ensurePatchedAuthlib("Industrial", null))
+    }
+
+    private companion object {
+        fun md5Hex(b: ByteArray): String =
+            MessageDigest.getInstance("MD5").digest(b).joinToString("") { "%02x".format(it) }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -47,6 +47,7 @@ interface AppStrings {
     fun stateError(msg: String): String
     fun stateMissingAuthProvider(providerKey: String): String
     fun stateHelperUnavailable(mcVersion: String): String
+    fun stateAuthlibUnavailable(mcVersion: String): String
 
     // --- Auth Success ---
     fun authSuccess(uuid: String): String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -50,6 +50,8 @@ object EnglishStrings : AppStrings {
     override fun stateError(msg: String)   = "Error: $msg"
     override fun stateHelperUnavailable(mcVersion: String) =
         "No open-smrt helper for Minecraft $mcVersion. Launch blocked so the proprietary Smarty mod isn't run; disable the helper swap in Settings to play with it."
+    override fun stateAuthlibUnavailable(mcVersion: String) =
+        "Could not get the SmartyCraft authlib for Minecraft $mcVersion. Launch blocked: the join would be rejected. Check your connection and SmartyCraft sign-in, then try again."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "This pack needs a SmartyCraft account. Sign in to play."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -47,6 +47,8 @@ object GermanStrings : AppStrings {
     override fun stateError(msg: String)   = "Fehler: $msg"
     override fun stateHelperUnavailable(mcVersion: String) =
         "Kein open-smrt-Helfer für Minecraft $mcVersion. Start blockiert, damit der proprietäre Smarty-Mod nicht läuft; deaktiviere den Helfer-Tausch in den Einstellungen, um damit zu spielen."
+    override fun stateAuthlibUnavailable(mcVersion: String) =
+        "SmartyCraft-authlib für Minecraft $mcVersion nicht erhalten. Start blockiert: der Beitritt würde abgelehnt. Prüfe Verbindung und SmartyCraft-Anmeldung und versuche es erneut."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "Dieses Pack braucht ein SmartyCraft-Konto. Bitte anmelden, um zu spielen."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -47,6 +47,8 @@ object RussianStrings : AppStrings {
     override fun stateError(msg: String)   = "Ошибка: $msg"
     override fun stateHelperUnavailable(mcVersion: String) =
         "Нет open-smrt хелпера для Minecraft $mcVersion. Запуск заблокирован, чтобы не запускать проприетарный мод Smarty; отключи подмену хелпера в настройках, чтобы играть с ним."
+    override fun stateAuthlibUnavailable(mcVersion: String) =
+        "Не удалось получить authlib SmartyCraft для Minecraft $mcVersion. Запуск заблокирован: сервер отклонит вход. Проверь соединение и вход в SmartyCraft и попробуй снова."
     override fun stateMissingAuthProvider(providerKey: String) = when (providerKey) {
         PackAuthRequirement.SmartyCraft.PROVIDER_KEY ->
             "Этой сборке нужен аккаунт SmartyCraft. Войдите, чтобы играть."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LaunchLogCollector.kt
@@ -103,5 +103,6 @@ private fun localizeError(error: LaunchError, s: AppStrings): String = when (err
     is LaunchError.TwoFactorExpired     -> s.auth2faExpired
     is LaunchError.AuthFail             -> "${s.stateAuthFail}: ${error.cause ?: ""}"
     is LaunchError.HelperUnavailable    -> s.stateHelperUnavailable(error.mcVersion)
+    is LaunchError.AuthlibUnavailable   -> s.stateAuthlibUnavailable(error.mcVersion)
     is LaunchError.MissingAuthProvider  -> s.stateMissingAuthProvider(error.providerKey)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/LaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/LaunchDriver.kt
@@ -228,6 +228,7 @@ class LaunchDriver(
                                                 ?: s.notifReasonAuthFail
         is LaunchError.MissingAuthProvider -> s.notifReasonMissingAuthProvider(reason.providerKey)
         is LaunchError.HelperUnavailable   -> s.stateHelperUnavailable(reason.mcVersion)
+        is LaunchError.AuthlibUnavailable  -> s.stateAuthlibUnavailable(reason.mcVersion)
         LaunchError.OfflineNoClient        -> s.notifReasonOfflineNoClient
         LaunchError.OfflineNoManifest      -> s.notifReasonOfflineNoManifest
         LaunchError.TwoFactorExpired       -> s.notifReasonTwoFactorExpired


### PR DESCRIPTION
## Problem
An SC-bound mirror pack cannot join its SmartyCraft server: the in-game join POST lands on sessionserver.mojang.com and is rejected (403) for an SC session token. Wire trace + byte compare: the pack provisions the VANILLA authlib from official CDNs, while SC clients ship a PATCHED authlib (same artifact, different bytes) that redirects the join to auth_joinserver.php.

## Change
For packs whose auth requirement is SmartyCraft (manifest auth block, or the name fallback), at launch:
- Swap the resolved authlib classpath entry for SC's patched authlib, sourced by serverId from the SC client distribution the `clients/` cache already uses, matched by artifact so a frozen SC version still resolves, md5-verified and cached per server under `smrt-authlib/<serverId>/`. The shared `libraries` root stays vanilla; only the per-launch resolved entry is repointed.
- Inject the open-smrt-network interop helper into the instance mods (the Smarty -> open-smrt swap, factored into `ModInjector` and shared with the server-list path).

authlib is a hard requirement (unresolvable -> launch blocked with `AuthlibUnavailable`); open-smrt is best-effort interop (a miss only degrades connection stability, never blocks).

## Tests
- `SmrtAuthlibSwapperTest`: artifact match incl. SC version drift, libraries-path guard, md5 verify + "any" sentinel, mismatch discard, no-manifest.
- `ModInjectorTest`: inject overwrite, strip-by-glob across subdirs, no-op.
- `LauncherServiceTest`: `findAuthlibLibrary` + `swapAuthlibPath` (the classpath swap).
- `LauncherControllerTest`: `PackPrepBlocked` maps to its `LaunchError`; the effective (fallback) auth requirement reaches the service.

## Follow-ups (separate)
- Mirror authoring: add the `auth` block + open-smrt/hidemymods to SC pack manifests, draining the name-based fallback.
- hidemymods / smartycraft jar layers if a barrier appears after open-smrt.

Verified live: the Industrial pack joins.
