### PR TITLE
fix(launcher): gate the pack authlib host redirect by pack origin

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
@@ -83,6 +83,10 @@ interface ILauncherService {
         javaPathOverride: Path?,
         allocatedMemoryMB: Int,
         adaptiveEnabled: Boolean = false,
+        // Redirect authlib's auth/account/session hosts at the configured mirror
+        // host. Mirror-derived packs only; a Modrinth / local / own pack leaves
+        // the default Mojang hosts so its own auth provider is not redirected.
+        redirectAuthHost: Boolean = true,
         displayName: String,
         onLog: (String, LauncherLogType) -> Unit,
     ): Process

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -134,6 +134,7 @@ internal class LauncherService(
         javaPathOverride: Path?,
         allocatedMemoryMB: Int,
         adaptiveEnabled: Boolean,
+        redirectAuthHost: Boolean,
         displayName: String,
         onLog: (String, LauncherLogType) -> Unit
     ): Process {
@@ -205,6 +206,7 @@ internal class LauncherService(
             runtime = resolved,
             session = sessionData,
             jvmArgsOverride = runtime.jvmArgs,
+            redirectAuthHost = redirectAuthHost,
             agentJarPath = adaptive.agentJar,
             metricsOutPath = adaptive.metricsOut,
         )

--- a/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
@@ -288,6 +288,7 @@ internal class GameCommandBuilder(
         runtime: ResolvedRuntime,
         session: SessionData,
         jvmArgsOverride: String?,
+        redirectAuthHost: Boolean = true,
         agentJarPath: Path? = null,
         metricsOutPath: Path? = null,
     ): List<String> {
@@ -303,12 +304,17 @@ internal class GameCommandBuilder(
         if (javaMajor <= 8) args.add("-noverify")
         addMacOsStartupFlags(args)
 
-        // Launcher identity + authlib redirect. Reaching the menu does not need
-        // it; joining an SC-derived server does (the redirect points auth at the
-        // configured host, same as the SC path).
-        args.add("-Dminecraft.api.auth.host=${protocolConfig.baseUrl}/launcher/")
-        args.add("-Dminecraft.api.account.host=${protocolConfig.baseUrl}/launcher/")
-        args.add("-Dminecraft.api.session.host=${protocolConfig.baseUrl}/launcher/")
+        // authlib redirect: point auth/account/session at the configured host so
+        // joining an SC/mirror-derived server authenticates there (same as the SC
+        // path). Mirror-derived packs ONLY -- a Modrinth / local / own pack keeps
+        // the default Mojang hosts so its own auth provider (e.g. real Yggdrasil)
+        // is never redirected to the mirror. No-op today (launcher is all mirror
+        // auth), load-bearing once a second provider exists.
+        if (redirectAuthHost) {
+            args.add("-Dminecraft.api.auth.host=${protocolConfig.baseUrl}/launcher/")
+            args.add("-Dminecraft.api.account.host=${protocolConfig.baseUrl}/launcher/")
+            args.add("-Dminecraft.api.session.host=${protocolConfig.baseUrl}/launcher/")
+        }
         args.add("-Dminecraft.launcher.brand=${Branding.UPSTREAM_NAME}")
         args.add("-Dminecraft.launcher.version=${Protocol.MIMIC_LAUNCHER_VERSION}")
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -10,6 +10,7 @@ import hivens.core.data.ContentToggle
 import hivens.core.data.OptionalContentRules
 import hivens.core.data.PackAuthRequirement
 import hivens.core.data.PackInstance
+import hivens.core.data.PackOrigin
 import hivens.core.data.SessionData
 import hivens.core.diag.ActionRing
 import hivens.launcher.CredentialsManager
@@ -515,6 +516,11 @@ class LauncherController(
                     javaPathOverride     = javaOverride,
                     allocatedMemoryMB    = settings.memoryMB,
                     adaptiveEnabled      = settings.experimentalFeaturesEnabled && settings.adaptiveMemoryEnabled,
+                    // Redirect authlib to the mirror auth host only for
+                    // mirror-derived packs. A Modrinth / local / own pack keeps
+                    // the default Mojang hosts so its own auth provider stands.
+                    redirectAuthHost     = refreshedInstance.packRef.origin
+                        .let { it == PackOrigin.Smartycraft || it == PackOrigin.Mirror },
                     displayName          = refreshedInstance.displayName,
                 ) { text, type ->
                     emit(LaunchLogEvent.ProcessOutput(text, type))

--- a/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/component/GameCommandBuilderTest.kt
@@ -527,6 +527,7 @@ class GameCommandBuilderTest {
     private fun packCommand(
         runtime: ResolvedRuntime = forgeRuntime(),
         javaMajor: Int = 8,
+        redirectAuthHost: Boolean = true,
     ) = builder.buildPackCommand(
         javaExec = "/usr/bin/java",
         memoryMB = 4096,
@@ -539,7 +540,26 @@ class GameCommandBuilderTest {
         runtime = runtime,
         session = session(),
         jvmArgsOverride = null,
+        redirectAuthHost = redirectAuthHost,
     )
+
+    @Test
+    fun `buildPackCommand redirects the auth hosts for a mirror-derived pack`() {
+        val cmd = packCommand(redirectAuthHost = true)
+        assertTrue(cmd.any { it.startsWith("-Dminecraft.api.auth.host=") })
+        assertTrue(cmd.any { it.startsWith("-Dminecraft.api.account.host=") })
+        assertTrue(cmd.any { it.startsWith("-Dminecraft.api.session.host=") })
+    }
+
+    @Test
+    fun `buildPackCommand leaves the default auth hosts for a non-mirror pack`() {
+        // Modrinth / local / own packs keep the default Mojang hosts so their own
+        // auth provider is not redirected to the mirror.
+        val cmd = packCommand(redirectAuthHost = false)
+        assertFalse(cmd.any { it.startsWith("-Dminecraft.api.auth.host=") })
+        assertFalse(cmd.any { it.startsWith("-Dminecraft.api.account.host=") })
+        assertFalse(cmd.any { it.startsWith("-Dminecraft.api.session.host=") })
+    }
 
     @Test
     fun `buildPackCommand drives mainClass, assetIndex and tweak from the runtime`() {

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -474,7 +474,7 @@ class LauncherControllerTest {
         // authlib; it throws PackPrepBlocked carrying the semantic reason.
         coEvery {
             launcherService.launchPackClient(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
         } throws PackPrepBlocked(LaunchError.AuthlibUnavailable("1.12.2"))
 
@@ -517,7 +517,7 @@ class LauncherControllerTest {
             state.reason,
         )
         coVerify(exactly = 0) {
-            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
         coVerify(exactly = 0) { authService.login(any(), any(), any()) }
     }
@@ -619,7 +619,7 @@ class LauncherControllerTest {
         assertIs<LaunchState.Error>(state)
         assertEquals(LaunchError.TwoFactorExpired, state.reason)
         coVerify(exactly = 0) {
-            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            launcherService.launchPackClient(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
     }
 


### PR DESCRIPTION
## Problem (#284)
`GameCommandBuilder.buildPackCommand` set `-Dminecraft.api.{auth,account,session}.host=<mirror>/launcher/` for **every** pack, including Modrinth and local ones. For mirror-derived packs that is correct; for a non-mirror pack it redirects auth at the mirror even though the pack has nothing to do with it. No-op today (the launcher is entirely on mirror auth), latent once a second auth provider exists.

## Change
Gate the redirect by pack origin: Smartycraft / Mirror packs keep it; Modrinth / local / own packs leave the default Mojang hosts, so a future pack with its own provider (e.g. real Yggdrasil) is not redirected. `redirectAuthHost` is computed from `PackInstance.packRef.origin` in `launchPackInstance` and threaded through `launchPackClient` (interface default `true`) into `buildPackCommand`. The SC server-list path (`build()`) is unchanged -- it is always SC.

## Tests
- `GameCommandBuilderTest`: redirect present when `redirectAuthHost = true`, absent when `false`.
- `LauncherControllerTest` mocks updated for the new param; suite green (`:client-launcher:test`).
