### PR TITLE
feat(launcher): make a warm pack relaunch fully offline

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/runtime/RuntimeProvisioner.kt
@@ -178,15 +178,16 @@ class RuntimeProvisioner(
         mcVersion: String,
         progress: DownloadProgress = { _, _, _ -> },
     ): VanillaRuntime = withContext(Dispatchers.IO) {
-        val versionUrl = resolveVersionUrl(mcVersion)
-        val version = json.decodeFromString(MojangVersion.serializer(), fetchText(versionUrl))
+        // Offline-friendly resolve. A Mojang version json is immutable per MC
+        // version, so cache it and reuse the on-disk copy -- a relaunch then skips
+        // BOTH the version-manifest and the version fetch. The asset index is
+        // reused when the on-disk copy already matches its sha (no refetch, no
+        // rewrite). With every library/object already present (fetchIfNeeded skips
+        // on size), a relaunch needs ZERO network -- the last thing that blocked
+        // offline launch.
+        val version = loadOrFetchVersion(mcVersion)
         val assetIndexId = version.assetIndex.id
-
-        // Fetch + persist the asset index, then enumerate its objects.
-        val indexBytes = fetchBytes(version.assetIndex.url)
-        verifyOrThrow(indexBytes, version.assetIndex.sha1, "asset index $assetIndexId")
-        writeBytes(assetsDir.resolve(assetIndexRelPath(assetIndexId)), indexBytes)
-        val assetIndex = json.decodeFromString(MojangAssetIndex.serializer(), indexBytes.decodeToString())
+        val assetIndex = ensureAssetIndex(assetIndexId, version.assetIndex.url, version.assetIndex.sha1)
 
         val tasks = planVanillaDownloads(mcVersion, version, assetIndex)
         log.info("vanilla runtime {}: {} files to verify/fetch (assetIndex={})", mcVersion, tasks.size, assetIndexId)
@@ -346,6 +347,10 @@ class RuntimeProvisioner(
     internal fun clientJarRelPath(mcVersion: String): String =
         "net/minecraft/minecraft/$mcVersion/minecraft-$mcVersion.jar"
 
+    /** Cached Mojang version json, next to the client jar in the shared root. */
+    internal fun versionJsonRelPath(mcVersion: String): String =
+        "net/minecraft/minecraft/$mcVersion/$mcVersion.json"
+
     internal fun assetIndexRelPath(assetIndexId: String): String = "indexes/$assetIndexId.json"
 
     internal fun assetObjectRelPath(hash: String): String = "objects/${hash.take(2)}/$hash"
@@ -359,6 +364,45 @@ class RuntimeProvisioner(
         val manifest = json.decodeFromString(MojangVersionManifest.serializer(), fetchText(versionManifestUrl))
         return manifest.versions.firstOrNull { it.id == mcVersion }?.url
             ?: throw IOException("Minecraft version $mcVersion not found in Mojang version manifest")
+    }
+
+    /**
+     * The Mojang version json for [mcVersion], from the on-disk cache when
+     * present (a released version's json never changes), else fetched from the
+     * manifest + persisted. The cache is what lets a relaunch skip the network.
+     * A corrupt/partial cache (rare; writes are atomic) falls back to a refetch.
+     */
+    private suspend fun loadOrFetchVersion(mcVersion: String): MojangVersion {
+        val cachePath = librariesDir.resolve(versionJsonRelPath(mcVersion))
+        if (Files.isRegularFile(cachePath)) {
+            runCatching { json.decodeFromString(MojangVersion.serializer(), Files.readString(cachePath)) }
+                .onSuccess { return it }
+                .onFailure { log.warn("cached version json for {} unreadable; refetching", mcVersion) }
+        }
+        val text = fetchText(resolveVersionUrl(mcVersion))
+        val parsed = json.decodeFromString(MojangVersion.serializer(), text)
+        runCatching { writeBytes(cachePath, text.toByteArray()) }
+            .onFailure { log.warn("could not cache version json for {}", mcVersion, it) }
+        return parsed
+    }
+
+    /**
+     * Returns the parsed asset index for [id], reusing the on-disk copy when it
+     * already matches [sha1] (no refetch, no rewrite -- the offline path), else
+     * fetching + verifying + persisting it.
+     */
+    private suspend fun ensureAssetIndex(id: String, url: String, sha1: String): MojangAssetIndex {
+        val indexPath = assetsDir.resolve(assetIndexRelPath(id))
+        val onDisk = if (Files.isRegularFile(indexPath)) runCatching { Files.readAllBytes(indexPath) }.getOrNull() else null
+        val bytes = if (onDisk != null && sha1Of(onDisk).equals(sha1, ignoreCase = true)) {
+            onDisk
+        } else {
+            val fetched = fetchBytes(url)
+            verifyOrThrow(fetched, sha1, "asset index $id")
+            writeBytes(indexPath, fetched)
+            fetched
+        }
+        return json.decodeFromString(MojangAssetIndex.serializer(), bytes.decodeToString())
     }
 
     private suspend fun fetchText(url: String): String =

--- a/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/runtime/RuntimeProvisionerTest.kt
@@ -292,12 +292,13 @@ class RuntimeProvisionerTest {
         assertEquals("com.mojang:patchy", result.libraries[0].coord.groupArtifact)
         assertEquals(librariesDir.resolve("com/mojang/patchy/1.1/patchy-1.1.jar"), result.libraries[0].path)
 
-        // Second call: metadata is re-read, but the heavy files are skipped (present + right size).
+        // Second call is FULLY OFFLINE: the version json is cached, the asset
+        // index sha already matches on disk, and every heavy file is present, so
+        // nothing touches the network. This is the offline-launch guarantee.
         requests.clear()
         val again = p.ensureVanilla("1.12.2")
         assertEquals("1.12", again.assetIndexId)
-        assertTrue(LIB_URL !in requests && CLIENT_URL !in requests, "downloaded jars must not be re-fetched, got: $requests")
-        assertTrue(requests.none { it.startsWith(RES_BASE) }, "asset objects must not be re-fetched, got: $requests")
+        assertTrue(requests.isEmpty(), "a warm relaunch must make ZERO network requests, got: $requests")
     }
 
     @Test


### PR DESCRIPTION
## Problem (#283)
`RuntimeProvisioner.ensureVanilla` re-fetched the version manifest, the per-version JSON, and the asset index on **every** launch, and rewrote the asset index to disk. So an already-installed pack could not start without a network connection -- the last blocker to genuine offline launch. (Auth is already decoupled: the user logs in once at game-server join, not per launch.)

## Change
- Cache the Mojang version JSON on disk (`net/minecraft/minecraft/<mc>/<mc>.json`, next to the client jar). A released version's JSON is immutable, so a relaunch reuses the on-disk copy and skips BOTH the version-manifest and the version fetch. A corrupt/partial cache falls back to a refetch (writes are atomic).
- Reuse the on-disk asset index when its sha already matches the version's declared `assetIndex.sha1` -- no refetch, no rewrite.
- The per-file downloads already skip on size (`fetchIfNeeded`). With those three together, a warm relaunch makes **zero** network requests; a missing/changed file still triggers exactly its fetch.

## Tests
- `RuntimeProvisionerTest`: the end-to-end case now asserts the second `ensureVanilla` makes ZERO network requests (was: skips heavy files but re-read metadata). Sha-mismatch + planning cases unchanged. `:client-launcher:test` green.

## Verification (manual)
Install a pack online, then relaunch with the network off -- it now starts.
