### PR TITLE
feat(authlib-agent): warn when the legacy getTextures gate goes missing

### DIFF
--- a/authlib-agent/src/main/java/hivens/authlib/agent/AuthlibRedirectAgent.java
+++ b/authlib-agent/src/main/java/hivens/authlib/agent/AuthlibRedirectAgent.java
@@ -173,8 +173,11 @@ public final class AuthlibRedirectAgent {
      * to {@code iconst_0}, so the following {@code ifeq} always branches past the
      * check straight to the decode + (already-repointed) whitelist step. The swap is
      * length- and stack-preserving, so no offsets, exception table, or stack-map need
-     * touching. Returns [classBytes] untouched when the method or the exact gate
-     * pattern is absent (e.g. modern authlib), never throws.
+     * touching. Returns [classBytes] untouched, and never throws, when the gate is
+     * not patched: silently if the method is simply absent (e.g. modern authlib),
+     * but with one stderr breadcrumb if the method is present yet its gate could not
+     * be located -- the legacy shape changed under us, so other players' skins will
+     * silently fall back to default while the join (URL rewrite) still works.
      */
     static byte[] acceptUnsignedTextures(byte[] classBytes) {
         int cpCount = u2(classBytes, 8);
@@ -185,11 +188,17 @@ public final class AuthlibRedirectAgent {
         int fields = u2(classBytes, p); p += 2;
         for (int f = 0; f < fields; f++) p = skipMember(classBytes, p, utf8, null);
         int methods = u2(classBytes, p); p += 2;
-        int[] gate = { -1 };
+        int[] gate = { -1, 0 }; // [0] requireSecure gate offset; [1] set once getTextures(...Z) is seen
         for (int m = 0; m < methods && gate[0] < 0; m++) {
             p = skipMember(classBytes, p, utf8, gate);
         }
-        if (gate[0] < 0) return classBytes;
+        if (gate[0] < 0) {
+            if (gate[1] != 0) {
+                System.err.println("[authlib-agent] legacy getTextures present but its requireSecure "
+                    + "gate was not found; other players' SmartyCraft skins may not load");
+            }
+            return classBytes;
+        }
         byte[] copy = classBytes.clone();
         copy[gate[0]] = 0x03; // iconst_0
         return copy;
@@ -216,8 +225,10 @@ public final class AuthlibRedirectAgent {
 
     /**
      * Advances past one field/method member at [p], returning the next member's
-     * offset. When [gateOut] is non-null and the member is the getTextures(...Z) Code
-     * attribute, records the absolute offset of its requireSecure iload_2 in gateOut[0].
+     * offset. When [gateOut] is non-null and the member is the getTextures(...Z)
+     * method, sets {@code gateOut[1]} to 1 (so the caller can tell "method absent"
+     * from "method present, gate missing") and records the absolute offset of its
+     * requireSecure iload_2 in {@code gateOut[0]}, leaving it -1 if not located.
      */
     private static int skipMember(byte[] b, int p, String[] utf8, int[] gateOut) {
         p += 2; // access_flags
@@ -227,6 +238,7 @@ public final class AuthlibRedirectAgent {
         boolean target = gateOut != null
             && TEXTURES_METHOD.equals(utf8[nameIdx])
             && utf8[descIdx].endsWith("Z)Ljava/util/Map;");
+        if (target) gateOut[1] = 1;
         for (int a = 0; a < attrs; a++) {
             int anIdx = u2(b, p); p += 2;
             int alen = u4(b, p); p += 4;

--- a/authlib-agent/src/test/java/hivens/authlib/agent/AuthlibRedirectAgentTest.java
+++ b/authlib-agent/src/test/java/hivens/authlib/agent/AuthlibRedirectAgentTest.java
@@ -4,12 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class AuthlibRedirectAgentTest {
@@ -87,6 +89,25 @@ class AuthlibRedirectAgentTest {
     }
 
     @Test
+    void acceptUnsignedTexturesWarnsOnlyWhenGetTexturesPresentButGateMissing() throws Exception {
+        // getTextures(...Z) is present but never branches on requireSecure, so there is
+        // no gate to flip: the bytes come back unchanged AND a breadcrumb is logged,
+        // because a present-but-unpatchable legacy method means the authlib shape moved
+        // under us and other players' skins will silently regress.
+        byte[] reshaped = readClassBytes(TextureSampleNoGate.class);
+        byte[][] out = new byte[1][];
+        String warned = captureErr(() -> out[0] = AuthlibRedirectAgent.acceptUnsignedTextures(reshaped));
+        assertSame(reshaped, out[0], "a getTextures with no requireSecure gate must be left untouched");
+        assertTrue(warned.contains("[authlib-agent]") && warned.contains("skins"),
+                "a present-but-unpatchable getTextures must leave a stderr breadcrumb: " + warned);
+
+        // getTextures(...Z) absent entirely (e.g. modern authlib): no-op AND silent.
+        byte[] absent = readClassBytes(Sample.class);
+        String quiet = captureErr(() -> AuthlibRedirectAgent.acceptUnsignedTextures(absent));
+        assertEquals("", quiet, "an absent getTextures must not warn");
+    }
+
+    @Test
     void rewriteReturnsSameArrayWhenNothingMatches() {
         // Empty map -> no entry can match -> the rewriter must return the input
         // array untouched (the no-op fast path).
@@ -98,6 +119,19 @@ class AuthlibRedirectAgentTest {
     private static String str(byte[] b) {
         assertNotNull(b);
         return new String(b, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    /** Runs [body] with System.err captured and returns everything it printed. */
+    private static String captureErr(Runnable body) throws Exception {
+        PrintStream original = System.err;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(buf, true, "UTF-8"));
+        try {
+            body.run();
+        } finally {
+            System.setErr(original);
+        }
+        return buf.toString("UTF-8");
     }
 
     private static String field(Class<?> c, String name) throws Exception {

--- a/authlib-agent/src/test/java/hivens/authlib/agent/TextureSampleNoGate.java
+++ b/authlib-agent/src/test/java/hivens/authlib/agent/TextureSampleNoGate.java
@@ -1,0 +1,19 @@
+package hivens.authlib.agent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test fixture for a reshaped legacy method: a {@code getTextures(...;Z)Ljava/util/Map;}
+ * whose body never reads {@code requireSecure}, so javac emits no {@code iload_2 ; ifeq}
+ * gate. Stands in for a future authlib whose method is present but no longer matches the
+ * agent's pattern -- the agent must SEE the method (and warn) yet leave the bytes
+ * untouched, because there is no gate to flip.
+ */
+public class TextureSampleNoGate {
+    public Map<String, String> getTextures(Object profile, boolean requireSecure) {
+        Map<String, String> out = new HashMap<String, String>();
+        out.put("SKIN", "ok");
+        return out;
+    }
+}


### PR DESCRIPTION
The unsigned-skin patch silently no-ops when it cannot find the requireSecure gate in `getTextures`. That is correct when the method is absent (modern authlib routes textures through `TextureUrlChecker`), but if the legacy method is present and merely reshaped by an upstream authlib change, the join still works while other players' skins fall back to default with no signal.

This tracks whether `getTextures(...Z)` was seen at all, so the present-but-unpatchable case prints one stderr line (surfaced in the game console), while the absent case stays silent.

Tests cover both no-op paths: a reshaped `getTextures` (warns) versus an absent one (silent). `:authlib-agent:test` 7/7.