### PR TITLE
perf(console): decouple the game console from the UI thread

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,15 @@ fun getGitVersion(providerFactory: ProviderFactory): String {
     return try {
         val version = providerFactory.exec {
             commandLine("git", "describe", "--tags", "--always", "--dirty")
-        }.standardOutput.asText.get().trim()
+        }.standardOutput.asText.get().trim().removePrefix("v")
 
-        version.removePrefix("v")
+        // `--always` falls back to a bare commit SHA when no tag is reachable
+        // (the test CI does a shallow, no-tags checkout). A SHA carries no dotted
+        // version component, and an all-numeric short SHA would otherwise parse as
+        // a single huge version number and invert every version comparison. Treat
+        // "no reachable tag" as an unknown 0.0.0 build (no prerelease suffix, so
+        // it stays a clean lower bound for comparisons).
+        if (version.contains('.')) version else "0.0.0"
     } catch (e: Exception) {
         println("Git version lookup failed: ${e.message}")
         "0.0.0-dev"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ConsoleWindow.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ConsoleWindow.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -63,7 +64,6 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -76,7 +76,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -124,8 +123,6 @@ import java.awt.datatransfer.StringSelection
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.conflate
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
@@ -169,11 +166,21 @@ private val CONSOLE_PAUSE_ACCENT   = Color(0xFFFFA726)
 // severity gutter strip needs -- one entry per LogEntry, carrying the char
 // range it occupies in `annotated` so the painter can ask layoutResult for
 // the y-extent of each visual line that range spans.
-private data class MatchIndex(
+// The full off-thread render result: the annotated document, F3/n match ranges,
+// the per-entry severity spans for the gutter, plus the scalar counts the
+// toolbar / footer show. Everything the UI needs is computed once on
+// Dispatchers.Default and swapped in together, so composition stays O(1).
+private data class ConsoleRender(
     val annotated:      AnnotatedString,
     val ranges:         List<IntRange>,
     val lineSeverities: List<LineSeverity>,
+    val filteredCount:  Int,
+    val totalCount:     Int,
+    val warnCount:      Int,
+    val errorCount:     Int,
 )
+
+private val EMPTY_RENDER = ConsoleRender(AnnotatedString(""), emptyList(), emptyList(), 0, 0, 0, 0)
 
 private data class LineSeverity(
     val startOffset: Int,
@@ -311,28 +318,18 @@ internal fun ConsoleContent(
     val logFocus        = remember { FocusRequester() }
     val density         = LocalDensity.current
 
-    // ── Frame-bounded log coalescer ────────────────────────────────────────
-    // Live source: modded MC startup floods 5k+ lines in ~2s. Rebuilding
-    // the whole AnnotatedString per append would jank; snapshotFlow +
-    // conflate + distinctUntilChanged keeps rebuilds to one per frame.
-    // File source: entries are static, so the tick never advances and the
-    // snapshot is the parsed file -- no coalescer needed.
-    var logTick by remember { mutableIntStateOf(0) }
-    LaunchedEffect(isLive) {
-        if (!isLive) return@LaunchedEffect
-        // Observe the content revision, not logs.size: an in-place
-        // appendOrUpdate (collapsed provisioning progress) overwrites a
-        // line without changing size, and a size-keyed flow would never
-        // re-render it.
-        snapshotFlow { gameConsole.revision }
-            .conflate()
-            .distinctUntilChanged()
-            .collect { logTick = it }
-    }
-    val logsCopy = when (source) {
-        is ConsoleSource.Live       -> remember(logTick) { gameConsole.logs.toList() }
+    // ── Buffer source ──────────────────────────────────────────────────────
+    // Live source: the service publishes a coalesced, off-thread ConsoleSnapshot
+    // -- ingestion, file IO, and the buffer copy all run on its drainer, never on
+    // Main -- so the consumer just reads the latest immutable list. A modded MC
+    // start floods 5k+ lines in ~2s; those collapse into a handful of snapshots.
+    // File source: a static, parsed list.
+    val liveSnapshot by gameConsole.snapshot.collectAsState()
+    val entries = when (source) {
+        is ConsoleSource.Live       -> liveSnapshot.entries
         is ConsoleSource.FileBacked -> source.entries
     }
+    val historyOffset = if (isLive) liveSnapshot.historyOffset else 0
 
     // ── Search query debounce ──────────────────────────────────────────────
     // Highlight + match-offset rebuild keys off the debounced value;
@@ -353,64 +350,41 @@ internal fun ConsoleContent(
         } else null
     }
 
-    // ── Filtered + annotated buffer ────────────────────────────────────────
-    // Two-stage filter: severity gates first, then optional query-narrowing
-    // when search-as-filter is on. The default (filter off) leaves search
-    // purely a highlight + F3 navigation aid; turning the mode on collapses
-    // the buffer to just lines containing the active query, the same shape
-    // less-grep gives. Dividers are kept verbatim either way so session
-    // boundaries stay visible.
-    val filtered = remember(
-        logsCopy, filterInfo, filterWarn, filterError,
-        searchAsFilter, effectiveQuery, regexMode, searchRegex,
-    ) {
-        val severityOk: (LogEntry) -> Boolean = { entry ->
-            when (entry.type) {
-                LogType.INFO    -> filterInfo
-                LogType.WARN    -> filterWarn
-                LogType.ERROR   -> filterError
-                LogType.DIVIDER -> true
-            }
-        }
-        val queryOk: (LogEntry) -> Boolean = q@{ entry ->
-            if (!searchAsFilter || effectiveQuery.isBlank()) return@q true
-            if (entry.type == LogType.DIVIDER) return@q true
-            val haystack = entry.text
-            if (regexMode) {
-                searchRegex?.containsMatchIn(haystack) ?: false
-            } else {
-                haystack.contains(effectiveQuery, ignoreCase = true)
-            }
-        }
-        logsCopy.filter { severityOk(it) && queryOk(it) }
-    }
-
-    val warnCount  = remember(logsCopy) { logsCopy.count { it.type == LogType.WARN } }
-    val errorCount = remember(logsCopy) { logsCopy.count { it.type == LogType.ERROR } }
-
-    // Async rebuild on Dispatchers.Default: the prior synchronous
-    // `remember(...) { buildConsoleAnnotated(...) }` blocked the UI
-    // thread for ~30-50 ms on 5000-line buffers under spammed filter
-    // toggles, producing the user-reported lag. produceState swaps the
-    // value in once the background coroutine returns; in-flight builds
-    // are cancelled when the input keys change, so rapid clicks
-    // collapse to one rebuild for the final state.
+    // ── Render: filter + counts + annotate, all OFF the UI thread ──────────
+    // The whole O(n) pass -- severity/query filtering, warn/error counts, and
+    // the AnnotatedString build -- runs on Dispatchers.Default and swaps in once
+    // via produceState. Nothing O(n) touches composition, so a 5000-line buffer
+    // (or a live flood) never blocks Main. In-flight builds cancel when any key
+    // changes, so rapid filter/search edits collapse to one final rebuild.
+    // First-render fallback is an empty render; the cold-open gap is sub-frame.
     //
-    // First-render fallback is an empty MatchIndex; the gap is
-    // sub-frame on a cold open (~30 ms) and visually negligible against
-    // the window's own paint.
-    val matchIndex by produceState(
-        initialValue = remember { MatchIndex(AnnotatedString(""), emptyList(), emptyList()) },
-        filtered, effectiveQuery, regexMode, searchRegex, palette, showTimestamps,
+    // Two-stage filter: severity gates first, then optional query-narrowing when
+    // search-as-filter is on (the default leaves search a pure highlight + F3
+    // aid). Dividers are kept verbatim so session boundaries stay visible.
+    val render by produceState(
+        initialValue = remember { EMPTY_RENDER },
+        entries, filterInfo, filterWarn, filterError,
+        searchAsFilter, effectiveQuery, regexMode, searchRegex, palette, showTimestamps,
     ) {
         value = withContext(Dispatchers.Default) {
-            buildConsoleAnnotated(filtered, effectiveQuery, regexMode, searchRegex, palette, showTimestamps)
+            buildConsoleRender(
+                all            = entries,
+                filterInfo     = filterInfo,
+                filterWarn     = filterWarn,
+                filterError    = filterError,
+                searchAsFilter = searchAsFilter,
+                rawQuery       = effectiveQuery,
+                regexMode      = regexMode,
+                regexCompiled  = searchRegex,
+                palette        = palette,
+                showTimestamps = showTimestamps,
+            )
         }
     }
 
     // Clamp current match index when the match set shrinks past it.
-    LaunchedEffect(matchIndex.ranges.size) {
-        if (currentMatch >= matchIndex.ranges.size) currentMatch = 0
+    LaunchedEffect(render.ranges.size) {
+        if (currentMatch >= render.ranges.size) currentMatch = 0
     }
 
     // Initial focus on the log area: BasicTextField is read-only but still
@@ -446,7 +420,7 @@ internal fun ConsoleContent(
             scrollState.maxValue == 0 || scrollState.value >= scrollState.maxValue - 16
         }
     }
-    LaunchedEffect(matchIndex.annotated) {
+    LaunchedEffect(render.annotated) {
         if (isAtBottom) scrollState.scrollTo(scrollState.maxValue)
     }
 
@@ -455,17 +429,14 @@ internal fun ConsoleContent(
     // entries dropped past the window, page the older entries back in.
     // The load is one-shot: a `loading` flag suppresses re-entry while the
     // batch is in flight, otherwise rapid scroll-to-top events would queue
-    // overlapping reads. Loaded entries land at the start of logs.toList()
-    // (the next snapshotFlow tick rebuilds the AnnotatedString), and we
-    // shift scrollState by the approximate height of the loaded block so
-    // the user's visual line stays put.
+    // overlapping reads. The drainer prepends the loaded entries and the next
+    // published snapshot carries them; we shift scrollState by the approximate
+    // height of the loaded block so the user's visual line stays put.
     var historyLoading by remember { mutableStateOf(false) }
-    // File-backed views load the whole (tail-bounded) file up front, so
-    // there is nothing to page; historyOffset is meaningful only for the
-    // live sliding window.
-    val historyOffset by remember {
-        derivedStateOf { if (isLive) gameConsole.historyOffset else 0 }
-    }
+    // historyOffset comes from the published snapshot (live only); file-backed
+    // views load the whole tail-bounded file up front, so there is nothing to
+    // page. loadHistoryBefore prepends to the buffer on the drainer and the next
+    // snapshot carries the older entries; we only do the scroll-anchor shift.
     LaunchedEffect(scrollState.value, historyOffset, isLive) {
         if (!isLive) return@LaunchedEffect
         if (historyLoading) return@LaunchedEffect
@@ -475,13 +446,9 @@ internal fun ConsoleContent(
         try {
             val loaded = gameConsole.loadHistoryBefore(count = 500)
             if (loaded.isNotEmpty()) {
-                // prependHistory bumps the content revision so the
-                // coalescer rebuilds matchIndex with the new front.
-                // ScrollState shifts by an approximate line height per
-                // loaded entry; not exact because line height under wrap
-                // depends on glyph metrics, but the miss is sub-100 px
-                // and unnoticeable in practice.
-                gameConsole.prependHistory(loaded)
+                // ScrollState shifts by an approximate line height per loaded
+                // entry so the user's visual line stays put; not exact (wrap
+                // line height depends on glyph metrics) but the miss is sub-100 px.
                 val approxLineHeightPx = with(density) { (fontSize * 1.4f).sp.toPx() }
                 val shift = (loaded.size * approxLineHeightPx).toInt()
                 scrollState.scrollTo((scrollState.value + shift).coerceAtMost(scrollState.maxValue))
@@ -492,17 +459,17 @@ internal fun ConsoleContent(
     }
 
     // ── TextFieldValue source of truth ─────────────────────────────────────
-    // Text comes from `matchIndex.annotated` (system-controlled). Selection
+    // Text comes from `render.annotated` (system-controlled). Selection
     // is user-controlled and persists across rebuilds; the read-only field
     // only routes selection changes (drag-select, Ctrl+A, click-position)
     // through onValueChange.
-    val textFieldValue = remember(matchIndex.annotated, selection) {
-        TextFieldValue(annotatedString = matchIndex.annotated, selection = selection)
+    val textFieldValue = remember(render.annotated, selection) {
+        TextFieldValue(annotatedString = render.annotated, selection = selection)
     }
 
     // ── Copy actions ───────────────────────────────────────────────────────
     fun copyAll() {
-        val text = logsCopy.joinToString("\n") { e ->
+        val text = entries.joinToString("\n") { e ->
             if (e.type == LogType.DIVIDER) e.text else "[${e.timestamp}] ${e.text}"
         }
         scope.launch { clipboard.setClipEntry(ClipEntry(StringSelection(text))) }
@@ -521,7 +488,7 @@ internal fun ConsoleContent(
     // the click + the toast that goes with it. One entry equals one
     // logical line in our builder, so '\n' bounds are authoritative.
     fun copyLine() {
-        val annotated = matchIndex.annotated
+        val annotated = render.annotated
         if (annotated.isEmpty()) return
         val text = annotated.text
         val pos = selection.start.coerceIn(0, text.length)
@@ -544,7 +511,7 @@ internal fun ConsoleContent(
     // the user can switch to copy-line for that case via the same menu.
     fun copySelection() {
         if (selection.collapsed) return
-        val annotated = matchIndex.annotated
+        val annotated = render.annotated
         val start = selection.start.coerceIn(0, annotated.length)
         val end   = selection.end.coerceIn(0, annotated.length)
         if (start >= end) return
@@ -559,15 +526,15 @@ internal fun ConsoleContent(
 
     // ── Match jumping ──────────────────────────────────────────────────────
     // The layout result may be from the PREVIOUS frame's BasicTextField measure
-    // while matchIndex.ranges references char positions in the JUST-rebuilt
+    // while render.ranges references char positions in the JUST-rebuilt
     // annotated string. Under flood, an offset can exceed the old layout's
     // text length -- MultiParagraph.getLineForOffset would throw. Guard on
     // text length first, then runCatching the layout call so a transient
     // out-of-range only loses one F3 press instead of crashing.
     fun scrollToMatch(idx: Int) {
         val layout = layoutResult ?: return
-        if (idx !in matchIndex.ranges.indices) return
-        val range = matchIndex.ranges[idx]
+        if (idx !in render.ranges.indices) return
+        val range = render.ranges[idx]
         val start = range.first
         val end   = range.last + 1
         if (start >= layout.layoutInput.text.length) return
@@ -578,19 +545,19 @@ internal fun ConsoleContent(
         // Selection mirrors the match span exactly -- in regex mode this
         // visualises the full matched text rather than collapsing to a
         // zero-width caret as the prior queryLength-based form did.
-        val safeEnd = end.coerceAtMost(matchIndex.annotated.length)
+        val safeEnd = end.coerceAtMost(render.annotated.length)
         selection = TextRange(start, safeEnd)
     }
 
     fun jumpNext() {
-        if (matchIndex.ranges.isEmpty()) return
-        currentMatch = (currentMatch + 1) % matchIndex.ranges.size
+        if (render.ranges.isEmpty()) return
+        currentMatch = (currentMatch + 1) % render.ranges.size
         scrollToMatch(currentMatch)
     }
 
     fun jumpPrev() {
-        if (matchIndex.ranges.isEmpty()) return
-        currentMatch = if (currentMatch == 0) matchIndex.ranges.lastIndex
+        if (render.ranges.isEmpty()) return
+        currentMatch = if (currentMatch == 0) render.ranges.lastIndex
                        else currentMatch - 1
         scrollToMatch(currentMatch)
     }
@@ -626,14 +593,14 @@ internal fun ConsoleContent(
     PuppetToggle("console.searchOpen",  searchOpen)  { if (it) openSearch() else closeSearch() }
     PuppetField ("console.search", searchQuery)      { searchQuery = it }
     PuppetClick ("console.clearSearch", enabled = searchQuery.isNotEmpty()) { searchQuery = "" }
-    PuppetClick ("console.saveToFile")   { gameConsole.exportEntries(logsCopy) }
+    PuppetClick ("console.saveToFile")   { gameConsole.exportEntries(entries) }
     PuppetClick ("console.copyAll")      { copyAll() }
     PuppetClick ("console.clear", enabled = isLive) { if (isLive) gameConsole.clear() }
-    PuppetClick ("console.jumpToBottom", enabled = filtered.isNotEmpty()) {
+    PuppetClick ("console.jumpToBottom", enabled = render.filteredCount > 0) {
         scope.launch { scrollState.animateScrollTo(scrollState.maxValue) }
     }
-    PuppetClick ("console.matchNext",    enabled = matchIndex.ranges.isNotEmpty()) { jumpNext() }
-    PuppetClick ("console.matchPrev",    enabled = matchIndex.ranges.isNotEmpty()) { jumpPrev() }
+    PuppetClick ("console.matchNext",    enabled = render.ranges.isNotEmpty()) { jumpNext() }
+    PuppetClick ("console.matchPrev",    enabled = render.ranges.isNotEmpty()) { jumpPrev() }
     FONT_SIZES.forEach { sz ->
         PuppetClick("console.fontSize.$sz") { onSettingsChange(settings.copy(fontSize = sz)) }
     }
@@ -651,7 +618,7 @@ internal fun ConsoleContent(
                 handleKey(
                     ev          = ev,
                     searchFocus = searchHasFocus,
-                    matchCount  = matchIndex.ranges.size,
+                    matchCount  = render.ranges.size,
                     onOpenSearch = { openSearch() },
                     onCloseSearch = {
                         if (searchQuery.isNotEmpty()) searchQuery = "" else closeSearch()
@@ -670,10 +637,10 @@ internal fun ConsoleContent(
         // ── Toolbar ─────────────────────────────────────────────────────────
         Toolbar(
             strings       = s,
-            filtered      = filtered.size,
-            total         = logsCopy.size,
-            warnCount     = warnCount,
-            errorCount    = errorCount,
+            filtered      = render.filteredCount,
+            total         = entries.size,
+            warnCount     = render.warnCount,
+            errorCount    = render.errorCount,
             filterInfo    = filterInfo,
             filterWarn    = filterWarn,
             filterError   = filterError,
@@ -691,9 +658,9 @@ internal fun ConsoleContent(
             onCopyAll     = { copyAll() },
             // Export what's on screen, not the live buffer: in a file-
             // backed Logs-tab view the live buffer may hold a different
-            // pack's session, so exportEntries(logsCopy) writes the
+            // pack's session, so exportEntries(entries) writes the
             // session the user is actually looking at.
-            onSave        = { gameConsole.exportEntries(logsCopy) },
+            onSave        = { gameConsole.exportEntries(entries) },
             // Clear only acts on the live buffer; a file-backed view is
             // read-only, so the button no-ops there rather than wiping
             // the running session's buffer behind the user's back.
@@ -722,17 +689,27 @@ internal fun ConsoleContent(
             // the actual rendered baseline rather than the canvas top.
             val gutterWidthPx = with(density) { 3.dp.toPx() }
             val verticalPaddingPx = with(density) { 4.dp.toPx() }
-            val gutterModifier = if (showGutter) {
+            // Precompute the WARN/ERROR strip rects once per (layout, severities,
+            // palette) change rather than walking every entry + querying the
+            // layout on every draw frame -- a 5000-line buffer would otherwise
+            // re-measure the gutter on each scroll tick.
+            val gutterRects = remember(
+                layoutResult, render.lineSeverities,
+                themeColors.warnAccent, themeColors.criticalAccent, verticalPaddingPx,
+            ) {
+                computeGutterRects(
+                    layout     = layoutResult,
+                    severities = render.lineSeverities,
+                    warnColor  = themeColors.warnAccent,
+                    errorColor = themeColors.criticalAccent,
+                    yOffsetPx  = verticalPaddingPx,
+                )
+            }
+            val gutterModifier = if (showGutter && gutterRects.isNotEmpty()) {
                 Modifier.drawBehind {
-                    val layout = layoutResult ?: return@drawBehind
-                    drawSeverityGutter(
-                        layout         = layout,
-                        severities     = matchIndex.lineSeverities,
-                        warnColor      = themeColors.warnAccent,
-                        errorColor     = themeColors.criticalAccent,
-                        gutterWidthPx  = gutterWidthPx,
-                        yOffsetPx      = verticalPaddingPx,
-                    )
+                    for (r in gutterRects) {
+                        drawRect(color = r.color, topLeft = Offset(0f, r.top), size = Size(gutterWidthPx, r.height))
+                    }
                 }
             } else {
                 Modifier
@@ -819,7 +796,7 @@ internal fun ConsoleContent(
                 ) {
                     SelectionContainer {
                         Text(
-                            text         = matchIndex.annotated,
+                            text         = render.annotated,
                             softWrap     = false,
                             style        = baseStyle,
                             onTextLayout = { layoutResult = it },
@@ -899,7 +876,7 @@ internal fun ConsoleContent(
             SearchPrompt(
                 query          = searchQuery,
                 // Position preserved across query refinements; the
-                // LaunchedEffect(matchIndex.ranges.size) clamp resets
+                // LaunchedEffect(render.ranges.size) clamp resets
                 // currentMatch only when the new match set has fewer
                 // entries than the cursor position. Refining 'NullPoint'
                 // to 'NullPointer' keeps the user at hit 5 of 12 instead
@@ -974,15 +951,15 @@ internal fun ConsoleContent(
 
         StatusFooter(
             strings        = s,
-            filtered       = filtered.size,
-            total          = logsCopy.size,
+            filtered       = render.filteredCount,
+            total          = entries.size,
             historyOffset  = historyOffset,
-            warnCount      = warnCount,
-            errorCount     = errorCount,
+            warnCount      = render.warnCount,
+            errorCount     = render.errorCount,
             following      = isAtBottom,
             searchActive   = effectiveQuery.isNotBlank(),
-            matchCurrent   = if (matchIndex.ranges.isNotEmpty()) currentMatch + 1 else 0,
-            matchTotal     = matchIndex.ranges.size,
+            matchCurrent   = if (render.ranges.isNotEmpty()) currentMatch + 1 else 0,
+            matchTotal     = render.ranges.size,
             onResumeFollow = {
                 scope.launch { scrollState.animateScrollTo(scrollState.maxValue) }
             },
@@ -1544,14 +1521,48 @@ private fun handleKey(
 // match's absolute offset for F3/n jumping. DIVIDERs render inline as their
 // own dimmed line.
 
-private fun buildConsoleAnnotated(
-    entries: List<LogEntry>,
+private fun buildConsoleRender(
+    all: List<LogEntry>,
+    filterInfo: Boolean,
+    filterWarn: Boolean,
+    filterError: Boolean,
+    searchAsFilter: Boolean,
     rawQuery: String,
     regexMode: Boolean,
     regexCompiled: Regex?,
     palette: ConsolePalette,
     showTimestamps: Boolean,
-): MatchIndex {
+): ConsoleRender {
+    // One pass for counts (over ALL entries) + the severity/query filter that
+    // produces the displayed list. Severity gates first; query-narrowing only
+    // when search-as-filter is on. Dividers always pass so session boundaries
+    // stay visible.
+    var warnCount = 0
+    var errorCount = 0
+    val entries = ArrayList<LogEntry>(all.size)
+    for (e in all) {
+        when (e.type) {
+            LogType.WARN  -> warnCount++
+            LogType.ERROR -> errorCount++
+            else          -> {}
+        }
+        val severityOk = when (e.type) {
+            LogType.INFO    -> filterInfo
+            LogType.WARN    -> filterWarn
+            LogType.ERROR   -> filterError
+            LogType.DIVIDER -> true
+        }
+        if (!severityOk) continue
+        val queryOk = if (!searchAsFilter || rawQuery.isBlank() || e.type == LogType.DIVIDER) {
+            true
+        } else if (regexMode) {
+            regexCompiled?.containsMatchIn(e.text) ?: false
+        } else {
+            e.text.contains(rawQuery, ignoreCase = true)
+        }
+        if (queryOk) entries.add(e)
+    }
+
     val matches = mutableListOf<IntRange>()
     val severities = mutableListOf<LineSeverity>()
 
@@ -1621,10 +1632,14 @@ private fun buildConsoleAnnotated(
         }
     }
 
-    return MatchIndex(
+    return ConsoleRender(
         annotated      = annotated,
         ranges         = matches,
         lineSeverities = severities,
+        filteredCount  = entries.size,
+        totalCount     = all.size,
+        warnCount      = warnCount,
+        errorCount     = errorCount,
     )
 }
 
@@ -1667,22 +1682,26 @@ private class ConsoleTextContextMenu(
     }
 }
 
-// Paint a thin vertical strip at the left edge of each rendered line whose
-// severity isn't INFO / DIVIDER. WARN / ERROR each get their own accent.
-// Layout-source-of-truth: the TextLayoutResult captured by the field /
-// Text's onTextLayout; runCatching guards keep a transient stale layout
-// from crashing the paint pass while the buffer catches up.
-private fun DrawScope.drawSeverityGutter(
-    layout: TextLayoutResult,
+// A precomputed gutter strip rect: a thin vertical bar at the left edge of a
+// rendered WARN / ERROR line. Computed off the draw frame (see
+// [computeGutterRects]) so the paint pass is a flat list iteration.
+private class GutterRect(val top: Float, val height: Float, val color: Color)
+
+// Map every WARN/ERROR entry's char range to its visual line extent via the
+// TextLayoutResult, once per layout / severities change. runCatching guards a
+// transient stale layout while the buffer catches up. INFO / DIVIDER lines get
+// no bar.
+private fun computeGutterRects(
+    layout: TextLayoutResult?,
     severities: List<LineSeverity>,
     warnColor: Color,
     errorColor: Color,
-    gutterWidthPx: Float,
     yOffsetPx: Float,
-) {
-    if (severities.isEmpty()) return
+): List<GutterRect> {
+    if (layout == null || severities.isEmpty()) return emptyList()
     val textLen = layout.layoutInput.text.length
-    if (textLen == 0) return
+    if (textLen == 0) return emptyList()
+    val rects = ArrayList<GutterRect>()
     for (sev in severities) {
         if (sev.type == LogType.INFO || sev.type == LogType.DIVIDER) continue
         val color = if (sev.type == LogType.ERROR) errorColor else warnColor
@@ -1694,13 +1713,10 @@ private fun DrawScope.drawSeverityGutter(
         for (line in startLine..endLine) {
             val top    = runCatching { layout.getLineTop(line) }.getOrNull() ?: continue
             val bottom = runCatching { layout.getLineBottom(line) }.getOrNull() ?: continue
-            drawRect(
-                color   = color,
-                topLeft = Offset(0f, yOffsetPx + top),
-                size    = Size(gutterWidthPx, bottom - top),
-            )
+            rects.add(GutterRect(yOffsetPx + top, bottom - top, color))
         }
     }
+    return rects
 }
 
 private fun findAllSubstring(text: String, query: String): List<IntRange> {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/utils/GameConsoleService.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/utils/GameConsoleService.kt
@@ -2,12 +2,19 @@ package hivens.ui.utils
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import hivens.core.logging.Redactor
 import hivens.launcher.platform.PlatformPaths
-import hivens.ui.notifications.drivers.LaunchDriver
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import java.io.BufferedWriter
 import java.io.File
@@ -18,275 +25,240 @@ import java.util.Date
 private val log = LoggerFactory.getLogger("GameConsoleService")
 
 /**
- * Holds the live in-memory console buffer + mirrors each entry to a
- * per-session `game-output-*.log` file. The in-memory buffer is a
- * sliding window: only the latest [maxLines] entries are kept; older
- * entries drop off the front but remain on disk. UI can ask for
- * [loadHistoryBefore] to page the older entries back into the window
- * (Phase 8.5 of the console rework -- see
- * [[project_console_sliding_window]]).
+ * Immutable, UI-facing view of the console buffer. Published off the UI thread
+ * by the drainer and read on Main via `collectAsState`; [entries] is already a
+ * fresh copy, so the consumer never copies a snapshot-state list on the hot path.
+ */
+data class ConsoleSnapshot(
+    val entries: List<LogEntry> = emptyList(),
+    val historyOffset: Int = 0,
+)
+
+/**
+ * Holds the live console buffer + mirrors each entry to a per-session
+ * `game-output-*.log` file. FULLY DECOUPLED from the UI thread:
  *
- * Why memory-bounded:
+ * A modded Minecraft start floods stdout (5000+ lines in ~2s). The old design
+ * mutated a `mutableStateListOf` AND `flush()`ed the file PER LINE on whatever
+ * thread called [append] -- which is Main (the launcher event collector runs in
+ * a LaunchedEffect). That dead-hung the UI during load and sometimes crashed
+ * the shell. Now every mutating call is a non-blocking enqueue onto [channel];
+ * a single drainer coroutine on [Dispatchers.IO] owns ALL mutable buffer + file
+ * state (so no locks), batches file writes (one flush per drained burst, never
+ * per line), and publishes a coalesced immutable [ConsoleSnapshot] at most once
+ * per burst. The UI only ever observes that snapshot.
  *
- * The AnnotatedString rebuild in `ConsoleWindow.buildConsoleAnnotated`
- * walks every entry in the window on every recomposition; if the
- * buffer grew unbounded, a long modded session would blow up the
- * rebuild cost. The disk file already exists per session (one line per
- * append, redacted at write time so safe to read back) and is the
- * obvious place to park history.
+ * The in-memory buffer is a sliding window: only the latest [maxLines] entries
+ * are kept; older entries drop off the front but remain on disk and page back
+ * via [loadHistoryBefore] (see [[project_console_sliding_window]]).
  *
- * Constructor-injected [paths] rather than a static
- * `PlatformPaths.system()` call so the singleton honors a mid-session
- * data-dir migration (`DataDirMover`) -- otherwise the in-memory writer
- * would keep landing lines in the old directory while everything else
- * writes to the new one.
- *
- * One instance is registered as a Koin singleton in the UI module and
- * shared between composables (`AppLayout`, `ConsoleWindow`, the
- * launcher controller). The snapshot-state list and `mutableStateOf`
- * flag survive recomposition naturally because Compose tracks the same
- * instance everywhere.
+ * Constructor-injected [paths] (not a static `PlatformPaths.system()`) so the
+ * singleton honors a mid-session data-dir migration. One Koin singleton shared
+ * across composables; the snapshot StateFlow + the low-rate Compose flags below
+ * survive recomposition naturally.
  */
 class GameConsoleService(
     private val paths: PlatformPaths,
 ) {
-    val logs = mutableStateListOf<LogEntry>()
+    private val _snapshot = MutableStateFlow(ConsoleSnapshot())
 
-    /**
-     * Bumped on every content mutation -- append, in-place
-     * [appendOrUpdate], [prependHistory], clear. The console's
-     * rebuild coalescer observes THIS, not `logs.size`: an
-     * [appendOrUpdate] that overwrites a line in place leaves the size
-     * unchanged, so a size-keyed snapshotFlow would never re-render the
-     * updated progress line.
-     */
-    var revision by mutableIntStateOf(0)
-        private set
+    /** Coalesced, off-thread view of the buffer. Consumed via `collectAsState`. */
+    val snapshot: StateFlow<ConsoleSnapshot> = _snapshot.asStateFlow()
 
     var shouldShowConsole by mutableStateOf(false)
 
     /**
-     * Command sink: set by the [LaunchDriver] when a game process
-     * spawns, cleared on error / clean exit. UI calls [sendCommand]
-     * which routes through the sink to the process stdin. The state
-     * field is observable so the input row can show / hide itself
-     * without polling.
-     *
-     * Backed by mutableStateOf so the canSendCommands flag is a
-     * regular Compose state read; the actual sink is the lambda the
-     * driver stuffs in. Null = no game running, sendCommand is a
-     * no-op.
+     * Command sink: set by the [hivens.ui.notifications.drivers.LaunchDriver]
+     * when a game process spawns, cleared on error / clean exit. Observable so
+     * the input row shows / hides without polling. Null = no game running.
      */
     private var _commandSink by mutableStateOf<((String) -> Unit)?>(null)
     val canSendCommands: Boolean get() = _commandSink != null
 
     /**
-     * In-memory sliding-window cap. ConsoleSettings.maxInMemoryLines
-     * drives this at runtime; the default is 5000 to give plenty of
-     * scrollback in memory before the user has to page back from disk.
-     * Trim runs on every append when size exceeds the cap.
+     * In-memory sliding-window cap. `ConsoleSettings.maxInMemoryLines` drives
+     * this at runtime; read by the drainer thread on every trim, written from
+     * the UI thread -- @Volatile for cross-thread visibility (a late-applied
+     * change is harmless).
      */
+    @Volatile
     var maxLines: Int = 5000
 
     /**
-     * Count of entries that were dropped off the front of [logs] to
-     * keep within [maxLines]. Equal to the number of older entries
-     * available via [loadHistoryBefore]. UI binds the status footer to
-     * this so the user sees "5000 in window / 12340 on disk".
-     */
-    private val _historyOffset = mutableIntStateOf(0)
-    val historyOffset: Int get() = _historyOffset.intValue
-
-    /**
-     * Current session's on-disk file. Set by [startSession]; consulted
-     * by [loadHistoryBefore] to know which file to page from. Null
-     * before the first session start or after [clear].
-     */
-    private var sessionFile: File? = null
-
-    /**
-     * Monotonic session-start counter. Bumped on every [startSession],
-     * regardless of which pack launched. The PackDetail Logs tab keys
-     * its file-list refresh on this: keying on the pack id would miss a
-     * relaunch of the SAME pack (same id, no change), leaving the new
-     * captured file + rewritten latest.log hidden until something else
-     * forced recomposition. Observable so the tab re-lists reactively.
+     * Monotonic session-start counter, bumped on every [startSession] (on the
+     * caller thread, before the drainer opens the file) so the PackDetail Logs
+     * tab can re-list reactively. Observable Compose state -- low rate, stays on
+     * the UI side.
      */
     var sessionStartCount by mutableIntStateOf(0)
         private set
 
+    // ── Drainer-owned state (touched ONLY on the drainer coroutine) ──────────
+    private val buffer = ArrayDeque<LogEntry>()
+    private val slotEntries = HashMap<String, LogEntry>()
+    private var historyOffset = 0
+    private var sessionFile: File? = null
     private var sessionWriter: BufferedWriter? = null
     private val fileDateFmt = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss")
 
+    // Unlimited so the cheap producer (trySend on Main) never blocks or drops;
+    // a flood backs up in the channel and the drainer batch-empties it.
+    private val channel = Channel<Msg>(Channel.UNLIMITED)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        scope.launch { drainLoop() }
+    }
+
+    private sealed interface Msg {
+        data class Append(val text: String, val type: LogType) : Msg
+        data class AppendOrUpdate(val slotId: String, val text: String, val type: LogType) : Msg
+        data class StartSession(val packId: String?) : Msg
+        data object Clear : Msg
+        data class LoadHistory(val count: Int, val result: CompletableDeferred<List<LogEntry>>) : Msg
+    }
+
     /**
-     * Serializes every [sessionWriter] / [sessionFile] touch. The
-     * launcher's event collector funnels stdout + stderr through one
-     * SharedFlow today but the writer historically supported direct
-     * concurrent callers; keeping the lock means a future regression
-     * does not corrupt the file's interleaving. Same lock guards
-     * open / close in [startSession] / [clear] so a write isn't racing
-     * the writer being swapped out, and [loadHistoryBefore] takes it
-     * briefly to flush before reading.
+     * Drain loop: block for one message, then batch-drain everything else queued
+     * without suspending. Under a flood this collapses thousands of appends into
+     * one flush + one snapshot publish; when idle it is one publish per line.
      */
-    private val writerLock = Any()
+    private suspend fun drainLoop() {
+        for (first in channel) {
+            apply(first)
+            while (true) {
+                val next = channel.tryReceive().getOrNull() ?: break
+                apply(next)
+            }
+            flushWriter()
+            publish()
+        }
+    }
 
-    private fun logsDir(): File =
-        paths.logsDir.toFile().also { it.mkdirs() }
-
-    fun startSession(packId: String? = null, packLabel: String? = null) { // TODO: Parameter "packLabel" is never used
-        sessionStartCount += 1
-        slotEntries.clear()
-        synchronized(writerLock) {
-            sessionWriter?.close()
-            sessionWriter = null
-            sessionFile = null
-            _historyOffset.intValue = 0
-            try {
-                // Per-pack file name so the Logs tab can list / scope a
-                // pack's own sessions. Unscoped sessions (null packId)
-                // keep the legacy "game-output-<ts>.log" shape. The
-                // sanitized id keeps arbitrary pack ids filesystem-safe.
-                val stamp = fileDateFmt.format(Date())
-                val fileName = if (packId.isNullOrBlank()) {
-                    "game-output-$stamp.log"
+    private fun apply(msg: Msg) {
+        when (msg) {
+            is Msg.Append -> {
+                val entry = LogEntry(Redactor.redact(msg.text), msg.type)
+                buffer.addLast(entry)
+                trim()
+                writeLine(entry)
+            }
+            is Msg.AppendOrUpdate -> {
+                // TTY carriage-return semantics: overwrite the slot's line in
+                // place so a flood of "Runtime 1/1342 ... 1342/1342" collapses
+                // to one updating line. NOT mirrored to the file (launcher-
+                // internal provisioning ticks; archiving every tick would bloat
+                // the file and break the disk/line-index alignment).
+                val entry = LogEntry(Redactor.redact(msg.text), msg.type)
+                val prev = slotEntries[msg.slotId]
+                val idx = if (prev != null) buffer.indexOf(prev) else -1
+                if (idx >= 0) {
+                    buffer[idx] = entry
                 } else {
-                    "game-output-${sanitizeId(packId)}-$stamp.log"
+                    buffer.addLast(entry)
+                    trim()
                 }
-                val file = File(logsDir(), fileName)
-                sessionFile = file
-                sessionWriter = BufferedWriter(FileWriter(file, true))
-            } catch (e: Exception) {
-                log.warn("Could not open per-session game-output log; in-memory console still works", e)
+                slotEntries[msg.slotId] = entry
             }
-        }
-
-        // The divider goes into BOTH the in-memory buffer AND the file
-        // so history reload reconstructs the session marker on the same
-        // line index as the live view.
-        val time = SimpleDateFormat("HH:mm:ss").format(Date())
-        val entry = LogEntry("--------- Session started $time ---------", LogType.DIVIDER, time)
-        logs.add(entry)
-        synchronized(writerLock) {
-            try {
-                sessionWriter?.apply {
-                    write(entry.text)
-                    newLine()
-                    flush()
-                }
-            } catch (e: Exception) {
-                log.debug("Failed to mirror session-start divider to file", e)
+            is Msg.StartSession -> openSession(msg.packId)
+            is Msg.Clear -> {
+                buffer.clear()
+                slotEntries.clear()
+                closeWriter()
+                historyOffset = 0
             }
+            is Msg.LoadHistory -> msg.result.complete(pageHistory(msg.count))
         }
     }
 
-    /**
-     * The most recent in-memory entry per progress slot, for
-     * [appendOrUpdate]. Cleared on session start / [clear] so a new
-     * session's progress never mutates the previous session's line.
-     */
-    private val slotEntries = HashMap<String, LogEntry>()
-
-    /**
-     * Append-or-overwrite a single mutable line keyed by [slotId].
-     * First touch appends; subsequent calls replace that line in place
-     * (TTY carriage-return semantics) so a flood of "Runtime 1/1342 ...
-     * 1342/1342" provisioning ticks collapses to one updating line
-     * instead of 1342 separate entries.
-     *
-     * Deliberately NOT mirrored to the session file: these are
-     * launcher-internal provisioning ticks, not game output worth
-     * archiving, and writing every tick would both bloat the file and
-     * break the sliding-window's file/line index alignment. Real
-     * errors during provisioning still arrive via [append] and are
-     * archived normally.
-     */
-    fun appendOrUpdate(slotId: String, text: String, type: LogType = LogType.INFO) {
-        val entry = LogEntry(Redactor.redact(text), type)
-        val prev = slotEntries[slotId]
-        val idx = if (prev != null) logs.indexOf(prev) else -1
-        if (idx >= 0) {
-            logs[idx] = entry
-        } else {
-            logs.add(entry)
-            if (logs.size > maxLines) {
-                logs.removeAt(0)
-                _historyOffset.intValue += 1
-            }
+    private fun trim() {
+        while (buffer.size > maxLines) {
+            buffer.removeFirst()
+            historyOffset += 1
         }
-        slotEntries[slotId] = entry
-        revision++
     }
 
-    /**
-     * Prepend paged-in history entries to the front of the live buffer
-     * (sliding-window scroll-up). Routed through the service so the
-     * content [revision] bumps and the console's coalescer re-renders.
-     */
-    fun prependHistory(entries: List<LogEntry>) {
-        if (entries.isEmpty()) return
-        logs.addAll(0, entries)
-        revision++
+    private fun publish() {
+        _snapshot.value = ConsoleSnapshot(buffer.toList(), historyOffset)
     }
+
+    // ── Public enqueue surface (non-blocking, callable from any thread) ──────
 
     fun append(text: String, type: LogType = LogType.INFO) {
-        // Redact at append time: the in-memory buffer (which feeds
-        // ConsoleWindow, the auto-save file, and `Save to file`
-        // exports) NEVER carries raw accessTokens / passwords / UUIDs.
-        // Means a screenshot of the console or a Ctrl+C copy of a log
-        // line is safe to share for support.
-        val entry = LogEntry(Redactor.redact(text), type)
-        logs.add(entry)
-        if (logs.size > maxLines) {
-            logs.removeAt(0)
-            _historyOffset.intValue += 1
-        }
-        revision++
+        channel.trySend(Msg.Append(text, type))
+    }
 
-        synchronized(writerLock) {
-            try {
-                sessionWriter?.apply {
-                    write(formatFileLine(entry))
-                    newLine()
-                    flush()
-                }
-            } catch (e: Exception) {
-                log.debug("Failed to mirror console entry to per-session file", e)
-            }
-        }
+    fun appendOrUpdate(slotId: String, text: String, type: LogType = LogType.INFO) {
+        channel.trySend(Msg.AppendOrUpdate(slotId, text, type))
+    }
+
+    fun startSession(packId: String? = null, packLabel: String? = null) {
+        // Bump on the caller thread (Main) so the observable Compose state write
+        // stays off the drainer; the file open happens in the drainer.
+        sessionStartCount += 1
+        channel.trySend(Msg.StartSession(packId))
+    }
+
+    fun clear() {
+        channel.trySend(Msg.Clear)
     }
 
     /**
-     * Read at most [count] entries from the current session's log file,
-     * positioned immediately before the sliding-window start. Returns
-     * them in chronological order (oldest first) so the caller can
-     * prepend to [logs]. Decrements [historyOffset] by the count
-     * actually returned. Returns an empty list when there is no
-     * remaining history, no session file yet, or the file read fails.
-     *
-     * Flush before read: the writer normally flushes on every append,
-     * but the lock guard against [clear] races also ensures the file
-     * is in a consistent state by the time the reader opens it.
+     * Page the [count] entries immediately before the sliding-window start back
+     * into the live buffer (scroll-up). Routed through the drainer so the buffer
+     * + historyOffset stay single-owner; returns the loaded entries (oldest
+     * first) for the caller's scroll-anchor math. Empty when there is no
+     * remaining history / no session file / read failure.
      */
-    fun loadHistoryBefore(count: Int): List<LogEntry> {
+    suspend fun loadHistoryBefore(count: Int): List<LogEntry> {
         if (count <= 0) return emptyList()
-        val current = _historyOffset.intValue
+        val result = CompletableDeferred<List<LogEntry>>()
+        channel.trySend(Msg.LoadHistory(count, result))
+        return result.await()
+    }
+
+    // ── Drainer-thread implementation ────────────────────────────────────────
+
+    private fun openSession(packId: String?) {
+        slotEntries.clear()
+        closeWriter()
+        historyOffset = 0
+        try {
+            val stamp = fileDateFmt.format(Date())
+            val fileName = if (packId.isNullOrBlank()) {
+                "game-output-$stamp.log"
+            } else {
+                "game-output-${sanitizeId(packId)}-$stamp.log"
+            }
+            val file = File(logsDir(), fileName)
+            sessionFile = file
+            sessionWriter = BufferedWriter(FileWriter(file, true))
+        } catch (e: Exception) {
+            log.warn("Could not open per-session game-output log; in-memory console still works", e)
+        }
+        // Session-start divider goes into BOTH buffer and file so a history
+        // reload reconstructs the marker on the same line index as the live view.
+        val time = SimpleDateFormat("HH:mm:ss").format(Date())
+        val entry = LogEntry("--------- Session started $time ---------", LogType.DIVIDER, time)
+        buffer.addLast(entry)
+        writeLine(entry)
+    }
+
+    /** Read+prepend history; returns the loaded entries (oldest first). */
+    private fun pageHistory(count: Int): List<LogEntry> {
+        val current = historyOffset
         if (current <= 0) return emptyList()
-        val file = synchronized(writerLock) {
-            sessionWriter?.flush()
-            sessionFile
-        } ?: return emptyList()
+        sessionWriter?.flush()
+        val file = sessionFile ?: return emptyList()
         if (!file.exists()) return emptyList()
 
         val take = count.coerceAtMost(current)
         val skip = current - take
-
         val out = ArrayList<LogEntry>(take)
         try {
             file.bufferedReader().use { reader ->
-                // Skip ahead to the window of interest. The disk file
-                // index = entry index since startSession (dividers and
-                // all), so historyOffset N corresponds to file lines
-                // [0..N) being the dropped tail.
+                // Disk file index = entry index since startSession, so
+                // historyOffset N means file lines [0..N) are the dropped tail.
                 var skipped = 0
                 while (skipped < skip) {
                     if (reader.readLine() == null) break
@@ -303,22 +275,51 @@ class GameConsoleService(
             log.warn("Failed to load history for sliding window", e)
             return emptyList()
         }
-
         if (out.isNotEmpty()) {
-            _historyOffset.intValue -= out.size
+            buffer.addAll(0, out)
+            historyOffset -= out.size
         }
         return out
     }
 
+    private fun writeLine(entry: LogEntry) {
+        if (entry.type == LogType.DIVIDER && entry.text.startsWith("---")) {
+            // dividers write verbatim
+        }
+        try {
+            sessionWriter?.apply {
+                write(formatFileLine(entry))
+                newLine()
+            }
+        } catch (e: Exception) {
+            log.debug("Failed to mirror console entry to per-session file", e)
+        }
+    }
+
+    private fun flushWriter() {
+        try {
+            sessionWriter?.flush()
+        } catch (e: Exception) {
+            log.debug("Failed to flush per-session file", e)
+        }
+    }
+
+    private fun closeWriter() {
+        try {
+            sessionWriter?.close()
+        } catch (_: Exception) {
+        }
+        sessionWriter = null
+        sessionFile = null
+    }
+
+    private fun logsDir(): File =
+        paths.logsDir.toFile().also { it.mkdirs() }
+
     /**
-     * Serialise a [LogEntry] to its on-disk line. INFO stays
-     * `[HH:MM:SS] text` (the common case -- keeps files clean and
-     * backward-compatible with pre-8.6 logs). WARN / ERROR carry a
-     * marker after the timestamp so [parseFileLine] can restore the
-     * severity colour on reload: `[HH:MM:SS] [WARN] text`. The marker
-     * sits after our timestamp, so a real game line's own
-     * `[Server thread/WARN]` (which appears later in the text) never
-     * collides with it. Dividers write their text verbatim.
+     * Serialise a [LogEntry] to its on-disk line. INFO stays `[HH:MM:SS] text`;
+     * WARN / ERROR carry a marker after the timestamp so [parseFileLine] can
+     * restore the severity on reload. Dividers write verbatim.
      */
     private fun formatFileLine(entry: LogEntry): String = when (entry.type) {
         LogType.DIVIDER -> entry.text
@@ -327,13 +328,7 @@ class GameConsoleService(
         LogType.ERROR   -> "[${entry.timestamp}] $MARKER_ERROR ${entry.text}"
     }
 
-    /**
-     * Best-effort parse of a single file line back into a LogEntry.
-     * Inverse of [formatFileLine]. A `[WARN]` / `[ERROR]` marker
-     * immediately after the timestamp restores the severity; absent a
-     * marker the line is INFO (also covers pre-8.6 files, which carried
-     * no severity). Dividers are detected by the `---` fence.
-     */
+    /** Inverse of [formatFileLine]; absent a marker the line is INFO. */
     private fun parseFileLine(line: String): LogEntry {
         if (line.startsWith("---") && line.endsWith("---")) {
             return LogEntry(line, LogType.DIVIDER, "")
@@ -351,17 +346,13 @@ class GameConsoleService(
         return LogEntry(line, LogType.INFO, "")
     }
 
-    /** Export the live buffer. Kept for callers that always mean "the
-     *  current session"; UI surfaces that may be showing a file-backed
-     *  view call [exportEntries] with what's actually on screen. */
-    fun saveToFile(): File? = exportEntries(logs)
+    /** Export the live buffer (current snapshot). */
+    fun saveToFile(): File? = exportEntries(snapshot.value.entries)
 
     /**
-     * Write the given entries to a fresh `console-export-*.log` using
-     * the same on-disk format as the session files. The Logs tab passes
-     * the entries it is currently displaying, so exporting a past
-     * session file view writes that session -- not whatever the live
-     * buffer happens to hold (which may belong to a different pack).
+     * Write [entries] to a fresh `console-export-*.log` in the on-disk format.
+     * The Logs tab passes whatever it currently displays, so exporting a past
+     * session writes that session -- not whatever the live buffer holds.
      */
     fun exportEntries(entries: List<LogEntry>): File? {
         return try {
@@ -377,43 +368,13 @@ class GameConsoleService(
         } catch (_: Exception) { null }
     }
 
-    fun clear() {
-        logs.clear()
-        slotEntries.clear()
-        revision++
-        synchronized(writerLock) {
-            sessionWriter?.close()
-            sessionWriter = null
-            sessionFile = null
-            _historyOffset.intValue = 0
-        }
-    }
-
     fun show() { shouldShowConsole = true }
     fun hide() { shouldShowConsole = false }
 
-    /**
-     * Attach a stdin writer for the currently running game process.
-     * Called by [LaunchDriver] on the [LaunchState.GameRunning]
-     * transition. Subsequent [sendCommand] calls route through this
-     * lambda. The driver replaces the sink on each launch, so the
-     * UI never holds a stale reference across game restarts.
-     */
-    fun attachCommandSink(sink: (String) -> Unit) {
-        _commandSink = sink
-    }
+    fun attachCommandSink(sink: (String) -> Unit) { _commandSink = sink }
+    fun detachCommandSink() { _commandSink = null }
 
-    fun detachCommandSink() {
-        _commandSink = null
-    }
-
-    /**
-     * Best-effort write to the game process's stdin. Newline-suffixed
-     * so each call lands as a complete command on the receiver side.
-     * No-op when no process is running; the UI is expected to gate
-     * the input affordance on [canSendCommands] but this is the
-     * defensive backstop.
-     */
+    /** Best-effort write to the running game's stdin. No-op when none running. */
     fun sendCommand(text: String) {
         val payload = text.trimEnd('\n', '\r')
         if (payload.isEmpty()) return
@@ -421,11 +382,9 @@ class GameConsoleService(
     }
 
     /**
-     * The launcher's own captured-session files for a pack, newest
-     * first. Matches the `game-output-<sanitized-packId>-<stamp>.log`
-     * naming from [startSession]. These are the redacted stdout/stderr
-     * captures (distinct from the game's own logs/ files); the Logs tab
-     * lists them alongside the instance's real logs.
+     * The launcher's captured-session files for a pack, newest first. Matches
+     * the `game-output-<sanitized-packId>-<stamp>.log` naming from
+     * [startSession]. File-backed (off the live path).
      */
     fun capturedSessionFiles(packId: String): List<File> {
         val prefix = "game-output-${sanitizeId(packId)}-"
@@ -437,17 +396,9 @@ class GameConsoleService(
     }
 
     /**
-     * Read a log file into a LogEntry list for a read-only file-backed
-     * view. Works for BOTH our captured-session format (`[ts] [WARN]
-     * text`) and a game's own log (`[ts] [Thread/WARN]: text`): our
-     * marker is restored by [parseFileLine], and an absent marker falls
-     * back to scanning the line for a Minecraft-style `/WARN]` /
-     * `/ERROR]` / `/FATAL]` level so latest.log + crash reports colour
-     * sensibly too. Every line is run through [Redactor] on read -- the
-     * game's own logs are not redacted on disk, so this keeps a
-     * screenshot / copy of an external log as safe to share as our
-     * captured buffer. Tail-bounded by [limit] so a huge crash log does
-     * not blow up memory.
+     * Read a log file into a LogEntry list for a read-only file-backed view.
+     * Handles both our captured format and a game's own log; every line is run
+     * through [Redactor] on read and the result is tail-bounded by [limit].
      */
     fun readLogFile(file: File, limit: Int = maxLines): List<LogEntry> {
         if (!file.exists()) return emptyList()
@@ -463,7 +414,6 @@ class GameConsoleService(
         val redacted = Redactor.redact(raw)
         val base = parseFileLine(redacted)
         if (base.type != LogType.INFO) return base
-        // No marker of ours -> sniff a Minecraft logger level token.
         val mc = when {
             base.text.contains("/ERROR]") || base.text.contains("/FATAL]") -> LogType.ERROR
             base.text.contains("/WARN]")                                   -> LogType.WARN
@@ -473,9 +423,6 @@ class GameConsoleService(
     }
 
     companion object {
-        // Severity markers written after the timestamp for non-INFO
-        // lines (see formatFileLine / parseFileLine). Kept as literals
-        // a human reading the raw log file recognises at a glance.
         private const val MARKER_WARN  = "[WARN]"
         private const val MARKER_ERROR = "[ERROR]"
 

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/utils/GameConsoleServiceTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/utils/GameConsoleServiceTest.kt
@@ -1,0 +1,107 @@
+package hivens.ui.utils
+
+import hivens.launcher.platform.PlatformPaths
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Exercises the off-thread drainer: enqueue on the test thread, await the
+ * coalesced [ConsoleSnapshot] the service publishes from its IO drainer. Proves
+ * ingestion + the sliding window + file mirroring all work without the UI.
+ */
+class GameConsoleServiceTest {
+
+    private lateinit var dir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("console-svc-")
+    }
+
+    @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun service(maxLines: Int = 5000): GameConsoleService {
+        val paths = PlatformPaths(
+            osName = "linux",
+            home = dir,
+            bootstrapDataDir = { null },
+            env = { name -> if (name == "NEXIRA_DATA_DIR") dir.toString() else null },
+        )
+        return GameConsoleService(paths).also { it.maxLines = maxLines }
+    }
+
+    private suspend fun GameConsoleService.awaitSnapshot(
+        predicate: (ConsoleSnapshot) -> Boolean,
+    ): ConsoleSnapshot = withTimeout(3.seconds) { snapshot.first(predicate) }
+
+    @Test
+    fun `append publishes the line off-thread`() = runBlocking {
+        val svc = service()
+        svc.append("hello")
+        val snap = svc.awaitSnapshot { s -> s.entries.any { it.text == "hello" } }
+        assertTrue(snap.entries.any { it.text == "hello" })
+    }
+
+    @Test
+    fun `sliding window keeps the last maxLines in order`() = runBlocking {
+        val svc = service(maxLines = 5)
+        repeat(12) { svc.append("line-$it") }
+        val snap = svc.awaitSnapshot { it.entries.size == 5 && it.entries.last().text == "line-11" }
+        assertEquals(
+            listOf("line-7", "line-8", "line-9", "line-10", "line-11"),
+            snap.entries.map { it.text },
+            "buffer keeps the latest maxLines in arrival order",
+        )
+        assertEquals(7, snap.historyOffset, "dropped entries are counted for history paging")
+    }
+
+    @Test
+    fun `appendOrUpdate collapses a slot to a single line`() = runBlocking {
+        val svc = service()
+        svc.appendOrUpdate("p", "1/3")
+        svc.appendOrUpdate("p", "2/3")
+        svc.appendOrUpdate("p", "3/3")
+        val snap = svc.awaitSnapshot { it.entries.size == 1 && it.entries[0].text == "3/3" }
+        assertEquals(1, snap.entries.size, "progress ticks overwrite one line, not append three")
+        assertEquals("3/3", snap.entries[0].text)
+    }
+
+    @Test
+    fun `session file persists every appended line`() = runBlocking {
+        val svc = service()
+        svc.startSession("Test")
+        repeat(3) { svc.append("l$it") }
+        svc.awaitSnapshot { s -> s.entries.count { it.text.startsWith("l") } == 3 }
+
+        val file = assertNotNull(svc.capturedSessionFiles("Test").firstOrNull(), "a per-session file is opened")
+        assertTrue(file.exists(), "the session file is written to disk")
+        val lines = file.readLines()
+        assertTrue(lines.any { it.contains("Session started") }, "divider is mirrored")
+        assertTrue(lines.any { it.endsWith("l0") } && lines.any { it.endsWith("l2") }, "all lines flushed")
+    }
+
+    @Test
+    fun `clear empties the buffer`() = runBlocking {
+        val svc = service()
+        svc.append("x")
+        svc.awaitSnapshot { it.entries.isNotEmpty() }
+        svc.clear()
+        val snap = svc.awaitSnapshot { it.entries.isEmpty() }
+        assertTrue(snap.entries.isEmpty())
+    }
+}


### PR DESCRIPTION
## Problem
A modded pack load floods stdout (5000+ lines in ~2s) and hung the launcher UI hard during load -- and occasionally crashed the shell (caught only by the crash-recovery restart). Two causes, both keeping heavy work on the Compose UI thread:

- **Ingestion on Main.** `LaunchLogCollector` collects launcher events in a `LaunchedEffect` (Main) and calls `GameConsoleService.append()` per line; `append()` mutated a `mutableStateListOf` AND `flush()`ed the session file **per line** on Main. A flood = thousands of synchronous file flushes + snapshot writes per second on the UI thread.
- **Consumer on Main.** `ConsoleWindow` copied (`logs.toList()`), filtered, and counted the whole buffer in composition on every coalesced tick; the severity gutter queried the text layout per WARN/ERROR line every draw frame.

## Change
- `GameConsoleService` is now fully off the UI thread: every mutating call (`append`/`appendOrUpdate`/`startSession`/`clear`) is a non-blocking enqueue onto a channel; a single `Dispatchers.IO` drainer owns the buffer + file writer (batched flush, never per line) and publishes a coalesced immutable `ConsoleSnapshot` via `StateFlow`. The sliding window + history paging (`loadHistoryBefore`) route through the same drainer, so the buffer stays single-owner (no locks).
- `ConsoleWindow` consumes the snapshot via `collectAsState` and folds filtering + warn/error counts + the `AnnotatedString` build into one off-thread `produceState` -- nothing O(n) stays in composition. The severity gutter precomputes its rects per layout/snapshot instead of per draw frame.
- `LaunchLogCollector` is unchanged; its `append` calls are now non-blocking enqueues.

Net: ingestion, processing, and render all run off the UI thread; a flood can no longer block or kill it.

## Tests
- `GameConsoleServiceTest`: off-thread publish, sliding-window order + historyOffset, `appendOrUpdate` slot collapse, session-file persistence (batched flush), clear.
- `:client-ui:desktopTest` green; existing console behavior (search, F3 nav, severity filter, file-backed view, gutter, export, command input, history page-in) unchanged.

## Verification (manual)
Launch a modded pack and confirm the window stays responsive during load AND while searching; sticky-bottom follow + scroll-up history page-in still work.
