### PR TITLE
feat(launcher): dependency-aware optional-mod toggling

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/data/OptionalContentRules.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/OptionalContentRules.kt
@@ -49,9 +49,19 @@ object OptionalContentRules {
     }
 
     /**
-     * Applies a single user toggle to [current], enforcing incompatibilities:
-     * enabling a mod disables every mod that conflicts with it. Disabling never
-     * cascades. Returns the new state (only optional + present entries change).
+     * Applies a single user toggle to [current], dependency-aware:
+     *
+     * - ENABLING pulls the mod on PLUS the transitive closure of its non-optional
+     *   `display.requires` -- so a library (e.g. Mixinbooter) can ship optional +
+     *   `default_enabled=false` and follow its consumers on, instead of being
+     *   flat-`required`. For each newly-on mod, mutual exclusions are enforced:
+     *   same-`role` members (one active per interchangeable group) and declared
+     *   `incompatibleWith` are turned off.
+     * - DISABLING never cascades: a library that was auto-enabled for another mod
+     *   stays put (harmlessly loaded-but-unused) rather than risking the surprise
+     *   of pulling content the user never touched.
+     *
+     * Returns the new state; only optional + present entries change.
      */
     fun applyToggle(
         mods: List<SmrtModEntry>,
@@ -60,14 +70,43 @@ object OptionalContentRules {
         enable: Boolean,
     ): Map<String, Boolean> {
         val next = current.toMutableMap()
-        next[filename] = enable
-        if (enable) {
+        if (!enable) {
+            next[filename] = false
+            return next
+        }
+        val byName = mods.associateBy { it.filename }
+        val toEnable = requiredClosure(byName, filename)
+        for (f in toEnable) next[f] = true
+        for (f in toEnable) {
+            val role = byName[f]?.display?.role
             for (other in mods) {
-                if (other.filename != filename && conflicts(mods, filename, other.filename)) {
+                if (other.filename == f) continue
+                val sameRole = role != null && other.display?.role == role
+                if (sameRole || conflicts(mods, f, other.filename)) {
                     next[other.filename] = false
                 }
             }
         }
         return next
+    }
+
+    /**
+     * [filename] plus the transitive closure of its NON-optional `requires`
+     * (optional/soft deps do not follow). Cycle-safe -- a `requires` cycle in a
+     * bad manifest terminates instead of looping. References to filenames absent
+     * from [byName] are skipped (the resolver surfaces those as warnings).
+     */
+    private fun requiredClosure(byName: Map<String, SmrtModEntry>, filename: String): Set<String> {
+        val out = LinkedHashSet<String>()
+        val stack = ArrayDeque<String>()
+        stack.addLast(filename)
+        while (stack.isNotEmpty()) {
+            val f = stack.removeLast()
+            if (!out.add(f)) continue
+            for (req in byName[f]?.display?.requires.orEmpty()) {
+                if (!req.optional && req.filename in byName) stack.addLast(req.filename)
+            }
+        }
+        return out
     }
 }

--- a/client-core/src/test/kotlin/hivens/core/data/OptionalContentRulesTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/data/OptionalContentRulesTest.kt
@@ -2,6 +2,7 @@ package hivens.core.data
 
 import hivens.core.api.dto.smrt.SmrtDisplay
 import hivens.core.api.dto.smrt.SmrtModEntry
+import hivens.core.api.dto.smrt.SmrtRequirement
 import hivens.core.api.dto.smrt.SmrtSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,15 +16,27 @@ class OptionalContentRulesTest {
         required: Boolean = true,
         defaultEnabled: Boolean = true,
         incompatibleWith: List<String> = emptyList(),
-    ) = SmrtModEntry(
-        filename = filename,
-        sha1 = "x",
-        sizeBytes = 1,
-        required = required,
-        defaultEnabled = defaultEnabled,
-        source = SmrtSource.SmrtStatic("https://example/$filename"),
-        display = if (incompatibleWith.isEmpty()) null else SmrtDisplay(incompatibleWith = incompatibleWith),
-    )
+        requires: List<String> = emptyList(),
+        optionalRequires: List<String> = emptyList(),
+        role: String? = null,
+    ): SmrtModEntry {
+        val hasDisplay = incompatibleWith.isNotEmpty() || requires.isNotEmpty() ||
+            optionalRequires.isNotEmpty() || role != null
+        return SmrtModEntry(
+            filename = filename,
+            sha1 = "x",
+            sizeBytes = 1,
+            required = required,
+            defaultEnabled = defaultEnabled,
+            source = SmrtSource.SmrtStatic("https://example/$filename"),
+            display = if (!hasDisplay) null else SmrtDisplay(
+                incompatibleWith = incompatibleWith,
+                role = role,
+                requires = requires.map { SmrtRequirement(it) } +
+                    optionalRequires.map { SmrtRequirement(it, optional = true) },
+            ),
+        )
+    }
 
     private val mods = listOf(
         mod("required.jar"),
@@ -67,5 +80,58 @@ class OptionalContentRulesTest {
         val afterDisable = OptionalContentRules.applyToggle(mods, afterEnable, "foamfix.jar", false)
         assertEquals(false, afterDisable["foamfix.jar"])
         assertEquals(false, afterDisable["mixinbooter.jar"], "disabling foamfix must not silently re-enable mixinbooter")
+    }
+
+    @Test
+    fun `applyToggle enabling a mod pulls its required deps on, transitively`() {
+        // A library can ship optional + default-off and follow its consumer on,
+        // instead of being flat-required: consumer -> libA -> libB.
+        val deps = listOf(
+            mod("consumer.jar", required = false, defaultEnabled = false, requires = listOf("libA.jar")),
+            mod("libA.jar", required = false, defaultEnabled = false, requires = listOf("libB.jar")),
+            mod("libB.jar", required = false, defaultEnabled = false),
+        )
+        val current = mapOf("consumer.jar" to false, "libA.jar" to false, "libB.jar" to false)
+        val after = OptionalContentRules.applyToggle(deps, current, "consumer.jar", true)
+        assertEquals(true, after["consumer.jar"])
+        assertEquals(true, after["libA.jar"], "direct required dep follows on")
+        assertEquals(true, after["libB.jar"], "transitive required dep follows on")
+    }
+
+    @Test
+    fun `applyToggle does not follow optional (soft) requires`() {
+        val deps = listOf(
+            mod("consumer.jar", required = false, defaultEnabled = false, optionalRequires = listOf("soft.jar")),
+            mod("soft.jar", required = false, defaultEnabled = false),
+        )
+        val after = OptionalContentRules.applyToggle(deps, mapOf("consumer.jar" to false, "soft.jar" to false), "consumer.jar", true)
+        assertEquals(true, after["consumer.jar"])
+        assertEquals(false, after["soft.jar"], "a soft (optional) requires must not be force-enabled")
+    }
+
+    @Test
+    fun `applyToggle enabling one role member disables the others in that role`() {
+        val viewers = listOf(
+            mod("jei.jar", required = false, defaultEnabled = true, role = "recipe_viewer"),
+            mod("rei.jar", required = false, defaultEnabled = false, role = "recipe_viewer"),
+            mod("unrelated.jar", required = false, defaultEnabled = true),
+        )
+        val current = mapOf("jei.jar" to true, "rei.jar" to false, "unrelated.jar" to true)
+        val after = OptionalContentRules.applyToggle(viewers, current, "rei.jar", true)
+        assertEquals(true, after["rei.jar"])
+        assertEquals(false, after["jei.jar"], "one active per interchangeable role")
+        assertEquals(true, after["unrelated.jar"], "a different role is untouched")
+    }
+
+    @Test
+    fun `applyToggle survives a requires cycle`() {
+        // A bad manifest with a -> b -> a must terminate, not loop.
+        val cyclic = listOf(
+            mod("a.jar", required = false, defaultEnabled = false, requires = listOf("b.jar")),
+            mod("b.jar", required = false, defaultEnabled = false, requires = listOf("a.jar")),
+        )
+        val after = OptionalContentRules.applyToggle(cyclic, mapOf("a.jar" to false, "b.jar" to false), "a.jar", true)
+        assertEquals(true, after["a.jar"])
+        assertEquals(true, after["b.jar"])
     }
 }


### PR DESCRIPTION
## What
`OptionalContentRules.applyToggle` is now dependency-aware, the launcher-side half of dependency-aware toggling (from the pack-dependencies backlog).

- **Enabling** an optional mod now also enables the transitive closure of its non-optional `display.requires`. So a shared library (e.g. Mixinbooter) can ship `required=false` + `default_enabled=false` and **follow its consumers on**, instead of being flat-`required` and always present. Optional/soft `requires` do not follow.
- **Enabling** also enforces same-`role` mutual exclusion (one active per interchangeable group -- the "Recipe viewer: JEI/REI/EMI" swap), alongside the existing `incompatibleWith` handling.
- **Disabling** still never cascades: an auto-enabled library stays put (harmlessly loaded-but-unused) rather than surprising the user by pulling content they never touched. Cycle-safe.

## Why
Lets the mirror mark shared libraries optional instead of flat-required, so they only install when something actually needs them.

## Scope
Pure rule change. The Content tab (`ContentTabPane`) already persists the full returned state, so followed-on deps are saved with no UI change. Role-swap is enforced in the rule now; wiring a role-swap toggle UI (the Content tab's role section is informational today) is a separate follow-on.

## Tests
`OptionalContentRulesTest`: transitive requires-follow, soft-deps don't follow, role mutual-exclusion, cycle survival; existing conflict + no-cascade cases unchanged. `:client-core:test` green.
